### PR TITLE
Stateless Challenge Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,15 @@ credentials.receive(responseToken).then(profile => {
   // Store user profile
 })
 ```
-
 For more information about the contents of the profile object see the uport-persona documentation.
+
+### Stateless Challenge/Response
+
+To ensure that the response received was created as a response to your selective disclosure request above, the original request is included in the response from the mobile app.
+
+The default verification rule is that the issuer of the embedded request must match the clientId in your Credentials object and that the original request has not yet expired.
+
+Some applications that exclusively live in the browser are unable to sign the original request. In those cases the request token verification is ignored.
 
 ### Requesting Push notification tokens from your users
 

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -79,8 +79,11 @@ describe('attest', () => {
 })
 
 describe('receive', () => {
+
   function createShareResp (payload = {}) {
-    return createJWT({address: '0x001122', signer}, {...payload, type: 'shareResp'})
+    return uport.createRequest({requested: ['name', 'phone']}).then((jwt) => {
+      return createJWT({address: '0x001122', signer}, {...payload, type: 'shareResp', req:jwt})
+    })
   }
 
   function createShareRespWithVerifiedCredential (payload = {}, verifiedClaim = {sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133996 + 1000}) {

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -13,6 +13,7 @@ const verifier = new TokenVerifier('ES256K', publicKey)
 const profileA = {publicKey, name: 'David Chaum'}
 const registry = (address) => new Promise((resolve, reject) => resolve(address === '0x001122' ? profileA : null))
 const uport = new Credentials({signer, address: '0x001122', registry})
+const uport2 = new Credentials({registry})
 
 describe('createRequest', () => {
   it('creates a valid JWT for a request', () => {
@@ -121,6 +122,40 @@ describe('receive', () => {
       expect(profile.pushToken).toEqual('PUSHTOKEN')
     )
   })
+
+/////////////////////////////// no address in uport settings ///////////////////////////////
+
+  it('returns profile mixing public and private claims', () => {
+    return createShareResp({own: {name: 'Davie', phone: '+15555551234'}}).then(jwt => uport2.receive(jwt)).then(profile =>
+      expect(profile).toMatchSnapshot()
+    )
+  })
+
+  it('returns profile mixing public and private claims and verified credentials', () => {
+    return createShareRespWithVerifiedCredential({own: {name: 'Davie', phone: '+15555551234'}}).then(jwt => uport2.receive(jwt)).then(profile =>
+      expect(profile).toMatchSnapshot()
+    )
+  })
+
+  it('returns profile with only public claims', () => {
+    return createShareResp().then(jwt => uport2.receive(jwt)).then(profile =>
+      expect(profile).toMatchSnapshot()
+    )
+  })
+
+  it('returns profile with private chain network id claims', () => {
+    return createShareResp({nad: '34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m'}).then(jwt => uport2.receive(jwt)).then(profile =>
+      expect(profile).toMatchSnapshot()
+    )
+  })
+
+  it('returns pushToken if available', () => {
+    return createShareResp({capabilities: ['PUSHTOKEN']}).then(jwt => uport2.receive(jwt)).then(profile =>
+      expect(profile.pushToken).toEqual('PUSHTOKEN')
+    )
+  })
+
+/////////////////////////////// no address in uport settings///////////////////////////////
 })
 
 describe('push', () => {

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -155,7 +155,37 @@ Object {
 }
 `;
 
+exports[`receive returns profile mixing public and private claims 2`] = `
+Object {
+  "address": "0x001122",
+  "name": "Davie",
+  "phone": "+15555551234",
+  "publicKey": "03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
+}
+`;
+
 exports[`receive returns profile mixing public and private claims and verified credentials 1`] = `
+Object {
+  "address": "0x001122",
+  "name": "Davie",
+  "phone": "+15555551234",
+  "publicKey": "03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
+  "verified": Array [
+    Object {
+      "claim": Object {
+        "email": "bingbangbung@email.com",
+      },
+      "exp": 1485321134996,
+      "iat": 1485321133996,
+      "iss": "0x001122",
+      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiIweDExMjIzMyIsImNsYWltIjp7ImVtYWlsIjoiYmluZ2JhbmdidW5nQGVtYWlsLmNvbSJ9LCJleHAiOjE0ODUzMjExMzQ5OTYsImlzcyI6IjB4MDAxMTIyIiwiaWF0IjoxNDg1MzIxMTMzOTk2fQ.-mEzVMPYnzqFhOr0O7fs71-dWAacnllVyOdWQY0zh2ZdIt7-30IYTewds4tGlkLmMky-Y1ZjRmIsxmM7xvAgxg",
+      "sub": "0x112233",
+    },
+  ],
+}
+`;
+
+exports[`receive returns profile mixing public and private claims and verified credentials 2`] = `
 Object {
   "address": "0x001122",
   "name": "Davie",
@@ -184,7 +214,24 @@ Object {
 }
 `;
 
