### PR TITLE
Better validation of parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,18 @@ You can ask for specific private data like this:
 
 ```javascript
 credentials.createRequest({
-    requested: ['name','phone','identity_no']
+    requested: ['name','phone','identity_no'],
+    callbackUrl: 'https://....' // URL to send the response of the request to 
   }.then(requestToken => {
   // send requestToken to browser
   })
 ```
 
-In your front end use 'uport-browser' to present it to your user either as a QR code or as a uport-button depending on whether they are on a desktop or mobile browser.
+In your front end use [uport-connect](https://github.com/uport-project/uport-connect) to present it to your user either as a QR code or as a uport-button depending on whether they are on a desktop or mobile browser.
 
 ```javascript
-window.uport.credentials.request(requestToken).then(response => {
+const connect = new uportconnect.Connect('app name')
+connect.showRequest(requestToken).then(response => {
   // send response back to server
 })
 ```
@@ -115,7 +117,7 @@ As part of the selective disclosure request you can ask for permission from your
 ```javascript
 credentials.createRequest({
   requested:[...],
-  capabilities: ['push']
+  notifications: true
 }).then(requestToken => {
   // send to browser
 })
@@ -156,17 +158,15 @@ credentials.attest({
 As before you will want to send this to your user. You can do this in the browser
 
 ```javascript
-window.uport.credentials.request(attestation).then(response => {
-
-})
+const connect = new uportconnect.Connect('app name')
+connect.showRequest(attestation) // no response is needed for an attestation
 ```
-
 
 If you requested a push notification token in the above selective disclosure step you can also send attestations directly to your users app in real time.
 
 ```javascript
 // Coming soon, not yet implemented
-credentials.uport.pushTo(pushToken, attestation).then(response => {
+credentials.pushTo(pushToken, attestation).then(response => {
 
 })
 ```
@@ -176,6 +176,7 @@ credentials.uport.pushTo(pushToken, attestation).then(response => {
 ```javascript
 import { Contract } from 'uport'
 
+// Coming soon
 const tokenContract = new Contract(address, abi)
 const txRequest = tokenContract.transfer(....)
 ```
@@ -183,7 +184,8 @@ const txRequest = tokenContract.transfer(....)
 In your front end use 'uport-browser' to present it to your user either as a QR code or as a uport-button depending on whether they are on a desktop or mobile browser.
 
 ```javascript
-window.uport.credentials.request(txRequest).then(txResponse => {
+const connect = new uportconnect.Connect('app name')
+connect.sendTransaction(txRequest).then(txResponse => {
   // send response back to server
 })
 ```

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -25,8 +25,26 @@ it('has correct payload in JWT for a plain request for public details', () => {
   })
 })
 
+it('ignores unsupported request parameters', () => {
+  return uport.createRequest({signing: true, sellSoul: true}).then((jwt) => {
+    return expect(decodeToken(jwt)).toMatchSnapshot()
+  })
+})
+
 it('has correct payload in JWT for a request', () => {
   return uport.createRequest({requested: ['name', 'phone']}).then((jwt) => {
+    return expect(decodeToken(jwt)).toMatchSnapshot()
+  })
+})
+
+it('has correct payload in JWT for a request with callbackUrl', () => {
+  return uport.createRequest({ requested: ['name', 'phone'], callbackUrl: 'https://myserver.com'}).then((jwt) => {
+    return expect(decodeToken(jwt)).toMatchSnapshot()
+  })
+})
+
+it('has correct payload in JWT for a request for push notifications', () => {
+  return uport.createRequest({ requested: ['name', 'phone'], notifications: true }).then((jwt) => {
     return expect(decodeToken(jwt)).toMatchSnapshot()
   })
 })
@@ -61,6 +79,12 @@ it('returns profile with only public claims', () => {
 
 it('has a default registry that looks up profile', () => {
   return new Credentials().settings.registry('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c').then(profile =>
+    expect(profile.publicKey).toEqual('0x0482780d59037778ea03c7d5169dd7cf47a835cb6d57a606b4e6cf98000a28d20d6d6bfae223cc76fd2f63d8a382a1c054788c4fafb1062ee89e718b96e0896d40')
+  )
+})
+
+it('has ability to lookup profile', () => {
+  return new Credentials().lookup('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c').then(profile =>
     expect(profile.publicKey).toEqual('0x0482780d59037778ea03c7d5169dd7cf47a835cb6d57a606b4e6cf98000a28d20d6d6bfae223cc76fd2f63d8a382a1c054788c4fafb1062ee89e718b96e0896d40')
   )
 })

--- a/__tests__/JWT-test.js
+++ b/__tests__/JWT-test.js
@@ -23,6 +23,18 @@ it('creates a JWT with correct format', () => {
   })
 })
 
+it('throws an error if no signer is configured', () => {
+  return createJWT({address: '0x001122'}, { requested: ['name', 'phone'] }).catch(error => {
+    return expect(error.message).toEqual('No Signer functionality has been configured')
+  })
+})
+
+it('throws an error if no address is configured', () => {
+  return createJWT({signer}, { requested: ['name', 'phone'] }).catch(error => {
+    return expect(error.message).toEqual('No application identity address has been configured')
+  })
+})
+
 const incomingJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1ZXN0ZWQiOlsibmFtZSIsInBob25lIl0sImlzcyI6IjB4MDAxMTIyIiwiaWF0IjoxNDg1MzIxMTMzOTk2fQ.zxGLQKo2WjgefrxEQWfwm_oago8Qr4YctBJoqNAm2XKE-48bADjolSo2T_tED9LnSikxqFIM9gNGpNgcY8JPdg'
 
 it('verifies the JWT and return correct payload', () => {

--- a/__tests__/JWT-test.js
+++ b/__tests__/JWT-test.js
@@ -103,3 +103,27 @@ it('rejects invalid audience', () => {
     ).then((p) => expect(p).toBeFalsy())
   )
 })
+
+it('rejects an invalid audience using callback_url where callback is wrong', () => {
+  return createJWT({ address: '0x001122', signer }, { aud: 'http://chasqui.uport.me/unique' }).then(jwt =>
+    verifyJWT({ registry }, jwt, 'http://chasqui.uport.me/unique/1').catch(error =>
+      expect(error.message).toEqual('JWT audience does not match the callback url')
+    )
+  )
+})
+
+it('rejects an invalid audience using callback_url where callback is missing', () => {
+  return createJWT({ address: '0x001122', signer }, { aud: 'http://chasqui.uport.me/unique' }).then(jwt =>
+    verifyJWT({ registry }, jwt).catch(error =>
+      expect(error.message).toEqual('JWT audience matching your callback url is required but one wasn\'t passed in')
+    )
+  )
+})
+
+it('rejects invalid audience as no address is present', () => {
+  return createJWT({ address: '0x001122', signer }, { aud: '0x001123' }).then(jwt =>
+    verifyJWT({ registry }, jwt).catch(error =>
+      expect(error.message).toEqual('JWT audience is required but your app address has not been configured')
+    ).then((p) => expect(p).toBeFalsy())
+  )
+})

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -32,6 +32,48 @@ Object {
 }
 `;
 
+exports[`test has correct payload in JWT for a request for push notifications 1`] = `
+Object {
+  "header": Object {
+    "alg": "ES256K",
+    "typ": "JWT",
+  },
+  "payload": Object {
+    "iat": 1485321133996,
+    "iss": "0x001122",
+    "permissions": Array [
+      "notifications",
+    ],
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+    "type": "shareReq",
+  },
+  "signature": "2i-T1Q4_vqcRPEz775irlCEWcW02coezZr1zD3dJbXiAmIPlgIL1QQ_UOGT5A5LKhOKF4eXvpxewTZmjg9uLBw",
+}
+`;
+
+exports[`test has correct payload in JWT for a request with callbackUrl 1`] = `
+Object {
+  "header": Object {
+    "alg": "ES256K",
+    "typ": "JWT",
+  },
+  "payload": Object {
+    "callback": "https://myserver.com",
+    "iat": 1485321133996,
+    "iss": "0x001122",
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+    "type": "shareReq",
+  },
+  "signature": "KJCZBA6CRibWB2ekNGpQkESQXzj1_6qjrAuZRKNRYVilVrIwIuT6D9gyigcUqsK3Ja2HkChNz9oAH78LvguJqw",
+}
+`;
+
 exports[`test has correct payload in JWT for an attestation 1`] = `
 Object {
   "header": Object {
@@ -48,6 +90,21 @@ Object {
     "sub": "0x112233",
   },
   "signature": "-mEzVMPYnzqFhOr0O7fs71-dWAacnllVyOdWQY0zh2ZdIt7-30IYTewds4tGlkLmMky-Y1ZjRmIsxmM7xvAgxg",
+}
+`;
+
+exports[`test ignores unsupported request parameters 1`] = `
+Object {
+  "header": Object {
+    "alg": "ES256K",
+    "typ": "JWT",
+  },
+  "payload": Object {
+    "iat": 1485321133996,
+    "iss": "0x001122",
+    "type": "shareReq",
+  },
+  "signature": "x5wOEbEa8gQtKtfteSDHkkIaW30kZmI9I8EQLk8-DmxL9GteEa9hvIAi8Zhxo22FPDFErxIpp48Ckgp9_ZsIEA",
 }
 `;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -16,7 +16,17 @@ export default class Credentials {
   }
 
   // Create request token
-  createRequest (payload) {
+  createRequest (params = {}) {
+    const payload = {}
+    if (params.requested) {
+      payload.requested = params.requested
+    }
+    if (params.notifications) {
+      payload.permissions = ['notifications']
+    }
+    if (params.callbackUrl) {
+      payload.callback = params.callbackUrl
+    }
     return createJWT(this.settings, {...payload, type: 'shareReq'})
   }
 
@@ -32,4 +42,8 @@ export default class Credentials {
     return createJWT(this.settings, {sub, claim, exp})
   }
 
+  // Lookup public uport address of any user
+  lookup (address) {
+    return this.settings.registry(address)
+  }
 }

--- a/src/JWT.js
+++ b/src/JWT.js
@@ -8,12 +8,14 @@ export function createJWT ({address, signer}, payload) {
     JOSE_HEADER,
     {...payload, iss: address, iat: new Date().getTime()}
   )
-  return new Promise((resolve, reject) =>
-    signer(signingInput, (error, signature) => {
+  return new Promise((resolve, reject) => {
+    if (!signer) return reject(new Error('No Signer functionality has been configured'))
+    if (!address) return reject(new Error('No application identity address has been configured'))
+    return signer(signingInput, (error, signature) => {
       if (error) return reject(error)
       resolve([signingInput, signature].join('.'))
     })
-  )
+  })
 }
 
 export function verifyJWT ({registry, address}, jwt, callbackUrl = null) {


### PR DESCRIPTION
- [x] `JWT.createJWT` validates presence of `signer` and `address` in settings
- [x] `credentials.createRequest()` only accepts supported parameters
- [x] `credentials.lookup()` is an easier way of looking up profiles
- [x] better tests
- [x] updated README