+exports[`receive returns profile with only public claims 2`] = `
+Object {
+  "address": "0x001122",
+  "name": "David Chaum",
+  "publicKey": "03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
+}
+`;
+
 exports[`receive returns profile with private chain network id claims 1`] = `
+Object {
+  "address": "0x001122",
+  "name": "David Chaum",
+  "networkAddress": "34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m",
+  "publicKey": "03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
+}
+`;
+
+exports[`receive returns profile with private chain network id claims 2`] = `
 Object {
   "address": "0x001122",
   "name": "David Chaum",

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -41,19 +41,43 @@ export default class Credentials {
   // Receive response token from user and return data to promise
   receive (token, callbackUrl = null) {
     return verifyJWT(this.settings, token, callbackUrl).then(({payload, profile}) => {
-      const credentials = {...profile, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
-      if (payload.nad) {
-        credentials.networkAddress = payload.nad
-      }
-      if (payload.verified) {
-        return Promise.all(payload.verified.map(token => verifyJWT(this.settings, token))).then(verified => {
-          return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
-        })
+      if(this.settings.address) {
+        if(payload.req) {
+          return verifyJWT(this.settings, payload.req).then(() => {
+            const credentials = {...profile, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
+            if (payload.nad) {
+              credentials.networkAddress = payload.nad
+            }
+            if (payload.verified) {
+              return Promise.all(payload.verified.map(token => verifyJWT(this.settings, token))).then(verified => {
+                return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
+              })
+            } else {
+
+              return credentials
+            }
+          })
+        } else {
+          console.log('Challenge was not included in response')
+        }
       } else {
-        return credentials
+        const credentials = {...profile, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
+        if (payload.nad) {
+          credentials.networkAddress = payload.nad
+        }
+        if (payload.verified) {
+          return Promise.all(payload.verified.map(token => verifyJWT(this.settings, token))).then(verified => {
+            return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
+          })
+        } else {
+
+          return credentials
+        }
       }
     })
   }
+
+
 
   push (token, {url}) {
     return new Promise((resolve, reject) => {

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -42,39 +42,33 @@ export default class Credentials {
   // Receive response token from user and return data to promise
   receive (token, callbackUrl = null) {
     return verifyJWT(this.settings, token, callbackUrl).then(({payload, profile}) => {
+
+      function processPayload(settings) {
+        const credentials = {...profile, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
+        if (payload.nad) {
+          credentials.networkAddress = payload.nad
+        }
+        if (payload.verified) {
+          return Promise.all(payload.verified.map(token => verifyJWT(settings, token))).then(verified => {
+            return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
+          })
+        } else {
+          return credentials
+        }
+      }
+
       if(this.settings.address) {
         if(payload.req) {
           return verifyJWT(this.settings, payload.req).then((challenge) => {
             if(challenge.payload.iss === this.settings.address) {
-              const credentials = {...profile, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
-              if (payload.nad) {
-                credentials.networkAddress = payload.nad
-              }
-              if (payload.verified) {
-                return Promise.all(payload.verified.map(token => verifyJWT(this.settings, token))).then(verified => {
-                  return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
-                })
-              } else {
-                return credentials
-              }
+              return processPayload(this.settings)
             }
           })
         } else {
           console.log('Challenge was not included in response')
         }
       } else {
-        const credentials = {...profile, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
-        if (payload.nad) {
-          credentials.networkAddress = payload.nad
-        }
-        if (payload.verified) {
-          return Promise.all(payload.verified.map(token => verifyJWT(this.settings, token))).then(verified => {
-            return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
-          })
-        } else {
-
-          return credentials
-        }
+        return processPayload(this.settings)
       }
     })
   }


### PR DESCRIPTION
To ensure that the response received was created as a response to your selective disclosure request above, the original request is included in the response from the mobile app.

The default verification rule is that the issuer of the embedded request must match the clientId in your Credentials object and that the original request has not yet expired.

Some applications that exclusively live in the browser are unable to sign the original request. In those cases the request token verification is ignored.

- [x] If Credentials object has a `this.settings.address` the `receive()` function verifies the JWT stored in the `req` parameter of shareResponse.
-- [ ] `iss` of request should === `this.settings.address`
-- [ ] request token should not be expired
- [x] if Credentials does not have an address set as mentioned above it should continue to work as before to support apps
