### PR TITLE
support for seconds (instead of miliseconds)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -203,7 +203,7 @@ Create a credential (a signed JSON Web Token)
 | [credential] | <code>Object</code> | a unsigned credential object |
 | credential.sub | <code>String</code> | subject of credential (a uPort address) |
 | credential.claim | <code>String</code> | claim about subject single key value or key mapping to object with multiple values (ie { address: {street: ..., zip: ..., country: ...}}) |
-| credential.exp | <code>String</code> | time at which this claim expires and is no longer valid |
+| credential.exp | <code>String</code> | time at which this claim expires and is no longer valid (seconds since epoch) |
 
 **Example**
 ```js

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -4,7 +4,7 @@ import SimpleSigner from '../src/SimpleSigner'
 import { SECP256K1Client, TokenVerifier, decodeToken } from 'jsontokens'
 import nock from 'nock'
 import MockDate from 'mockdate'
-MockDate.set(1485321133996)
+MockDate.set(1485321133 * 1000)
 
 const privateKey = '278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
 const publicKey = SECP256K1Client.privateKeyToPublicKey(privateKey)
@@ -67,13 +67,13 @@ describe('createRequest', () => {
 
 describe('attest', () => {
   it('creates a valid JWT for an attestation', () => {
-    return uport.attest({sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133996 + 1000}).then((jwt) => {
+    return uport.attest({sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133 + 1}).then((jwt) => {
       return expect(verifier.verify(jwt)).toBeTruthy()
     })
   })
 
   it('has correct payload in JWT for an attestation', () => {
-    return uport.attest({sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133996 + 1000}).then((jwt) => {
+    return uport.attest({sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133 + 1}).then((jwt) => {
       return expect(decodeToken(jwt)).toMatchSnapshot()
     })
   })
@@ -88,12 +88,12 @@ describe('receive', () => {
   }
 
   function createShareRespWithExpiredRequest (payload = {}) {
-    return uport.createRequest({requested: ['name', 'phone'], exp: Date().getTime() - 3600000}).then((jwt) => {
+    return uport.createRequest({requested: ['name', 'phone'], exp: Date.now() - 1}).then((jwt) => {
       return createJWT({address: '0x001122', signer}, {...payload, type: 'shareResp', req:jwt})
     })
   }
 
-  function createShareRespWithVerifiedCredential (payload = {}, verifiedClaim = {sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133996 + 1000}) {
+  function createShareRespWithVerifiedCredential (payload = {}, verifiedClaim = {sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133 + 1}) {
     return uport.attest(verifiedClaim).then(jwt => {
       return createShareResp({...payload, verified: [jwt]})
     })

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -7,7 +7,7 @@ import MockDate from 'mockdate'
 MockDate.set(1485321133 * 1000)
 
 const privateKey = '278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
-const publicKey = SECP256K1Client.privateKeyToPublicKey(privateKey)
+const publicKey = SECP256K1Client.derivePublicKey(privateKey)
 const signer = SimpleSigner(privateKey)
 const verifier = new TokenVerifier('ES256K', publicKey)
 const profileA = {publicKey, name: 'David Chaum'}

--- a/__tests__/JWT-test.js
+++ b/__tests__/JWT-test.js
@@ -5,7 +5,7 @@ import MockDate from 'mockdate'
 MockDate.set(1485321133 * 1000)
 
 const privateKey = '278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
-const publicKey = SECP256K1Client.privateKeyToPublicKey(privateKey)
+const publicKey = SECP256K1Client.derivePublicKey(privateKey)
 const signer = SimpleSigner(privateKey)
 const verifier = new TokenVerifier('ES256K', publicKey)
 const profileA = {publicKey: `0x${publicKey}`, name: 'David Chaum'}

--- a/__tests__/JWT-test.js
+++ b/__tests__/JWT-test.js
@@ -2,7 +2,7 @@ import { createJWT, verifyJWT } from '../src/JWT'
 import SimpleSigner from '../src/SimpleSigner'
 import { SECP256K1Client, TokenVerifier, decodeToken } from 'jsontokens'
 import MockDate from 'mockdate'
-MockDate.set(1485321133996)
+MockDate.set(1485321133 * 1000)
 
 const privateKey = '278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
 const publicKey = SECP256K1Client.privateKeyToPublicKey(privateKey)
@@ -35,7 +35,8 @@ it('throws an error if no address is configured', () => {
   })
 })
 
-const incomingJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1ZXN0ZWQiOlsibmFtZSIsInBob25lIl0sImlzcyI6IjB4MDAxMTIyIiwiaWF0IjoxNDg1MzIxMTMzOTk2fQ.zxGLQKo2WjgefrxEQWfwm_oago8Qr4YctBJoqNAm2XKE-48bADjolSo2T_tED9LnSikxqFIM9gNGpNgcY8JPdg'
+const incomingJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1ZXN0ZWQiOlsibmFtZSIsInBob25lIl0sImlzcyI6IjB4MDAxMTIyIiwiaWF0IjoxNDg1MzIxMTMzfQ.OGgdP_rDix6YRKoSpFVgM_myCTv1ObJE7DaAMG8WIlHulReX8-dr0vqDo7XfQwKGSBqV-MnLg0u7z8J5C2Qgjg'
+
 
 it('verifies the JWT and return correct payload', () => {
   return verifyJWT({registry, address: '0x001122'}, incomingJwt).then(({payload}) => {
@@ -64,8 +65,25 @@ it('rejects a JWT with bad signature', () => {
   ).then((p) => expect(p).toBeFalsy())
 })
 
+it('accepts a valid iat', () => {
+  return createJWT({address: '0x001122', signer}, {iat: 1485321133}).then(jwt =>
+    verifyJWT({registry, address: '0x001122'}, jwt).then(({payload}) =>
+      expect(payload).toMatchSnapshot()
+    )
+  )
+})
+
+it('rejects an iat in the future', () => {
+  return createJWT({address: '0x001122', signer}, {iat: 1485321133 + 1}).then(jwt =>
+    verifyJWT({registry, address: '0x001122'}, jwt).catch(error =>
+      expect(error.message).toEqual('JWT not valid yet (issued in the future)')
+    ).then((p) => expect(p).toBeFalsy())
+  )
+})
+
+
 it('accepts a valid exp', () => {
-  return createJWT({address: '0x001122', signer}, {exp: 1485321133996+1}).then(jwt =>
+  return createJWT({address: '0x001122', signer}, {exp: 1485321133+1}).then(jwt =>
     verifyJWT({registry, address: '0x001122'}, jwt).then(({payload}) =>
       expect(payload).toMatchSnapshot()
     )
@@ -73,7 +91,7 @@ it('accepts a valid exp', () => {
 })
 
 it('rejects an expired JWT', () => {
-  return createJWT({address: '0x001122', signer}, {exp: 1485321133996 - 1}).then(jwt =>
+  return createJWT({address: '0x001122', signer}, {exp: 1485321133 - 1}).then(jwt =>
     verifyJWT({registry, address: '0x001122'}, jwt).catch(error =>
       expect(error.message).toEqual('JWT has expired')
     ).then((p) => expect(p).toBeFalsy())

--- a/__tests__/SimpleSigner-test.js
+++ b/__tests__/SimpleSigner-test.js
@@ -2,7 +2,7 @@ import SimpleSigner from '../src/SimpleSigner'
 import { SECP256K1Client } from 'jsontokens'
 
 const privateKey = '278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
-const publicKey = SECP256K1Client.privateKeyToPublicKey(privateKey)
+const publicKey = SECP256K1Client.derivePublicKey(privateKey)
 
 const signer = SimpleSigner(privateKey)
 

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -17,6 +17,12 @@ Object {
 }
 `;
 
+exports[`configNetworks if networks key is passed in it must contain configuration object 1`] = `"Network configuration object required"`;
+
+exports[`configNetworks should require a registry address 1`] = `"Malformed network config object, object must have \'registry\' key specified."`;
+
+exports[`configNetworks should require a rpcUrl 1`] = `"Malformed network config object, object must have \'rpcUrl\' key specified."`;
+
 exports[`createRequest has correct payload in JWT for a plain request for public details 1`] = `
 Object {
   "header": Object {

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -8,12 +8,12 @@ Object {
     "claim": Object {
       "email": "bingbangbung@email.com",
     },
-    "exp": 1485321134996,
-    "iat": 1485321133996,
+    "exp": 1485321134,
+    "iat": 1485321133,
     "iss": "0x001122",
     "sub": "0x112233",
   },
-  "signature": "-mEzVMPYnzqFhOr0O7fs71-dWAacnllVyOdWQY0zh2ZdIt7-30IYTewds4tGlkLmMky-Y1ZjRmIsxmM7xvAgxg",
+  "signature": "kO5mGjkW6vkvE_JjWfKrt-ZSITo_EXoRIslhDCss78bM2458nQF-wBiFzIWtvjC38TR2NrLh6trz8wG_auTEig",
 }
 `;
 
@@ -24,12 +24,12 @@ Object {
     "typ": "JWT",
   },
   "payload": Object {
-    "exp": 1485321733996,
-    "iat": 1485321133996,
+    "exp": 1485321733,
+    "iat": 1485321133,
     "iss": "0x001122",
     "type": "shareReq",
   },
-  "signature": "BvclScIROeRimK_81fZp3yGVkhM0BF2cJOWp5yvpqz0z5kr4dPucDkdZsltUGhAXEaeuwxOE4c3vJYyeIHOmxg",
+  "signature": "kUs_SxnmUvmAa7-NKJ_qiIoODAB_MgCEMdmkw6pGy3ULMwQ-KWh6-M5CYkvPxPyHoDHVB5yGcFmTMxp_PU8a-g",
 }
 `;
 
@@ -40,8 +40,8 @@ Object {
     "typ": "JWT",
   },
   "payload": Object {
-    "exp": 1485321733996,
-    "iat": 1485321133996,
+    "exp": 1485321733,
+    "iat": 1485321133,
     "iss": "0x001122",
     "requested": Array [
       "name",
@@ -49,7 +49,7 @@ Object {
     ],
     "type": "shareReq",
   },
-  "signature": "aL2fTdDTIB_fcp0tTOlAFj9J0zFr2GRrgxxrP60bdguEpfC5LJJHufUpu2fXq_q42PrX_KHHm5-C2RZEWQnP0g",
+  "signature": "n8RNFvH4VY4BGM9Tvm9sw_UlPMi5dLX66bkCv8I_6TGcyS7trpPsjttZjilYnGCakzWtnok9D9aqFsd2W5Qkng",
 }
 `;
 
@@ -60,8 +60,8 @@ Object {
     "typ": "JWT",
   },
   "payload": Object {
-    "exp": 1485321733996,
-    "iat": 1485321133996,
+    "exp": 1485321733,
+    "iat": 1485321133,
     "iss": "0x001122",
     "requested": Array [
       "name",
@@ -72,7 +72,7 @@ Object {
       "name",
     ],
   },
-  "signature": "pvi7cEu3wg7VQ-FvdHG_DYrvJy6JH5pK_61E7tCITtsnLk-mkwWGB1y7GmJ89e1F3-SXT7dcVNvR9fwbS0i0FA",
+  "signature": "qmFvkl3wvtQiV7QAlLEljP-Uv_4wdNqsgcX_c9T0DFWfQE_p2nI0XugDHOAyF6_DTDhMxoNZvhLq6awUmlFGHA",
 }
 `;
 
@@ -83,8 +83,8 @@ Object {
     "typ": "JWT",
   },
   "payload": Object {
-    "exp": 1485321733996,
-    "iat": 1485321133996,
+    "exp": 1485321733,
+    "iat": 1485321133,
     "iss": "0x001122",
     "permissions": Array [
       "notifications",
@@ -95,7 +95,7 @@ Object {
     ],
     "type": "shareReq",
   },
-  "signature": "9SIKcKERFJ9l6LgHVQ7AX058MDJahYmB29hjZ6gmToDS2nvClF6QjgUCmQnRHynIYmSn0ePcKjD1MQ9BVy1Ucg",
+  "signature": "GNWPTAF9blrt7TtMps-j6Lt28bM9zzGCmj6S10nmLltgWIM4fLamibv2w1ktt-LtIFlU6cPTsnlOJr0bCi49CQ",
 }
 `;
 
@@ -107,8 +107,8 @@ Object {
   },
   "payload": Object {
     "callback": "https://myserver.com",
-    "exp": 1485321733996,
-    "iat": 1485321133996,
+    "exp": 1485321733,
+    "iat": 1485321133,
     "iss": "0x001122",
     "requested": Array [
       "name",
@@ -116,7 +116,7 @@ Object {
     ],
     "type": "shareReq",
   },
-  "signature": "jbd6jKCc4X8zO3ybWQGhX8pCb72Ml1-H5XH8pJGZfBscIYHX8pkbf2GW2na--uQe18OKwYu2HGU9VEGPjWsMnw",
+  "signature": "5OxjY-V3fdvRyv4XF5fayeQI9EiDZFrx47AUMnh8WnpUQes8qw6vs12bP9F0OnjEfYCkBmM-hTcq7OtTQBK4Ww",
 }
 `;
 
@@ -127,13 +127,13 @@ Object {
     "typ": "JWT",
   },
   "payload": Object {
-    "exp": 1485321733996,
-    "iat": 1485321133996,
+    "exp": 1485321733,
+    "iat": 1485321133,
     "iss": "0x001122",
     "net": "0x4",
     "type": "shareReq",
   },
-  "signature": "ZTi2D7bjK3QZP9aEYkmoOJfX_rDsqO8T024Hcrj9vo7MUss3Un4J12KJqpWdifXc5PXjjRc8cFT-G4jUTyenlQ",
+  "signature": "itf9cAdqqOz635UidRXvCIV6U3DNbzBfDGivELfjypXbRGZgTS7CyDSJxjKwSRxGRqyhof9XzEKqzrldngTeAA",
 }
 `;
 
@@ -144,12 +144,12 @@ Object {
     "typ": "JWT",
   },
   "payload": Object {
-    "exp": 1485321733996,
-    "iat": 1485321133996,
+    "exp": 1485321733,
+    "iat": 1485321133,
     "iss": "0x001122",
     "type": "shareReq",
   },
-  "signature": "BvclScIROeRimK_81fZp3yGVkhM0BF2cJOWp5yvpqz0z5kr4dPucDkdZsltUGhAXEaeuwxOE4c3vJYyeIHOmxg",
+  "signature": "kUs_SxnmUvmAa7-NKJ_qiIoODAB_MgCEMdmkw6pGy3ULMwQ-KWh6-M5CYkvPxPyHoDHVB5yGcFmTMxp_PU8a-g",
 }
 `;
 
@@ -182,10 +182,10 @@ Object {
       "claim": Object {
         "email": "bingbangbung@email.com",
       },
-      "exp": 1485321134996,
-      "iat": 1485321133996,
+      "exp": 1485321134,
+      "iat": 1485321133,
       "iss": "0x001122",
-      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiIweDExMjIzMyIsImNsYWltIjp7ImVtYWlsIjoiYmluZ2JhbmdidW5nQGVtYWlsLmNvbSJ9LCJleHAiOjE0ODUzMjExMzQ5OTYsImlzcyI6IjB4MDAxMTIyIiwiaWF0IjoxNDg1MzIxMTMzOTk2fQ.-mEzVMPYnzqFhOr0O7fs71-dWAacnllVyOdWQY0zh2ZdIt7-30IYTewds4tGlkLmMky-Y1ZjRmIsxmM7xvAgxg",
+      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDAwMTEyMiIsImlhdCI6MTQ4NTMyMTEzMywic3ViIjoiMHgxMTIyMzMiLCJjbGFpbSI6eyJlbWFpbCI6ImJpbmdiYW5nYnVuZ0BlbWFpbC5jb20ifSwiZXhwIjoxNDg1MzIxMTM0fQ.kO5mGjkW6vkvE_JjWfKrt-ZSITo_EXoRIslhDCss78bM2458nQF-wBiFzIWtvjC38TR2NrLh6trz8wG_auTEig",
       "sub": "0x112233",
     },
   ],
@@ -203,10 +203,10 @@ Object {
       "claim": Object {
         "email": "bingbangbung@email.com",
       },
-      "exp": 1485321134996,
-      "iat": 1485321133996,
+      "exp": 1485321134,
+      "iat": 1485321133,
       "iss": "0x001122",
-      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiIweDExMjIzMyIsImNsYWltIjp7ImVtYWlsIjoiYmluZ2JhbmdidW5nQGVtYWlsLmNvbSJ9LCJleHAiOjE0ODUzMjExMzQ5OTYsImlzcyI6IjB4MDAxMTIyIiwiaWF0IjoxNDg1MzIxMTMzOTk2fQ.-mEzVMPYnzqFhOr0O7fs71-dWAacnllVyOdWQY0zh2ZdIt7-30IYTewds4tGlkLmMky-Y1ZjRmIsxmM7xvAgxg",
+      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDAwMTEyMiIsImlhdCI6MTQ4NTMyMTEzMywic3ViIjoiMHgxMTIyMzMiLCJjbGFpbSI6eyJlbWFpbCI6ImJpbmdiYW5nYnVuZ0BlbWFpbC5jb20ifSwiZXhwIjoxNDg1MzIxMTM0fQ.kO5mGjkW6vkvE_JjWfKrt-ZSITo_EXoRIslhDCss78bM2458nQF-wBiFzIWtvjC38TR2NrLh6trz8wG_auTEig",
       "sub": "0x112233",
     },
   ],

--- a/__tests__/__snapshots__/JWT-test.js.snap
+++ b/__tests__/__snapshots__/JWT-test.js.snap
@@ -29,6 +29,21 @@ Object {
 }
 `;
 
+exports[`test accepts a valid legacy exp 1`] = `
+Object {
+  "exp": 1485321133001,
+  "iat": 1485321133,
+  "iss": "0x001122",
+}
+`;
+
+exports[`test accepts a valid legacy iat 1`] = `
+Object {
+  "iat": 1485321133000,
+  "iss": "0x001122",
+}
+`;
+
 exports[`test creates a JWT with correct format 1`] = `
 Object {
   "header": Object {

--- a/__tests__/__snapshots__/JWT-test.js.snap
+++ b/__tests__/__snapshots__/JWT-test.js.snap
@@ -1,7 +1,7 @@
 exports[`test accepts a valid audience 1`] = `
 Object {
   "aud": "0x001122",
-  "iat": 1485321133996,
+  "iat": 1485321133,
   "iss": "0x001122",
 }
 `;
@@ -9,15 +9,22 @@ Object {
 exports[`test accepts a valid audience using callback_url 1`] = `
 Object {
   "aud": "http://pututu.uport.me/unique",
-  "iat": 1485321133996,
+  "iat": 1485321133,
   "iss": "0x001122",
 }
 `;
 
 exports[`test accepts a valid exp 1`] = `
 Object {
-  "exp": 1485321133997,
-  "iat": 1485321133996,
+  "exp": 1485321134,
+  "iat": 1485321133,
+  "iss": "0x001122",
+}
+`;
+
+exports[`test accepts a valid iat 1`] = `
+Object {
+  "iat": 1485321133,
   "iss": "0x001122",
 }
 `;
@@ -29,20 +36,20 @@ Object {
     "typ": "JWT",
   },
   "payload": Object {
-    "iat": 1485321133996,
+    "iat": 1485321133,
     "iss": "0x001122",
     "requested": Array [
       "name",
       "phone",
     ],
   },
-  "signature": "zxGLQKo2WjgefrxEQWfwm_oago8Qr4YctBJoqNAm2XKE-48bADjolSo2T_tED9LnSikxqFIM9gNGpNgcY8JPdg",
+  "signature": "L0rjVxN1lT1AklZXT49EVPtYsQLZ4vVvtqnsBD5AOCwySoff_0Lff7IPg-A43eUCAPuGVBblKx1flYDt8T87TQ",
 }
 `;
 
 exports[`test verifies the JWT and return correct payload 1`] = `
 Object {
-  "iat": 1485321133996,
+  "iat": 1485321133,
   "iss": "0x001122",
   "requested": Array [
     "name",

--- a/dist/uport.js
+++ b/dist/uport.js
@@ -149,7 +149,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @example
 	   * import { Credentials, SimpleSigner } from 'uport'
-	   * const networks = {  '0x94365e3b': { rpcUrl: 'https://private.chain/rpc', address: '0x0101.... }}
+	   * const networks = {  '0x94365e3b': { rpcUrl: 'https://private.chain/rpc', registry: '0x0101.... }}
 	   * const setttings = { networks, address: '5A8bRWU3F7j3REx3vkJ...', signer: new SimpleSigner(process.env.PRIVATE_KEY)}
 	   * const credentials = new Credentials(settings)
 	   *
@@ -291,7 +291,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	              }
 	            });
 	          } else {
-	            console.log('Challenge was not included in response');
+	            throw new Error('Challenge was not included in response');
 	          }
 	        } else {
 	          return processPayload(_this.settings);
@@ -453,6 +453,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var ENCODED_HEADER = encodeSection(JOSE_HEADER);
 
+	var LEGACY_MS = 1000000000000;
 	/**  @module uport-js/JWT */
 
 	/**
@@ -521,10 +522,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var publicKey = profile.publicKey.match(/^0x/) ? profile.publicKey.slice(2) : profile.publicKey;
 	      var verifier = new _jsontokens.TokenVerifier('ES256K', publicKey);
 	      if (verifier.verify(jwt)) {
-	        if (payload.iat > Date.now() / 1000) {
+	        if (payload.iat >= LEGACY_MS && payload.iat > Date.now() || payload.iat < LEGACY_MS && payload.iat > Date.now() / 1000) {
 	          return reject(new Error('JWT not valid yet (issued in the future)'));
 	        }
-	        if (payload.exp && payload.exp <= Date.now() / 1000) {
+	        if (payload.exp && payload.exp >= LEGACY_MS && payload.exp <= Date.now() || payload.iat < LEGACY_MS && payload.exp <= Date.now() / 1000) {
 	          return reject(new Error('JWT has expired'));
 	        }
 	        if (payload.aud) {

--- a/dist/uport.js
+++ b/dist/uport.js
@@ -60,11 +60,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _Credentials2 = _interopRequireDefault(_Credentials);
 
-	var _SimpleSigner = __webpack_require__(118);
+	var _SimpleSigner = __webpack_require__(235);
 
 	var _SimpleSigner2 = _interopRequireDefault(_SimpleSigner);
 
-	var _Contract = __webpack_require__(119);
+	var _Contract = __webpack_require__(236);
 
 	var _JWT = __webpack_require__(2);
 
@@ -118,11 +118,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _jsontokens = __webpack_require__(3);
 
-	var _uportLite = __webpack_require__(108);
+	var _uportLite = __webpack_require__(225);
 
 	var _uportLite2 = _interopRequireDefault(_uportLite);
 
-	var _nets = __webpack_require__(110);
+	var _nets = __webpack_require__(227);
 
 	var _nets2 = _interopRequireDefault(_nets);
 
@@ -233,7 +233,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        //checks for expiration on requests, if none is provided the default is 10 min
 	        payload.exp = params.exp;
 	      } else {
-	        payload.exp = new Date().getTime() + 600000;
+	        payload.exp = Date().getTime() / 1000 + 600;
 	      }
 	      return (0, _JWT.createJWT)(this.settings, _extends({}, payload, { type: 'shareReq' }));
 	    }
@@ -356,7 +356,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      * @param    {Object}            [credential]           a unsigned credential object
 	      * @param    {String}            credential.sub         subject of credential (a uPort address)
 	      * @param    {String}            credential.claim       claim about subject single key value or key mapping to object with multiple values (ie { address: {street: ..., zip: ..., country: ...}})
-	      * @param    {String}            credential.exp         time at which this claim expires and is no longer valid
+	      * @param    {String}            credential.exp         time at which this claim expires and is no longer valid (seconds since epoch)
 	      * @return   {Promise<Object, Error>}                   a promise which resolves with a credential (JWT) or rejects with an error
 	      */
 
@@ -435,9 +435,23 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _jsontokens = __webpack_require__(3);
 
-	var _mnid = __webpack_require__(105);
+	var _mnid = __webpack_require__(222);
+
+	var _base64url = __webpack_require__(5);
+
+	var _base64url2 = _interopRequireDefault(_base64url);
+
+	function _interopRequireDefault(obj) {
+	  return obj && obj.__esModule ? obj : { default: obj };
+	}
 
 	var JOSE_HEADER = { typ: 'JWT', alg: 'ES256K' };
+
+	function encodeSection(data) {
+	  return _base64url2.default.encode(JSON.stringify(data));
+	}
+
+	var ENCODED_HEADER = encodeSection(JOSE_HEADER);
 
 	/**  @module uport-js/JWT */
 
@@ -460,7 +474,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var address = _ref.address,
 	      signer = _ref.signer;
 
-	  var signingInput = (0, _jsontokens.createUnsignedToken)(JOSE_HEADER, _extends({}, payload, { iss: address, iat: new Date().getTime() }));
+	  var signingInput = [ENCODED_HEADER, encodeSection(_extends({ iss: address, iat: Date.now() / 1000 }, payload))].join('.');
+
 	  return new Promise(function (resolve, reject) {
 	    if (!signer) return reject(new Error('No Signer functionality has been configured'));
 	    if (!address) return reject(new Error('No application identity address has been configured'));
@@ -506,7 +521,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var publicKey = profile.publicKey.match(/^0x/) ? profile.publicKey.slice(2) : profile.publicKey;
 	      var verifier = new _jsontokens.TokenVerifier('ES256K', publicKey);
 	      if (verifier.verify(jwt)) {
-	        if (payload.exp && payload.exp <= new Date().getTime()) {
+	        if (payload.iat > Date.now() / 1000) {
+	          return reject(new Error('JWT not valid yet (issued in the future)'));
+	        }
+	        if (payload.exp && payload.exp <= Date.now() / 1000) {
 	          return reject(new Error('JWT has expired'));
 	        }
 	        if (payload.aud) {
@@ -555,14 +573,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return _signer.TokenSigner;
 	  }
 	});
-	Object.defineProperty(exports, 'createUnsignedToken', {
+	Object.defineProperty(exports, 'createUnsecuredToken', {
 	  enumerable: true,
 	  get: function get() {
-	    return _signer.createUnsignedToken;
+	    return _signer.createUnsecuredToken;
 	  }
 	});
 
-	var _verifier = __webpack_require__(104);
+	var _verifier = __webpack_require__(221);
 
 	Object.defineProperty(exports, 'TokenVerifier', {
 	  enumerable: true,
@@ -571,7 +589,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	});
 
-	var _decode = __webpack_require__(103);
+	var _decode = __webpack_require__(220);
 
 	Object.defineProperty(exports, 'decodeToken', {
 	  enumerable: true,
@@ -580,12 +598,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	});
 
-	var _errors = __webpack_require__(102);
+	var _errors = __webpack_require__(219);
 
 	Object.defineProperty(exports, 'MissingParametersError', {
 	  enumerable: true,
 	  get: function get() {
 	    return _errors.MissingParametersError;
+	  }
+	});
+	Object.defineProperty(exports, 'InvalidTokenError', {
+	  enumerable: true,
+	  get: function get() {
+	    return _errors.InvalidTokenError;
 	  }
 	});
 
@@ -617,7 +641,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-	exports.createUnsignedToken = createUnsignedToken;
+	exports.createUnsecuredToken = createUnsecuredToken;
 
 	var _base64url = __webpack_require__(5);
 
@@ -625,7 +649,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _cryptoClients = __webpack_require__(12);
 
-	var _decode = __webpack_require__(103);
+	var _decode = __webpack_require__(220);
 
 	var _decode2 = _interopRequireDefault(_decode);
 
@@ -633,7 +657,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	function createUnsignedToken(header, payload) {
+	function createSigningInput(payload, header) {
 	    var tokenParts = [];
 
 	    // add in the header
@@ -649,6 +673,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    // return the signing input
 	    return signingInput;
+	}
+
+	function createUnsecuredToken(payload) {
+	    var header = { typ: 'JWT', alg: 'none' };
+	    return createSigningInput(payload, header) + '.';
 	}
 
 	var TokenSigner = exports.TokenSigner = function () {
@@ -679,7 +708,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        key: 'sign',
 	        value: function sign(payload) {
 	            // prepare the message to be signed
-	            var signingInput = createUnsignedToken(this.header(), payload);
+	            var signingInput = createSigningInput(payload, this.header());
 	            var signingInputHash = this.cryptoClient.createHash(signingInput);
 
 	            // sign the message and add in the signature
@@ -2826,9 +2855,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _crypto = __webpack_require__(45);
 
-	var _ecdsaSigFormatter = __webpack_require__(100);
+	var _keyEncoder = __webpack_require__(100);
 
-	var _errors = __webpack_require__(102);
+	var _keyEncoder2 = _interopRequireDefault(_keyEncoder);
+
+	var _validator = __webpack_require__(137);
+
+	var _ecdsaSigFormatter = __webpack_require__(202);
+
+	var _errors = __webpack_require__(219);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -2856,24 +2893,37 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return SECP256K1Client.ec.keyFromPublic(rawPublicKey, 'hex');
 	    }
 	  }, {
-	    key: 'privateKeyToPublicKey',
-	    value: function privateKeyToPublicKey(rawPrivateKey) {
-	      if (typeof rawPrivateKey !== 'string') {
-	        throw 'private key must be a string';
+	    key: 'encodePublicKey',
+	    value: function encodePublicKey(publicKey, originalFormat, destinationFormat) {
+	      return SECP256K1Client.keyEncoder.encodePublic(publicKey, originalFormat, destinationFormat);
+	    }
+	  }, {
+	    key: 'derivePublicKey',
+	    value: function derivePublicKey(privateKey, compressed) {
+	      if (typeof privateKey !== 'string') {
+	        throw Error('private key must be a string');
 	      }
-	      if (rawPrivateKey.length === 66) {
-	        rawPrivateKey = rawPrivateKey.slice(0, 64);
-	      } else if (rawPrivateKey.length === 64) {
+	      if (!(0, _validator.isHexadecimal)(privateKey)) {
+	        throw Error('private key must be a hex string');
+	      }
+	      if (privateKey.length == 66) {
+	        privateKey = privateKey.slice(0, 64);
+	      } else if (privateKey.length <= 64) {
 	        // do nothing
 	      } else {
-	        throw 'private key must be a 64 or 66 character hex string';
+	        throw Error('private key must be 66 characters or less');
 	      }
-	      var keypair = SECP256K1Client.ec.keyFromPrivate(rawPrivateKey);
-	      return keypair.getPublic(true, 'hex');
+	      if (compressed === undefined) {
+	        compressed = true;
+	      }
+	      var keypair = SECP256K1Client.ec.keyFromPrivate(privateKey);
+	      return keypair.getPublic(compressed, 'hex');
 	    }
 	  }, {
 	    key: 'signHash',
 	    value: function signHash(signingInputHash, rawPrivateKey) {
+	      var format = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'jose';
+
 	      // make sure the required parameters are provided
 	      if (!(signingInputHash && rawPrivateKey)) {
 	        throw new _errors.MissingParametersError('a signing input hash and private key are all required');
@@ -2883,9 +2933,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // calculate the signature
 	      var signatureObject = privateKeyObject.sign(signingInputHash);
 	      var derSignature = new Buffer(signatureObject.toDER());
-	      var joseSignature = (0, _ecdsaSigFormatter.derToJose)(derSignature, 'ES256');
-	      // return the JOSE-formatted signature
-	      return joseSignature;
+
+	      if (format === 'der') {
+	        return derSignature.toString('hex');
+	      } else if (format === 'jose') {
+	        // return the JOSE-formatted signature
+	        return (0, _ecdsaSigFormatter.derToJose)(derSignature, 'ES256');
+	      } else {
+	        throw Error('Invalid signature format');
+	      }
 	    }
 	  }, {
 	    key: 'loadSignature',
@@ -2912,6 +2968,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	SECP256K1Client.algorithmName = 'ES256K';
 	SECP256K1Client.ec = new _elliptic.ec('secp256k1');
+	SECP256K1Client.keyEncoder = new _keyEncoder2.default({
+	  curveParameters: [1, 3, 132, 0, 10],
+	  privatePEMOptions: { label: 'EC PRIVATE KEY' },
+	  publicPEMOptions: { label: 'PUBLIC KEY' },
+	  curve: SECP256K1Client.ec
+	});
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
@@ -19767,240 +19829,18911 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 100 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {'use strict';
+	'use strict'
 
-	Object.defineProperty(exports, "__esModule", {
-	  value: true
-	});
-	exports.derToJose = derToJose;
-	exports.joseToDer = joseToDer;
-
-	var _base64Url = __webpack_require__(101);
-
-	//var Buffer = require('safe-buffer').Buffer;
-
-	function getParamSize(keySize) {
-	  return (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
-	}
-
-	var paramBytesForAlg = {
-	  ES256: getParamSize(256),
-	  ES384: getParamSize(384),
-	  ES512: getParamSize(521)
-	};
-
-	function getParamBytesForAlg(alg) {
-	  var paramBytes = paramBytesForAlg[alg];
-	  if (paramBytes) {
-	    return paramBytes;
-	  }
-
-	  throw new Error('Unknown algorithm "' + alg + '"');
-	}
-
-	var MAX_OCTET = 0x80,
-	    CLASS_UNIVERSAL = 0,
-	    PRIMITIVE_BIT = 0x20,
-	    TAG_SEQ = 0x10,
-	    TAG_INT = 0x02,
-	    ENCODED_TAG_SEQ = TAG_SEQ | PRIMITIVE_BIT | CLASS_UNIVERSAL << 6,
-	    ENCODED_TAG_INT = TAG_INT | CLASS_UNIVERSAL << 6;
-
-	function signatureAsBuffer(signature) {
-	  if (Buffer.isBuffer(signature)) {
-	    return signature;
-	  } else if ('string' === typeof signature) {
-	    return Buffer.from(signature, 'base64');
-	  }
-
-	  throw new TypeError('ECDSA signature must be a Base64 string or a Buffer');
-	}
-
-	function derToJose(signature, alg) {
-	  signature = signatureAsBuffer(signature);
-	  var paramBytes = getParamBytesForAlg(alg);
-
-	  // the DER encoded param should at most be the param size, plus a padding
-	  // zero, since due to being a signed integer
-	  var maxEncodedParamLength = paramBytes + 1;
-
-	  var inputLength = signature.length;
-
-	  var offset = 0;
-	  if (signature[offset++] !== ENCODED_TAG_SEQ) {
-	    throw new Error('Could not find expected "seq"');
-	  }
-
-	  var seqLength = signature[offset++];
-	  if (seqLength === (MAX_OCTET | 1)) {
-	    seqLength = signature[offset++];
-	  }
-
-	  if (inputLength - offset < seqLength) {
-	    throw new Error('"seq" specified length of "' + seqLength + '", only "' + (inputLength - offset) + '" remaining');
-	  }
-
-	  if (signature[offset++] !== ENCODED_TAG_INT) {
-	    throw new Error('Could not find expected "int" for "r"');
-	  }
-
-	  var rLength = signature[offset++];
-
-	  if (inputLength - offset - 2 < rLength) {
-	    throw new Error('"r" specified length of "' + rLength + '", only "' + (inputLength - offset - 2) + '" available');
-	  }
-
-	  if (maxEncodedParamLength < rLength) {
-	    throw new Error('"r" specified length of "' + rLength + '", max of "' + maxEncodedParamLength + '" is acceptable');
-	  }
-
-	  var rOffset = offset;
-	  offset += rLength;
-
-	  if (signature[offset++] !== ENCODED_TAG_INT) {
-	    throw new Error('Could not find expected "int" for "s"');
-	  }
-
-	  var sLength = signature[offset++];
-
-	  if (inputLength - offset !== sLength) {
-	    throw new Error('"s" specified length of "' + sLength + '", expected "' + (inputLength - offset) + '"');
-	  }
-
-	  if (maxEncodedParamLength < sLength) {
-	    throw new Error('"s" specified length of "' + sLength + '", max of "' + maxEncodedParamLength + '" is acceptable');
-	  }
-
-	  var sOffset = offset;
-	  offset += sLength;
-
-	  if (offset !== inputLength) {
-	    throw new Error('Expected to consume entire buffer, but "' + (inputLength - offset) + '" bytes remain');
-	  }
-
-	  var rPadding = paramBytes - rLength,
-	      sPadding = paramBytes - sLength;
-
-	  var dst = Buffer.allocUnsafe(rPadding + rLength + sPadding + sLength);
-
-	  for (offset = 0; offset < rPadding; ++offset) {
-	    dst[offset] = 0;
-	  }
-	  signature.copy(dst, offset, rOffset + Math.max(-rPadding, 0), rOffset + rLength);
-
-	  offset = paramBytes;
-
-	  for (var o = offset; offset < o + sPadding; ++offset) {
-	    dst[offset] = 0;
-	  }
-	  signature.copy(dst, offset, sOffset + Math.max(-sPadding, 0), sOffset + sLength);
-
-	  dst = dst.toString('base64');
-	  dst = (0, _base64Url.escape)(dst);
-
-	  return dst;
-	}
-
-	function countPadding(buf, start, stop) {
-	  var padding = 0;
-	  while (start + padding < stop && buf[start + padding] === 0) {
-	    ++padding;
-	  }
-
-	  var needsSign = buf[start + padding] >= MAX_OCTET;
-	  if (needsSign) {
-	    --padding;
-	  }
-
-	  return padding;
-	}
-
-	function joseToDer(signature, alg) {
-	  signature = signatureAsBuffer(signature);
-	  var paramBytes = getParamBytesForAlg(alg);
-
-	  var signatureBytes = signature.length;
-	  if (signatureBytes !== paramBytes * 2) {
-	    throw new TypeError('"' + alg + '" signatures must be "' + paramBytes * 2 + '" bytes, saw "' + signatureBytes + '"');
-	  }
-
-	  var rPadding = countPadding(signature, 0, paramBytes);
-	  var sPadding = countPadding(signature, paramBytes, signature.length);
-	  var rLength = paramBytes - rPadding;
-	  var sLength = paramBytes - sPadding;
-
-	  var rsBytes = 1 + 1 + rLength + 1 + 1 + sLength;
-
-	  var shortLength = rsBytes < MAX_OCTET;
-
-	  var dst = Buffer.allocUnsafe((shortLength ? 2 : 3) + rsBytes);
-
-	  var offset = 0;
-	  dst[offset++] = ENCODED_TAG_SEQ;
-	  if (shortLength) {
-	    // Bit 8 has value "0"
-	    // bits 7-1 give the length.
-	    dst[offset++] = rsBytes;
-	  } else {
-	    // Bit 8 of first octet has value "1"
-	    // bits 7-1 give the number of additional length octets.
-	    dst[offset++] = MAX_OCTET | 1;
-	    // length, base 256
-	    dst[offset++] = rsBytes & 0xff;
-	  }
-	  dst[offset++] = ENCODED_TAG_INT;
-	  dst[offset++] = rLength;
-	  if (rPadding < 0) {
-	    dst[offset++] = 0;
-	    offset += signature.copy(dst, offset, 0, paramBytes);
-	  } else {
-	    offset += signature.copy(dst, offset, rPadding, paramBytes);
-	  }
-	  dst[offset++] = ENCODED_TAG_INT;
-	  dst[offset++] = sLength;
-	  if (sPadding < 0) {
-	    dst[offset++] = 0;
-	    signature.copy(dst, offset, paramBytes);
-	  } else {
-	    signature.copy(dst, offset, paramBytes + sPadding);
-	  }
-
-	  return dst;
-	}
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
+	module.exports = __webpack_require__(101)
 
 /***/ }),
 /* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(Buffer) {'use strict';
+	/* WEBPACK VAR INJECTION */(function(Buffer) {'use strict'
 
-	var base64url = module.exports;
+	var asn1 = __webpack_require__(102),
+	    BN = __webpack_require__(119),
+	    EC = __webpack_require__(120).ec
 
-	base64url.unescape = function unescape (str) {
-	  return (str + '==='.slice((str.length + 3) % 4))
-	    .replace(/\-/g, '+')
-	    .replace(/_/g, '/');
-	};
+	var ECPrivateKeyASN = asn1.define('ECPrivateKey', function() {
+	    this.seq().obj(
+	        this.key('version').int(),
+	        this.key('privateKey').octstr(),
+	        this.key('parameters').explicit(0).objid().optional(),
+	        this.key('publicKey').explicit(1).bitstr().optional()
+	    )
+	})
 
-	base64url.escape = function escape (str) {
-	  return str.replace(/\+/g, '-')
-	    .replace(/\//g, '_')
-	    .replace(/=/g, '');
-	};
+	var SubjectPublicKeyInfoASN = asn1.define('SubjectPublicKeyInfo', function() {
+	    this.seq().obj(
+	        this.key('algorithm').seq().obj(
+	            this.key("id").objid(),
+	            this.key("curve").objid()
+	        ),
+	        this.key('pub').bitstr()
+	    )
+	})
 
-	base64url.encode = function encode (str) {
-	  return this.escape(new Buffer(str).toString('base64'));
-	};
+	var curves = {
+	    secp256k1: {
+	        curveParameters: [1, 3, 132, 0, 10],
+	        privatePEMOptions: {label: 'EC PRIVATE KEY'},
+	        publicPEMOptions: {label: 'PUBLIC KEY'},
+	        curve: new EC('secp256k1')
+	    }
+	}
 
-	base64url.decode = function decode (str) {
-	  return new Buffer(this.unescape(str), 'base64').toString();
-	};
+	function assert(val, msg) {
+	    if (!val) {
+	        throw new Error(msg || 'Assertion failed')
+	    }
+	}
 
+	function KeyEncoder(options) {
+	    if (typeof options === 'string') {
+	        assert(curves.hasOwnProperty(options), 'Unknown curve ' + options)
+	        options = curves[options]
+	    }
+	    this.options = options
+	    this.algorithmID = [1, 2, 840, 10045, 2, 1]
+	}
+
+	KeyEncoder.ECPrivateKeyASN = ECPrivateKeyASN
+	KeyEncoder.SubjectPublicKeyInfoASN = SubjectPublicKeyInfoASN
+
+	KeyEncoder.prototype.privateKeyObject = function(rawPrivateKey, rawPublicKey) {
+	    var privateKeyObject = {
+	        version: new BN(1),
+	        privateKey: new Buffer(rawPrivateKey, 'hex'),
+	        parameters: this.options.curveParameters
+	    }
+
+	    if (rawPublicKey) {
+	        privateKeyObject.publicKey = {
+	            unused: 0,
+	            data: new Buffer(rawPublicKey, 'hex')
+	        }
+	    }
+
+	    return privateKeyObject
+	}
+
+	KeyEncoder.prototype.publicKeyObject = function(rawPublicKey) {
+	    return {
+	        algorithm: {
+	            id: this.algorithmID,
+	            curve: this.options.curveParameters
+	        },
+	        pub: {
+	            unused: 0,
+	            data: new Buffer(rawPublicKey, 'hex')
+	        }
+	    }
+	}
+
+	KeyEncoder.prototype.encodePrivate = function(privateKey, originalFormat, destinationFormat) {
+	    var privateKeyObject
+
+	    /* Parse the incoming private key and convert it to a private key object */
+	    if (originalFormat === 'raw') {
+	        if (!typeof privateKey === 'string') {
+	            throw 'private key must be a string'
+	        }
+	        var privateKeyObject = this.options.curve.keyFromPrivate(privateKey, 'hex'),
+	            rawPublicKey = privateKeyObject.getPublic('hex')
+	        privateKeyObject = this.privateKeyObject(privateKey, rawPublicKey)
+	    } else if (originalFormat === 'der') {
+	        if (typeof privateKey === 'buffer') {
+	            // do nothing
+	        } else if (typeof privateKey === 'string') {
+	            privateKey = new Buffer(privateKey, 'hex')
+	        } else {
+	            throw 'private key must be a buffer or a string'
+	        }
+	        privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'der')
+	    } else if (originalFormat === 'pem') {
+	        if (!typeof privateKey === 'string') {
+	            throw 'private key must be a string'
+	        }
+	        privateKeyObject = ECPrivateKeyASN.decode(privateKey, 'pem', this.options.privatePEMOptions)
+	    } else {
+	        throw 'invalid private key format'
+	    }
+
+	    /* Export the private key object to the desired format */
+	    if (destinationFormat === 'raw') {
+	        return privateKeyObject.privateKey.toString('hex')
+	    } else if (destinationFormat === 'der') {
+	        return ECPrivateKeyASN.encode(privateKeyObject, 'der').toString('hex')
+	    } else if (destinationFormat === 'pem') {
+	        return ECPrivateKeyASN.encode(privateKeyObject, 'pem', this.options.privatePEMOptions)
+	    } else {
+	        throw 'invalid destination format for private key'
+	    }
+	}
+
+	KeyEncoder.prototype.encodePublic = function(publicKey, originalFormat, destinationFormat) {
+	    var publicKeyObject
+
+	    /* Parse the incoming public key and convert it to a public key object */
+	    if (originalFormat === 'raw') {
+	        if (!typeof publicKey === 'string') {
+	            throw 'public key must be a string'
+	        }
+	        publicKeyObject = this.publicKeyObject(publicKey)
+	    } else if (originalFormat === 'der') {
+	        if (typeof publicKey === 'buffer') {
+	            // do nothing
+	        } else if (typeof publicKey === 'string') {
+	            publicKey = new Buffer(publicKey, 'hex')
+	        } else {
+	            throw 'public key must be a buffer or a string'
+	        }
+	        publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'der')
+	    } else if (originalFormat === 'pem') {
+	        if (!typeof publicKey === 'string') {
+	            throw 'public key must be a string'
+	        }
+	        publicKeyObject = SubjectPublicKeyInfoASN.decode(publicKey, 'pem', this.options.publicPEMOptions)
+	    } else {
+	        throw 'invalid public key format'
+	    }
+
+	    /* Export the private key object to the desired format */
+	    if (destinationFormat === 'raw') {
+	        return publicKeyObject.pub.data.toString('hex')
+	    } else if (destinationFormat === 'der') {
+	        return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'der').toString('hex')
+	    } else if (destinationFormat === 'pem') {
+	        return SubjectPublicKeyInfoASN.encode(publicKeyObject, 'pem', this.options.publicPEMOptions)
+	    } else {
+	        throw 'invalid destination format for public key'
+	    }
+	}
+
+	module.exports = KeyEncoder
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
 /* 102 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var asn1 = exports;
+
+	asn1.bignum = __webpack_require__(103);
+
+	asn1.define = __webpack_require__(104).define;
+	asn1.base = __webpack_require__(107);
+	asn1.constants = __webpack_require__(111);
+	asn1.decoders = __webpack_require__(113);
+	asn1.encoders = __webpack_require__(116);
+
+
+/***/ }),
+/* 103 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(module) {(function (module, exports) {
+
+	'use strict';
+
+	// Utils
+
+	function assert(val, msg) {
+	  if (!val)
+	    throw new Error(msg || 'Assertion failed');
+	}
+
+	// Could use `inherits` module, but don't want to move from single file
+	// architecture yet.
+	function inherits(ctor, superCtor) {
+	  ctor.super_ = superCtor;
+	  var TempCtor = function () {};
+	  TempCtor.prototype = superCtor.prototype;
+	  ctor.prototype = new TempCtor();
+	  ctor.prototype.constructor = ctor;
+	}
+
+	// BN
+
+	function BN(number, base, endian) {
+	  // May be `new BN(bn)` ?
+	  if (number !== null &&
+	      typeof number === 'object' &&
+	      Array.isArray(number.words)) {
+	    return number;
+	  }
+
+	  this.sign = false;
+	  this.words = null;
+	  this.length = 0;
+
+	  // Reduction context
+	  this.red = null;
+
+	  if (base === 'le' || base === 'be') {
+	    endian = base;
+	    base = 10;
+	  }
+
+	  if (number !== null)
+	    this._init(number || 0, base || 10, endian || 'be');
+	}
+	if (typeof module === 'object')
+	  module.exports = BN;
+	else
+	  exports.BN = BN;
+
+	BN.BN = BN;
+	BN.wordSize = 26;
+
+	BN.prototype._init = function init(number, base, endian) {
+	  if (typeof number === 'number') {
+	    return this._initNumber(number, base, endian);
+	  } else if (typeof number === 'object') {
+	    return this._initArray(number, base, endian);
+	  }
+	  if (base === 'hex')
+	    base = 16;
+	  assert(base === (base | 0) && base >= 2 && base <= 36);
+
+	  number = number.toString().replace(/\s+/g, '');
+	  var start = 0;
+	  if (number[0] === '-')
+	    start++;
+
+	  if (base === 16)
+	    this._parseHex(number, start);
+	  else
+	    this._parseBase(number, base, start);
+
+	  if (number[0] === '-')
+	    this.sign = true;
+
+	  this.strip();
+
+	  if (endian !== 'le')
+	    return;
+
+	  this._initArray(this.toArray(), base, endian);
+	};
+
+	BN.prototype._initNumber = function _initNumber(number, base, endian) {
+	  if (number < 0) {
+	    this.sign = true;
+	    number = -number;
+	  }
+	  if (number < 0x4000000) {
+	    this.words = [ number & 0x3ffffff ];
+	    this.length = 1;
+	  } else if (number < 0x10000000000000) {
+	    this.words = [
+	      number & 0x3ffffff,
+	      (number / 0x4000000) & 0x3ffffff
+	    ];
+	    this.length = 2;
+	  } else {
+	    assert(number < 0x20000000000000); // 2 ^ 53 (unsafe)
+	    this.words = [
+	      number & 0x3ffffff,
+	      (number / 0x4000000) & 0x3ffffff,
+	      1
+	    ];
+	    this.length = 3;
+	  }
+
+	  if (endian !== 'le')
+	    return;
+
+	  // Reverse the bytes
+	  this._initArray(this.toArray(), base, endian);
+	};
+
+	BN.prototype._initArray = function _initArray(number, base, endian) {
+	  // Perhaps a Uint8Array
+	  assert(typeof number.length === 'number');
+	  if (number.length <= 0) {
+	    this.words = [ 0 ];
+	    this.length = 1;
+	    return this;
+	  }
+
+	  this.length = Math.ceil(number.length / 3);
+	  this.words = new Array(this.length);
+	  for (var i = 0; i < this.length; i++)
+	    this.words[i] = 0;
+
+	  var off = 0;
+	  if (endian === 'be') {
+	    for (var i = number.length - 1, j = 0; i >= 0; i -= 3) {
+	      var w = number[i] | (number[i - 1] << 8) | (number[i - 2] << 16);
+	      this.words[j] |= (w << off) & 0x3ffffff;
+	      this.words[j + 1] = (w >>> (26 - off)) & 0x3ffffff;
+	      off += 24;
+	      if (off >= 26) {
+	        off -= 26;
+	        j++;
+	      }
+	    }
+	  } else if (endian === 'le') {
+	    for (var i = 0, j = 0; i < number.length; i += 3) {
+	      var w = number[i] | (number[i + 1] << 8) | (number[i + 2] << 16);
+	      this.words[j] |= (w << off) & 0x3ffffff;
+	      this.words[j + 1] = (w >>> (26 - off)) & 0x3ffffff;
+	      off += 24;
+	      if (off >= 26) {
+	        off -= 26;
+	        j++;
+	      }
+	    }
+	  }
+	  return this.strip();
+	};
+
+	function parseHex(str, start, end) {
+	  var r = 0;
+	  var len = Math.min(str.length, end);
+	  for (var i = start; i < len; i++) {
+	    var c = str.charCodeAt(i) - 48;
+
+	    r <<= 4;
+
+	    // 'a' - 'f'
+	    if (c >= 49 && c <= 54)
+	      r |= c - 49 + 0xa;
+
+	    // 'A' - 'F'
+	    else if (c >= 17 && c <= 22)
+	      r |= c - 17 + 0xa;
+
+	    // '0' - '9'
+	    else
+	      r |= c & 0xf;
+	  }
+	  return r;
+	}
+
+	BN.prototype._parseHex = function _parseHex(number, start) {
+	  // Create possibly bigger array to ensure that it fits the number
+	  this.length = Math.ceil((number.length - start) / 6);
+	  this.words = new Array(this.length);
+	  for (var i = 0; i < this.length; i++)
+	    this.words[i] = 0;
+
+	  // Scan 24-bit chunks and add them to the number
+	  var off = 0;
+	  for (var i = number.length - 6, j = 0; i >= start; i -= 6) {
+	    var w = parseHex(number, i, i + 6);
+	    this.words[j] |= (w << off) & 0x3ffffff;
+	    this.words[j + 1] |= w >>> (26 - off) & 0x3fffff;
+	    off += 24;
+	    if (off >= 26) {
+	      off -= 26;
+	      j++;
+	    }
+	  }
+	  if (i + 6 !== start) {
+	    var w = parseHex(number, start, i + 6);
+	    this.words[j] |= (w << off) & 0x3ffffff;
+	    this.words[j + 1] |= w >>> (26 - off) & 0x3fffff;
+	  }
+	  this.strip();
+	};
+
+	function parseBase(str, start, end, mul) {
+	  var r = 0;
+	  var len = Math.min(str.length, end);
+	  for (var i = start; i < len; i++) {
+	    var c = str.charCodeAt(i) - 48;
+
+	    r *= mul;
+
+	    // 'a'
+	    if (c >= 49)
+	      r += c - 49 + 0xa;
+
+	    // 'A'
+	    else if (c >= 17)
+	      r += c - 17 + 0xa;
+
+	    // '0' - '9'
+	    else
+	      r += c;
+	  }
+	  return r;
+	}
+
+	BN.prototype._parseBase = function _parseBase(number, base, start) {
+	  // Initialize as zero
+	  this.words = [ 0 ];
+	  this.length = 1;
+
+	  // Find length of limb in base
+	  for (var limbLen = 0, limbPow = 1; limbPow <= 0x3ffffff; limbPow *= base)
+	    limbLen++;
+	  limbLen--;
+	  limbPow = (limbPow / base) | 0;
+
+	  var total = number.length - start;
+	  var mod = total % limbLen;
+	  var end = Math.min(total, total - mod) + start;
+
+	  var word = 0;
+	  for (var i = start; i < end; i += limbLen) {
+	    word = parseBase(number, i, i + limbLen, base);
+
+	    this.imuln(limbPow);
+	    if (this.words[0] + word < 0x4000000)
+	      this.words[0] += word;
+	    else
+	      this._iaddn(word);
+	  }
+
+	  if (mod !== 0) {
+	    var pow = 1;
+	    var word = parseBase(number, i, number.length, base);
+
+	    for (var i = 0; i < mod; i++)
+	      pow *= base;
+	    this.imuln(pow);
+	    if (this.words[0] + word < 0x4000000)
+	      this.words[0] += word;
+	    else
+	      this._iaddn(word);
+	  }
+	};
+
+	BN.prototype.copy = function copy(dest) {
+	  dest.words = new Array(this.length);
+	  for (var i = 0; i < this.length; i++)
+	    dest.words[i] = this.words[i];
+	  dest.length = this.length;
+	  dest.sign = this.sign;
+	  dest.red = this.red;
+	};
+
+	BN.prototype.clone = function clone() {
+	  var r = new BN(null);
+	  this.copy(r);
+	  return r;
+	};
+
+	// Remove leading `0` from `this`
+	BN.prototype.strip = function strip() {
+	  while (this.length > 1 && this.words[this.length - 1] === 0)
+	    this.length--;
+	  return this._normSign();
+	};
+
+	BN.prototype._normSign = function _normSign() {
+	  // -0 = 0
+	  if (this.length === 1 && this.words[0] === 0)
+	    this.sign = false;
+	  return this;
+	};
+
+	BN.prototype.inspect = function inspect() {
+	  return (this.red ? '<BN-R: ' : '<BN: ') + this.toString(16) + '>';
+	};
+
+	/*
+
+	var zeros = [];
+	var groupSizes = [];
+	var groupBases = [];
+
+	var s = '';
+	var i = -1;
+	while (++i < BN.wordSize) {
+	  zeros[i] = s;
+	  s += '0';
+	}
+	groupSizes[0] = 0;
+	groupSizes[1] = 0;
+	groupBases[0] = 0;
+	groupBases[1] = 0;
+	var base = 2 - 1;
+	while (++base < 36 + 1) {
+	  var groupSize = 0;
+	  var groupBase = 1;
+	  while (groupBase < (1 << BN.wordSize) / base) {
+	    groupBase *= base;
+	    groupSize += 1;
+	  }
+	  groupSizes[base] = groupSize;
+	  groupBases[base] = groupBase;
+	}
+
+	*/
+
+	var zeros = [
+	  '',
+	  '0',
+	  '00',
+	  '000',
+	  '0000',
+	  '00000',
+	  '000000',
+	  '0000000',
+	  '00000000',
+	  '000000000',
+	  '0000000000',
+	  '00000000000',
+	  '000000000000',
+	  '0000000000000',
+	  '00000000000000',
+	  '000000000000000',
+	  '0000000000000000',
+	  '00000000000000000',
+	  '000000000000000000',
+	  '0000000000000000000',
+	  '00000000000000000000',
+	  '000000000000000000000',
+	  '0000000000000000000000',
+	  '00000000000000000000000',
+	  '000000000000000000000000',
+	  '0000000000000000000000000'
+	];
+
+	var groupSizes = [
+	  0, 0,
+	  25, 16, 12, 11, 10, 9, 8,
+	  8, 7, 7, 7, 7, 6, 6,
+	  6, 6, 6, 6, 6, 5, 5,
+	  5, 5, 5, 5, 5, 5, 5,
+	  5, 5, 5, 5, 5, 5, 5
+	];
+
+	var groupBases = [
+	  0, 0,
+	  33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216,
+	  43046721, 10000000, 19487171, 35831808, 62748517, 7529536, 11390625,
+	  16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632,
+	  6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149,
+	  24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176
+	];
+
+	BN.prototype.toString = function toString(base, padding) {
+	  base = base || 10;
+	  if (base === 16 || base === 'hex') {
+	    var out = '';
+	    var off = 0;
+	    var padding = padding | 0 || 1;
+	    var carry = 0;
+	    for (var i = 0; i < this.length; i++) {
+	      var w = this.words[i];
+	      var word = (((w << off) | carry) & 0xffffff).toString(16);
+	      carry = (w >>> (24 - off)) & 0xffffff;
+	      if (carry !== 0 || i !== this.length - 1)
+	        out = zeros[6 - word.length] + word + out;
+	      else
+	        out = word + out;
+	      off += 2;
+	      if (off >= 26) {
+	        off -= 26;
+	        i--;
+	      }
+	    }
+	    if (carry !== 0)
+	      out = carry.toString(16) + out;
+	    while (out.length % padding !== 0)
+	      out = '0' + out;
+	    if (this.sign)
+	      out = '-' + out;
+	    return out;
+	  } else if (base === (base | 0) && base >= 2 && base <= 36) {
+	    // var groupSize = Math.floor(BN.wordSize * Math.LN2 / Math.log(base));
+	    var groupSize = groupSizes[base];
+	    // var groupBase = Math.pow(base, groupSize);
+	    var groupBase = groupBases[base];
+	    var out = '';
+	    var c = this.clone();
+	    c.sign = false;
+	    while (c.cmpn(0) !== 0) {
+	      var r = c.modn(groupBase).toString(base);
+	      c = c.idivn(groupBase);
+
+	      if (c.cmpn(0) !== 0)
+	        out = zeros[groupSize - r.length] + r + out;
+	      else
+	        out = r + out;
+	    }
+	    if (this.cmpn(0) === 0)
+	      out = '0' + out;
+	    if (this.sign)
+	      out = '-' + out;
+	    return out;
+	  } else {
+	    assert(false, 'Base should be between 2 and 36');
+	  }
+	};
+
+	BN.prototype.toJSON = function toJSON() {
+	  return this.toString(16);
+	};
+
+	BN.prototype.toArray = function toArray(endian) {
+	  this.strip();
+	  var res = new Array(this.byteLength());
+	  res[0] = 0;
+
+	  var q = this.clone();
+	  if (endian !== 'le') {
+	    // Assume big-endian
+	    for (var i = 0; q.cmpn(0) !== 0; i++) {
+	      var b = q.andln(0xff);
+	      q.ishrn(8);
+
+	      res[res.length - i - 1] = b;
+	    }
+	  } else {
+	    // Assume little-endian
+	    for (var i = 0; q.cmpn(0) !== 0; i++) {
+	      var b = q.andln(0xff);
+	      q.ishrn(8);
+
+	      res[i] = b;
+	    }
+	  }
+
+	  return res;
+	};
+
+	if (Math.clz32) {
+	  BN.prototype._countBits = function _countBits(w) {
+	    return 32 - Math.clz32(w);
+	  };
+	} else {
+	  BN.prototype._countBits = function _countBits(w) {
+	    var t = w;
+	    var r = 0;
+	    if (t >= 0x1000) {
+	      r += 13;
+	      t >>>= 13;
+	    }
+	    if (t >= 0x40) {
+	      r += 7;
+	      t >>>= 7;
+	    }
+	    if (t >= 0x8) {
+	      r += 4;
+	      t >>>= 4;
+	    }
+	    if (t >= 0x02) {
+	      r += 2;
+	      t >>>= 2;
+	    }
+	    return r + t;
+	  };
+	}
+
+	BN.prototype._zeroBits = function _zeroBits(w) {
+	  // Short-cut
+	  if (w === 0)
+	    return 26;
+
+	  var t = w;
+	  var r = 0;
+	  if ((t & 0x1fff) === 0) {
+	    r += 13;
+	    t >>>= 13;
+	  }
+	  if ((t & 0x7f) === 0) {
+	    r += 7;
+	    t >>>= 7;
+	  }
+	  if ((t & 0xf) === 0) {
+	    r += 4;
+	    t >>>= 4;
+	  }
+	  if ((t & 0x3) === 0) {
+	    r += 2;
+	    t >>>= 2;
+	  }
+	  if ((t & 0x1) === 0)
+	    r++;
+	  return r;
+	};
+
+	// Return number of used bits in a BN
+	BN.prototype.bitLength = function bitLength() {
+	  var hi = 0;
+	  var w = this.words[this.length - 1];
+	  var hi = this._countBits(w);
+	  return (this.length - 1) * 26 + hi;
+	};
+
+	// Number of trailing zero bits
+	BN.prototype.zeroBits = function zeroBits() {
+	  if (this.cmpn(0) === 0)
+	    return 0;
+
+	  var r = 0;
+	  for (var i = 0; i < this.length; i++) {
+	    var b = this._zeroBits(this.words[i]);
+	    r += b;
+	    if (b !== 26)
+	      break;
+	  }
+	  return r;
+	};
+
+	BN.prototype.byteLength = function byteLength() {
+	  return Math.ceil(this.bitLength() / 8);
+	};
+
+	// Return negative clone of `this`
+	BN.prototype.neg = function neg() {
+	  if (this.cmpn(0) === 0)
+	    return this.clone();
+
+	  var r = this.clone();
+	  r.sign = !this.sign;
+	  return r;
+	};
+
+
+	// Or `num` with `this` in-place
+	BN.prototype.ior = function ior(num) {
+	  this.sign = this.sign || num.sign;
+
+	  while (this.length < num.length)
+	    this.words[this.length++] = 0;
+
+	  for (var i = 0; i < num.length; i++)
+	    this.words[i] = this.words[i] | num.words[i];
+
+	  return this.strip();
+	};
+
+
+	// Or `num` with `this`
+	BN.prototype.or = function or(num) {
+	  if (this.length > num.length)
+	    return this.clone().ior(num);
+	  else
+	    return num.clone().ior(this);
+	};
+
+
+	// And `num` with `this` in-place
+	BN.prototype.iand = function iand(num) {
+	  this.sign = this.sign && num.sign;
+
+	  // b = min-length(num, this)
+	  var b;
+	  if (this.length > num.length)
+	    b = num;
+	  else
+	    b = this;
+
+	  for (var i = 0; i < b.length; i++)
+	    this.words[i] = this.words[i] & num.words[i];
+
+	  this.length = b.length;
+
+	  return this.strip();
+	};
+
+
+	// And `num` with `this`
+	BN.prototype.and = function and(num) {
+	  if (this.length > num.length)
+	    return this.clone().iand(num);
+	  else
+	    return num.clone().iand(this);
+	};
+
+
+	// Xor `num` with `this` in-place
+	BN.prototype.ixor = function ixor(num) {
+	  this.sign = this.sign || num.sign;
+
+	  // a.length > b.length
+	  var a;
+	  var b;
+	  if (this.length > num.length) {
+	    a = this;
+	    b = num;
+	  } else {
+	    a = num;
+	    b = this;
+	  }
+
+	  for (var i = 0; i < b.length; i++)
+	    this.words[i] = a.words[i] ^ b.words[i];
+
+	  if (this !== a)
+	    for (; i < a.length; i++)
+	      this.words[i] = a.words[i];
+
+	  this.length = a.length;
+
+	  return this.strip();
+	};
+
+
+	// Xor `num` with `this`
+	BN.prototype.xor = function xor(num) {
+	  if (this.length > num.length)
+	    return this.clone().ixor(num);
+	  else
+	    return num.clone().ixor(this);
+	};
+
+
+	// Set `bit` of `this`
+	BN.prototype.setn = function setn(bit, val) {
+	  assert(typeof bit === 'number' && bit >= 0);
+
+	  var off = (bit / 26) | 0;
+	  var wbit = bit % 26;
+
+	  while (this.length <= off)
+	    this.words[this.length++] = 0;
+
+	  if (val)
+	    this.words[off] = this.words[off] | (1 << wbit);
+	  else
+	    this.words[off] = this.words[off] & ~(1 << wbit);
+
+	  return this.strip();
+	};
+
+
+	// Add `num` to `this` in-place
+	BN.prototype.iadd = function iadd(num) {
+	  // negative + positive
+	  if (this.sign && !num.sign) {
+	    this.sign = false;
+	    var r = this.isub(num);
+	    this.sign = !this.sign;
+	    return this._normSign();
+
+	  // positive + negative
+	  } else if (!this.sign && num.sign) {
+	    num.sign = false;
+	    var r = this.isub(num);
+	    num.sign = true;
+	    return r._normSign();
+	  }
+
+	  // a.length > b.length
+	  var a;
+	  var b;
+	  if (this.length > num.length) {
+	    a = this;
+	    b = num;
+	  } else {
+	    a = num;
+	    b = this;
+	  }
+
+	  var carry = 0;
+	  for (var i = 0; i < b.length; i++) {
+	    var r = a.words[i] + b.words[i] + carry;
+	    this.words[i] = r & 0x3ffffff;
+	    carry = r >>> 26;
+	  }
+	  for (; carry !== 0 && i < a.length; i++) {
+	    var r = a.words[i] + carry;
+	    this.words[i] = r & 0x3ffffff;
+	    carry = r >>> 26;
+	  }
+
+	  this.length = a.length;
+	  if (carry !== 0) {
+	    this.words[this.length] = carry;
+	    this.length++;
+	  // Copy the rest of the words
+	  } else if (a !== this) {
+	    for (; i < a.length; i++)
+	      this.words[i] = a.words[i];
+	  }
+
+	  return this;
+	};
+
+	// Add `num` to `this`
+	BN.prototype.add = function add(num) {
+	  if (num.sign && !this.sign) {
+	    num.sign = false;
+	    var res = this.sub(num);
+	    num.sign = true;
+	    return res;
+	  } else if (!num.sign && this.sign) {
+	    this.sign = false;
+	    var res = num.sub(this);
+	    this.sign = true;
+	    return res;
+	  }
+
+	  if (this.length > num.length)
+	    return this.clone().iadd(num);
+	  else
+	    return num.clone().iadd(this);
+	};
+
+	// Subtract `num` from `this` in-place
+	BN.prototype.isub = function isub(num) {
+	  // this - (-num) = this + num
+	  if (num.sign) {
+	    num.sign = false;
+	    var r = this.iadd(num);
+	    num.sign = true;
+	    return r._normSign();
+
+	  // -this - num = -(this + num)
+	  } else if (this.sign) {
+	    this.sign = false;
+	    this.iadd(num);
+	    this.sign = true;
+	    return this._normSign();
+	  }
+
+	  // At this point both numbers are positive
+	  var cmp = this.cmp(num);
+
+	  // Optimization - zeroify
+	  if (cmp === 0) {
+	    this.sign = false;
+	    this.length = 1;
+	    this.words[0] = 0;
+	    return this;
+	  }
+
+	  // a > b
+	  var a;
+	  var b;
+	  if (cmp > 0) {
+	    a = this;
+	    b = num;
+	  } else {
+	    a = num;
+	    b = this;
+	  }
+
+	  var carry = 0;
+	  for (var i = 0; i < b.length; i++) {
+	    var r = a.words[i] - b.words[i] + carry;
+	    carry = r >> 26;
+	    this.words[i] = r & 0x3ffffff;
+	  }
+	  for (; carry !== 0 && i < a.length; i++) {
+	    var r = a.words[i] + carry;
+	    carry = r >> 26;
+	    this.words[i] = r & 0x3ffffff;
+	  }
+
+	  // Copy rest of the words
+	  if (carry === 0 && i < a.length && a !== this)
+	    for (; i < a.length; i++)
+	      this.words[i] = a.words[i];
+	  this.length = Math.max(this.length, i);
+
+	  if (a !== this)
+	    this.sign = true;
+
+	  return this.strip();
+	};
+
+	// Subtract `num` from `this`
+	BN.prototype.sub = function sub(num) {
+	  return this.clone().isub(num);
+	};
+
+	/*
+	// NOTE: This could be potentionally used to generate loop-less multiplications
+	function _genCombMulTo(alen, blen) {
+	  var len = alen + blen - 1;
+	  var src = [
+	    'var a = this.words, b = num.words, o = out.words, c = 0, w, ' +
+	        'mask = 0x3ffffff, shift = 0x4000000;',
+	    'out.length = ' + len + ';'
+	  ];
+	  for (var k = 0; k < len; k++) {
+	    var minJ = Math.max(0, k - alen + 1);
+	    var maxJ = Math.min(k, blen - 1);
+
+	    for (var j = minJ; j <= maxJ; j++) {
+	      var i = k - j;
+	      var mul = 'a[' + i + '] * b[' + j + ']';
+
+	      if (j === minJ) {
+	        src.push('w = ' + mul + ' + c;');
+	        src.push('c = (w / shift) | 0;');
+	      } else {
+	        src.push('w += ' + mul + ';');
+	        src.push('c += (w / shift) | 0;');
+	      }
+	      src.push('w &= mask;');
+	    }
+	    src.push('o[' + k + '] = w;');
+	  }
+	  src.push('if (c !== 0) {',
+	           '  o[' + k + '] = c;',
+	           '  out.length++;',
+	           '}',
+	           'return out;');
+
+	  return src.join('\n');
+	}
+	*/
+
+	BN.prototype._smallMulTo = function _smallMulTo(num, out) {
+	  out.sign = num.sign !== this.sign;
+	  out.length = this.length + num.length;
+
+	  var carry = 0;
+	  for (var k = 0; k < out.length - 1; k++) {
+	    // Sum all words with the same `i + j = k` and accumulate `ncarry`,
+	    // note that ncarry could be >= 0x3ffffff
+	    var ncarry = carry >>> 26;
+	    var rword = carry & 0x3ffffff;
+	    var maxJ = Math.min(k, num.length - 1);
+	    for (var j = Math.max(0, k - this.length + 1); j <= maxJ; j++) {
+	      var i = k - j;
+	      var a = this.words[i] | 0;
+	      var b = num.words[j] | 0;
+	      var r = a * b;
+
+	      var lo = r & 0x3ffffff;
+	      ncarry = (ncarry + ((r / 0x4000000) | 0)) | 0;
+	      lo = (lo + rword) | 0;
+	      rword = lo & 0x3ffffff;
+	      ncarry = (ncarry + (lo >>> 26)) | 0;
+	    }
+	    out.words[k] = rword;
+	    carry = ncarry;
+	  }
+	  if (carry !== 0) {
+	    out.words[k] = carry;
+	  } else {
+	    out.length--;
+	  }
+
+	  return out.strip();
+	};
+
+	BN.prototype._bigMulTo = function _bigMulTo(num, out) {
+	  out.sign = num.sign !== this.sign;
+	  out.length = this.length + num.length;
+
+	  var carry = 0;
+	  var hncarry = 0;
+	  for (var k = 0; k < out.length - 1; k++) {
+	    // Sum all words with the same `i + j = k` and accumulate `ncarry`,
+	    // note that ncarry could be >= 0x3ffffff
+	    var ncarry = hncarry;
+	    hncarry = 0;
+	    var rword = carry & 0x3ffffff;
+	    var maxJ = Math.min(k, num.length - 1);
+	    for (var j = Math.max(0, k - this.length + 1); j <= maxJ; j++) {
+	      var i = k - j;
+	      var a = this.words[i] | 0;
+	      var b = num.words[j] | 0;
+	      var r = a * b;
+
+	      var lo = r & 0x3ffffff;
+	      ncarry = (ncarry + ((r / 0x4000000) | 0)) | 0;
+	      lo = (lo + rword) | 0;
+	      rword = lo & 0x3ffffff;
+	      ncarry = (ncarry + (lo >>> 26)) | 0;
+
+	      hncarry += ncarry >>> 26;
+	      ncarry &= 0x3ffffff;
+	    }
+	    out.words[k] = rword;
+	    carry = ncarry;
+	    ncarry = hncarry;
+	  }
+	  if (carry !== 0) {
+	    out.words[k] = carry;
+	  } else {
+	    out.length--;
+	  }
+
+	  return out.strip();
+	};
+
+	BN.prototype.mulTo = function mulTo(num, out) {
+	  var res;
+	  if (this.length + num.length < 63)
+	    res = this._smallMulTo(num, out);
+	  else
+	    res = this._bigMulTo(num, out);
+	  return res;
+	};
+
+	// Multiply `this` by `num`
+	BN.prototype.mul = function mul(num) {
+	  var out = new BN(null);
+	  out.words = new Array(this.length + num.length);
+	  return this.mulTo(num, out);
+	};
+
+	// In-place Multiplication
+	BN.prototype.imul = function imul(num) {
+	  if (this.cmpn(0) === 0 || num.cmpn(0) === 0) {
+	    this.words[0] = 0;
+	    this.length = 1;
+	    return this;
+	  }
+
+	  var tlen = this.length;
+	  var nlen = num.length;
+
+	  this.sign = num.sign !== this.sign;
+	  this.length = this.length + num.length;
+	  this.words[this.length - 1] = 0;
+
+	  for (var k = this.length - 2; k >= 0; k--) {
+	    // Sum all words with the same `i + j = k` and accumulate `carry`,
+	    // note that carry could be >= 0x3ffffff
+	    var carry = 0;
+	    var rword = 0;
+	    var maxJ = Math.min(k, nlen - 1);
+	    for (var j = Math.max(0, k - tlen + 1); j <= maxJ; j++) {
+	      var i = k - j;
+	      var a = this.words[i];
+	      var b = num.words[j];
+	      var r = a * b;
+
+	      var lo = r & 0x3ffffff;
+	      carry += (r / 0x4000000) | 0;
+	      lo += rword;
+	      rword = lo & 0x3ffffff;
+	      carry += lo >>> 26;
+	    }
+	    this.words[k] = rword;
+	    this.words[k + 1] += carry;
+	    carry = 0;
+	  }
+
+	  // Propagate overflows
+	  var carry = 0;
+	  for (var i = 1; i < this.length; i++) {
+	    var w = this.words[i] + carry;
+	    this.words[i] = w & 0x3ffffff;
+	    carry = w >>> 26;
+	  }
+
+	  return this.strip();
+	};
+
+	BN.prototype.imuln = function imuln(num) {
+	  assert(typeof num === 'number');
+
+	  // Carry
+	  var carry = 0;
+	  for (var i = 0; i < this.length; i++) {
+	    var w = this.words[i] * num;
+	    var lo = (w & 0x3ffffff) + (carry & 0x3ffffff);
+	    carry >>= 26;
+	    carry += (w / 0x4000000) | 0;
+	    // NOTE: lo is 27bit maximum
+	    carry += lo >>> 26;
+	    this.words[i] = lo & 0x3ffffff;
+	  }
+
+	  if (carry !== 0) {
+	    this.words[i] = carry;
+	    this.length++;
+	  }
+
+	  return this;
+	};
+
+	BN.prototype.muln = function muln(num) {
+	  return this.clone().imuln(num);
+	};
+
+	// `this` * `this`
+	BN.prototype.sqr = function sqr() {
+	  return this.mul(this);
+	};
+
+	// `this` * `this` in-place
+	BN.prototype.isqr = function isqr() {
+	  return this.mul(this);
+	};
+
+	// Shift-left in-place
+	BN.prototype.ishln = function ishln(bits) {
+	  assert(typeof bits === 'number' && bits >= 0);
+	  var r = bits % 26;
+	  var s = (bits - r) / 26;
+	  var carryMask = (0x3ffffff >>> (26 - r)) << (26 - r);
+
+	  if (r !== 0) {
+	    var carry = 0;
+	    for (var i = 0; i < this.length; i++) {
+	      var newCarry = this.words[i] & carryMask;
+	      var c = (this.words[i] - newCarry) << r;
+	      this.words[i] = c | carry;
+	      carry = newCarry >>> (26 - r);
+	    }
+	    if (carry) {
+	      this.words[i] = carry;
+	      this.length++;
+	    }
+	  }
+
+	  if (s !== 0) {
+	    for (var i = this.length - 1; i >= 0; i--)
+	      this.words[i + s] = this.words[i];
+	    for (var i = 0; i < s; i++)
+	      this.words[i] = 0;
+	    this.length += s;
+	  }
+
+	  return this.strip();
+	};
+
+	// Shift-right in-place
+	// NOTE: `hint` is a lowest bit before trailing zeroes
+	// NOTE: if `extended` is present - it will be filled with destroyed bits
+	BN.prototype.ishrn = function ishrn(bits, hint, extended) {
+	  assert(typeof bits === 'number' && bits >= 0);
+	  var h;
+	  if (hint)
+	    h = (hint - (hint % 26)) / 26;
+	  else
+	    h = 0;
+
+	  var r = bits % 26;
+	  var s = Math.min((bits - r) / 26, this.length);
+	  var mask = 0x3ffffff ^ ((0x3ffffff >>> r) << r);
+	  var maskedWords = extended;
+
+	  h -= s;
+	  h = Math.max(0, h);
+
+	  // Extended mode, copy masked part
+	  if (maskedWords) {
+	    for (var i = 0; i < s; i++)
+	      maskedWords.words[i] = this.words[i];
+	    maskedWords.length = s;
+	  }
+
+	  if (s === 0) {
+	    // No-op, we should not move anything at all
+	  } else if (this.length > s) {
+	    this.length -= s;
+	    for (var i = 0; i < this.length; i++)
+	      this.words[i] = this.words[i + s];
+	  } else {
+	    this.words[0] = 0;
+	    this.length = 1;
+	  }
+
+	  var carry = 0;
+	  for (var i = this.length - 1; i >= 0 && (carry !== 0 || i >= h); i--) {
+	    var word = this.words[i];
+	    this.words[i] = (carry << (26 - r)) | (word >>> r);
+	    carry = word & mask;
+	  }
+
+	  // Push carried bits as a mask
+	  if (maskedWords && carry !== 0)
+	    maskedWords.words[maskedWords.length++] = carry;
+
+	  if (this.length === 0) {
+	    this.words[0] = 0;
+	    this.length = 1;
+	  }
+
+	  this.strip();
+
+	  return this;
+	};
+
+	// Shift-left
+	BN.prototype.shln = function shln(bits) {
+	  return this.clone().ishln(bits);
+	};
+
+	// Shift-right
+	BN.prototype.shrn = function shrn(bits) {
+	  return this.clone().ishrn(bits);
+	};
+
+	// Test if n bit is set
+	BN.prototype.testn = function testn(bit) {
+	  assert(typeof bit === 'number' && bit >= 0);
+	  var r = bit % 26;
+	  var s = (bit - r) / 26;
+	  var q = 1 << r;
+
+	  // Fast case: bit is much higher than all existing words
+	  if (this.length <= s) {
+	    return false;
+	  }
+
+	  // Check bit and return
+	  var w = this.words[s];
+
+	  return !!(w & q);
+	};
+
+	// Return only lowers bits of number (in-place)
+	BN.prototype.imaskn = function imaskn(bits) {
+	  assert(typeof bits === 'number' && bits >= 0);
+	  var r = bits % 26;
+	  var s = (bits - r) / 26;
+
+	  assert(!this.sign, 'imaskn works only with positive numbers');
+
+	  if (r !== 0)
+	    s++;
+	  this.length = Math.min(s, this.length);
+
+	  if (r !== 0) {
+	    var mask = 0x3ffffff ^ ((0x3ffffff >>> r) << r);
+	    this.words[this.length - 1] &= mask;
+	  }
+
+	  return this.strip();
+	};
+
+	// Return only lowers bits of number
+	BN.prototype.maskn = function maskn(bits) {
+	  return this.clone().imaskn(bits);
+	};
+
+	// Add plain number `num` to `this`
+	BN.prototype.iaddn = function iaddn(num) {
+	  assert(typeof num === 'number');
+	  if (num < 0)
+	    return this.isubn(-num);
+
+	  // Possible sign change
+	  if (this.sign) {
+	    if (this.length === 1 && this.words[0] < num) {
+	      this.words[0] = num - this.words[0];
+	      this.sign = false;
+	      return this;
+	    }
+
+	    this.sign = false;
+	    this.isubn(num);
+	    this.sign = true;
+	    return this;
+	  }
+
+	  // Add without checks
+	  return this._iaddn(num);
+	};
+
+	BN.prototype._iaddn = function _iaddn(num) {
+	  this.words[0] += num;
+
+	  // Carry
+	  for (var i = 0; i < this.length && this.words[i] >= 0x4000000; i++) {
+	    this.words[i] -= 0x4000000;
+	    if (i === this.length - 1)
+	      this.words[i + 1] = 1;
+	    else
+	      this.words[i + 1]++;
+	  }
+	  this.length = Math.max(this.length, i + 1);
+
+	  return this;
+	};
+
+	// Subtract plain number `num` from `this`
+	BN.prototype.isubn = function isubn(num) {
+	  assert(typeof num === 'number');
+	  if (num < 0)
+	    return this.iaddn(-num);
+
+	  if (this.sign) {
+	    this.sign = false;
+	    this.iaddn(num);
+	    this.sign = true;
+	    return this;
+	  }
+
+	  this.words[0] -= num;
+
+	  // Carry
+	  for (var i = 0; i < this.length && this.words[i] < 0; i++) {
+	    this.words[i] += 0x4000000;
+	    this.words[i + 1] -= 1;
+	  }
+
+	  return this.strip();
+	};
+
+	BN.prototype.addn = function addn(num) {
+	  return this.clone().iaddn(num);
+	};
+
+	BN.prototype.subn = function subn(num) {
+	  return this.clone().isubn(num);
+	};
+
+	BN.prototype.iabs = function iabs() {
+	  this.sign = false;
+
+	  return this;
+	};
+
+	BN.prototype.abs = function abs() {
+	  return this.clone().iabs();
+	};
+
+	BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
+	  // Bigger storage is needed
+	  var len = num.length + shift;
+	  var i;
+	  if (this.words.length < len) {
+	    var t = new Array(len);
+	    for (var i = 0; i < this.length; i++)
+	      t[i] = this.words[i];
+	    this.words = t;
+	  } else {
+	    i = this.length;
+	  }
+
+	  // Zeroify rest
+	  this.length = Math.max(this.length, len);
+	  for (; i < this.length; i++)
+	    this.words[i] = 0;
+
+	  var carry = 0;
+	  for (var i = 0; i < num.length; i++) {
+	    var w = this.words[i + shift] + carry;
+	    var right = num.words[i] * mul;
+	    w -= right & 0x3ffffff;
+	    carry = (w >> 26) - ((right / 0x4000000) | 0);
+	    this.words[i + shift] = w & 0x3ffffff;
+	  }
+	  for (; i < this.length - shift; i++) {
+	    var w = this.words[i + shift] + carry;
+	    carry = w >> 26;
+	    this.words[i + shift] = w & 0x3ffffff;
+	  }
+
+	  if (carry === 0)
+	    return this.strip();
+
+	  // Subtraction overflow
+	  assert(carry === -1);
+	  carry = 0;
+	  for (var i = 0; i < this.length; i++) {
+	    var w = -this.words[i] + carry;
+	    carry = w >> 26;
+	    this.words[i] = w & 0x3ffffff;
+	  }
+	  this.sign = true;
+
+	  return this.strip();
+	};
+
+	BN.prototype._wordDiv = function _wordDiv(num, mode) {
+	  var shift = this.length - num.length;
+
+	  var a = this.clone();
+	  var b = num;
+
+	  // Normalize
+	  var bhi = b.words[b.length - 1];
+	  var bhiBits = this._countBits(bhi);
+	  shift = 26 - bhiBits;
+	  if (shift !== 0) {
+	    b = b.shln(shift);
+	    a.ishln(shift);
+	    bhi = b.words[b.length - 1];
+	  }
+
+	  // Initialize quotient
+	  var m = a.length - b.length;
+	  var q;
+
+	  if (mode !== 'mod') {
+	    q = new BN(null);
+	    q.length = m + 1;
+	    q.words = new Array(q.length);
+	    for (var i = 0; i < q.length; i++)
+	      q.words[i] = 0;
+	  }
+
+	  var diff = a.clone()._ishlnsubmul(b, 1, m);
+	  if (!diff.sign) {
+	    a = diff;
+	    if (q)
+	      q.words[m] = 1;
+	  }
+
+	  for (var j = m - 1; j >= 0; j--) {
+	    var qj = a.words[b.length + j] * 0x4000000 + a.words[b.length + j - 1];
+
+	    // NOTE: (qj / bhi) is (0x3ffffff * 0x4000000 + 0x3ffffff) / 0x2000000 max
+	    // (0x7ffffff)
+	    qj = Math.min((qj / bhi) | 0, 0x3ffffff);
+
+	    a._ishlnsubmul(b, qj, j);
+	    while (a.sign) {
+	      qj--;
+	      a.sign = false;
+	      a._ishlnsubmul(b, 1, j);
+	      if (a.cmpn(0) !== 0)
+	        a.sign = !a.sign;
+	    }
+	    if (q)
+	      q.words[j] = qj;
+	  }
+	  if (q)
+	    q.strip();
+	  a.strip();
+
+	  // Denormalize
+	  if (mode !== 'div' && shift !== 0)
+	    a.ishrn(shift);
+	  return { div: q ? q : null, mod: a };
+	};
+
+	BN.prototype.divmod = function divmod(num, mode) {
+	  assert(num.cmpn(0) !== 0);
+
+	  if (this.sign && !num.sign) {
+	    var res = this.neg().divmod(num, mode);
+	    var div;
+	    var mod;
+	    if (mode !== 'mod')
+	      div = res.div.neg();
+	    if (mode !== 'div')
+	      mod = res.mod.cmpn(0) === 0 ? res.mod : num.sub(res.mod);
+	    return {
+	      div: div,
+	      mod: mod
+	    };
+	  } else if (!this.sign && num.sign) {
+	    var res = this.divmod(num.neg(), mode);
+	    var div;
+	    if (mode !== 'mod')
+	      div = res.div.neg();
+	    return { div: div, mod: res.mod };
+	  } else if (this.sign && num.sign) {
+	    return this.neg().divmod(num.neg(), mode);
+	  }
+
+	  // Both numbers are positive at this point
+
+	  // Strip both numbers to approximate shift value
+	  if (num.length > this.length || this.cmp(num) < 0)
+	    return { div: new BN(0), mod: this };
+
+	  // Very short reduction
+	  if (num.length === 1) {
+	    if (mode === 'div')
+	      return { div: this.divn(num.words[0]), mod: null };
+	    else if (mode === 'mod')
+	      return { div: null, mod: new BN(this.modn(num.words[0])) };
+	    return {
+	      div: this.divn(num.words[0]),
+	      mod: new BN(this.modn(num.words[0]))
+	    };
+	  }
+
+	  return this._wordDiv(num, mode);
+	};
+
+	// Find `this` / `num`
+	BN.prototype.div = function div(num) {
+	  return this.divmod(num, 'div').div;
+	};
+
+	// Find `this` % `num`
+	BN.prototype.mod = function mod(num) {
+	  return this.divmod(num, 'mod').mod;
+	};
+
+	// Find Round(`this` / `num`)
+	BN.prototype.divRound = function divRound(num) {
+	  var dm = this.divmod(num);
+
+	  // Fast case - exact division
+	  if (dm.mod.cmpn(0) === 0)
+	    return dm.div;
+
+	  var mod = dm.div.sign ? dm.mod.isub(num) : dm.mod;
+
+	  var half = num.shrn(1);
+	  var r2 = num.andln(1);
+	  var cmp = mod.cmp(half);
+
+	  // Round down
+	  if (cmp < 0 || r2 === 1 && cmp === 0)
+	    return dm.div;
+
+	  // Round up
+	  return dm.div.sign ? dm.div.isubn(1) : dm.div.iaddn(1);
+	};
+
+	BN.prototype.modn = function modn(num) {
+	  assert(num <= 0x3ffffff);
+	  var p = (1 << 26) % num;
+
+	  var acc = 0;
+	  for (var i = this.length - 1; i >= 0; i--)
+	    acc = (p * acc + this.words[i]) % num;
+
+	  return acc;
+	};
+
+	// In-place division by number
+	BN.prototype.idivn = function idivn(num) {
+	  assert(num <= 0x3ffffff);
+
+	  var carry = 0;
+	  for (var i = this.length - 1; i >= 0; i--) {
+	    var w = this.words[i] + carry * 0x4000000;
+	    this.words[i] = (w / num) | 0;
+	    carry = w % num;
+	  }
+
+	  return this.strip();
+	};
+
+	BN.prototype.divn = function divn(num) {
+	  return this.clone().idivn(num);
+	};
+
+	BN.prototype.egcd = function egcd(p) {
+	  assert(!p.sign);
+	  assert(p.cmpn(0) !== 0);
+
+	  var x = this;
+	  var y = p.clone();
+
+	  if (x.sign)
+	    x = x.mod(p);
+	  else
+	    x = x.clone();
+
+	  // A * x + B * y = x
+	  var A = new BN(1);
+	  var B = new BN(0);
+
+	  // C * x + D * y = y
+	  var C = new BN(0);
+	  var D = new BN(1);
+
+	  var g = 0;
+
+	  while (x.isEven() && y.isEven()) {
+	    x.ishrn(1);
+	    y.ishrn(1);
+	    ++g;
+	  }
+
+	  var yp = y.clone();
+	  var xp = x.clone();
+
+	  while (x.cmpn(0) !== 0) {
+	    while (x.isEven()) {
+	      x.ishrn(1);
+	      if (A.isEven() && B.isEven()) {
+	        A.ishrn(1);
+	        B.ishrn(1);
+	      } else {
+	        A.iadd(yp).ishrn(1);
+	        B.isub(xp).ishrn(1);
+	      }
+	    }
+
+	    while (y.isEven()) {
+	      y.ishrn(1);
+	      if (C.isEven() && D.isEven()) {
+	        C.ishrn(1);
+	        D.ishrn(1);
+	      } else {
+	        C.iadd(yp).ishrn(1);
+	        D.isub(xp).ishrn(1);
+	      }
+	    }
+
+	    if (x.cmp(y) >= 0) {
+	      x.isub(y);
+	      A.isub(C);
+	      B.isub(D);
+	    } else {
+	      y.isub(x);
+	      C.isub(A);
+	      D.isub(B);
+	    }
+	  }
+
+	  return {
+	    a: C,
+	    b: D,
+	    gcd: y.ishln(g)
+	  };
+	};
+
+	// This is reduced incarnation of the binary EEA
+	// above, designated to invert members of the
+	// _prime_ fields F(p) at a maximal speed
+	BN.prototype._invmp = function _invmp(p) {
+	  assert(!p.sign);
+	  assert(p.cmpn(0) !== 0);
+
+	  var a = this;
+	  var b = p.clone();
+
+	  if (a.sign)
+	    a = a.mod(p);
+	  else
+	    a = a.clone();
+
+	  var x1 = new BN(1);
+	  var x2 = new BN(0);
+
+	  var delta = b.clone();
+
+	  while (a.cmpn(1) > 0 && b.cmpn(1) > 0) {
+	    while (a.isEven()) {
+	      a.ishrn(1);
+	      if (x1.isEven())
+	        x1.ishrn(1);
+	      else
+	        x1.iadd(delta).ishrn(1);
+	    }
+	    while (b.isEven()) {
+	      b.ishrn(1);
+	      if (x2.isEven())
+	        x2.ishrn(1);
+	      else
+	        x2.iadd(delta).ishrn(1);
+	    }
+	    if (a.cmp(b) >= 0) {
+	      a.isub(b);
+	      x1.isub(x2);
+	    } else {
+	      b.isub(a);
+	      x2.isub(x1);
+	    }
+	  }
+	  if (a.cmpn(1) === 0)
+	    return x1;
+	  else
+	    return x2;
+	};
+
+	BN.prototype.gcd = function gcd(num) {
+	  if (this.cmpn(0) === 0)
+	    return num.clone();
+	  if (num.cmpn(0) === 0)
+	    return this.clone();
+
+	  var a = this.clone();
+	  var b = num.clone();
+	  a.sign = false;
+	  b.sign = false;
+
+	  // Remove common factor of two
+	  for (var shift = 0; a.isEven() && b.isEven(); shift++) {
+	    a.ishrn(1);
+	    b.ishrn(1);
+	  }
+
+	  do {
+	    while (a.isEven())
+	      a.ishrn(1);
+	    while (b.isEven())
+	      b.ishrn(1);
+
+	    var r = a.cmp(b);
+	    if (r < 0) {
+	      // Swap `a` and `b` to make `a` always bigger than `b`
+	      var t = a;
+	      a = b;
+	      b = t;
+	    } else if (r === 0 || b.cmpn(1) === 0) {
+	      break;
+	    }
+
+	    a.isub(b);
+	  } while (true);
+
+	  return b.ishln(shift);
+	};
+
+	// Invert number in the field F(num)
+	BN.prototype.invm = function invm(num) {
+	  return this.egcd(num).a.mod(num);
+	};
+
+	BN.prototype.isEven = function isEven() {
+	  return (this.words[0] & 1) === 0;
+	};
+
+	BN.prototype.isOdd = function isOdd() {
+	  return (this.words[0] & 1) === 1;
+	};
+
+	// And first word and num
+	BN.prototype.andln = function andln(num) {
+	  return this.words[0] & num;
+	};
+
+	// Increment at the bit position in-line
+	BN.prototype.bincn = function bincn(bit) {
+	  assert(typeof bit === 'number');
+	  var r = bit % 26;
+	  var s = (bit - r) / 26;
+	  var q = 1 << r;
+
+	  // Fast case: bit is much higher than all existing words
+	  if (this.length <= s) {
+	    for (var i = this.length; i < s + 1; i++)
+	      this.words[i] = 0;
+	    this.words[s] |= q;
+	    this.length = s + 1;
+	    return this;
+	  }
+
+	  // Add bit and propagate, if needed
+	  var carry = q;
+	  for (var i = s; carry !== 0 && i < this.length; i++) {
+	    var w = this.words[i];
+	    w += carry;
+	    carry = w >>> 26;
+	    w &= 0x3ffffff;
+	    this.words[i] = w;
+	  }
+	  if (carry !== 0) {
+	    this.words[i] = carry;
+	    this.length++;
+	  }
+	  return this;
+	};
+
+	BN.prototype.cmpn = function cmpn(num) {
+	  var sign = num < 0;
+	  if (sign)
+	    num = -num;
+
+	  if (this.sign && !sign)
+	    return -1;
+	  else if (!this.sign && sign)
+	    return 1;
+
+	  num &= 0x3ffffff;
+	  this.strip();
+
+	  var res;
+	  if (this.length > 1) {
+	    res = 1;
+	  } else {
+	    var w = this.words[0];
+	    res = w === num ? 0 : w < num ? -1 : 1;
+	  }
+	  if (this.sign)
+	    res = -res;
+	  return res;
+	};
+
+	// Compare two numbers and return:
+	// 1 - if `this` > `num`
+	// 0 - if `this` == `num`
+	// -1 - if `this` < `num`
+	BN.prototype.cmp = function cmp(num) {
+	  if (this.sign && !num.sign)
+	    return -1;
+	  else if (!this.sign && num.sign)
+	    return 1;
+
+	  var res = this.ucmp(num);
+	  if (this.sign)
+	    return -res;
+	  else
+	    return res;
+	};
+
+	// Unsigned comparison
+	BN.prototype.ucmp = function ucmp(num) {
+	  // At this point both numbers have the same sign
+	  if (this.length > num.length)
+	    return 1;
+	  else if (this.length < num.length)
+	    return -1;
+
+	  var res = 0;
+	  for (var i = this.length - 1; i >= 0; i--) {
+	    var a = this.words[i];
+	    var b = num.words[i];
+
+	    if (a === b)
+	      continue;
+	    if (a < b)
+	      res = -1;
+	    else if (a > b)
+	      res = 1;
+	    break;
+	  }
+	  return res;
+	};
+
+	//
+	// A reduce context, could be using montgomery or something better, depending
+	// on the `m` itself.
+	//
+	BN.red = function red(num) {
+	  return new Red(num);
+	};
+
+	BN.prototype.toRed = function toRed(ctx) {
+	  assert(!this.red, 'Already a number in reduction context');
+	  assert(!this.sign, 'red works only with positives');
+	  return ctx.convertTo(this)._forceRed(ctx);
+	};
+
+	BN.prototype.fromRed = function fromRed() {
+	  assert(this.red, 'fromRed works only with numbers in reduction context');
+	  return this.red.convertFrom(this);
+	};
+
+	BN.prototype._forceRed = function _forceRed(ctx) {
+	  this.red = ctx;
+	  return this;
+	};
+
+	BN.prototype.forceRed = function forceRed(ctx) {
+	  assert(!this.red, 'Already a number in reduction context');
+	  return this._forceRed(ctx);
+	};
+
+	BN.prototype.redAdd = function redAdd(num) {
+	  assert(this.red, 'redAdd works only with red numbers');
+	  return this.red.add(this, num);
+	};
+
+	BN.prototype.redIAdd = function redIAdd(num) {
+	  assert(this.red, 'redIAdd works only with red numbers');
+	  return this.red.iadd(this, num);
+	};
+
+	BN.prototype.redSub = function redSub(num) {
+	  assert(this.red, 'redSub works only with red numbers');
+	  return this.red.sub(this, num);
+	};
+
+	BN.prototype.redISub = function redISub(num) {
+	  assert(this.red, 'redISub works only with red numbers');
+	  return this.red.isub(this, num);
+	};
+
+	BN.prototype.redShl = function redShl(num) {
+	  assert(this.red, 'redShl works only with red numbers');
+	  return this.red.shl(this, num);
+	};
+
+	BN.prototype.redMul = function redMul(num) {
+	  assert(this.red, 'redMul works only with red numbers');
+	  this.red._verify2(this, num);
+	  return this.red.mul(this, num);
+	};
+
+	BN.prototype.redIMul = function redIMul(num) {
+	  assert(this.red, 'redMul works only with red numbers');
+	  this.red._verify2(this, num);
+	  return this.red.imul(this, num);
+	};
+
+	BN.prototype.redSqr = function redSqr() {
+	  assert(this.red, 'redSqr works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.sqr(this);
+	};
+
+	BN.prototype.redISqr = function redISqr() {
+	  assert(this.red, 'redISqr works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.isqr(this);
+	};
+
+	// Square root over p
+	BN.prototype.redSqrt = function redSqrt() {
+	  assert(this.red, 'redSqrt works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.sqrt(this);
+	};
+
+	BN.prototype.redInvm = function redInvm() {
+	  assert(this.red, 'redInvm works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.invm(this);
+	};
+
+	// Return negative clone of `this` % `red modulo`
+	BN.prototype.redNeg = function redNeg() {
+	  assert(this.red, 'redNeg works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.neg(this);
+	};
+
+	BN.prototype.redPow = function redPow(num) {
+	  assert(this.red && !num.red, 'redPow(normalNum)');
+	  this.red._verify1(this);
+	  return this.red.pow(this, num);
+	};
+
+	// Prime numbers with efficient reduction
+	var primes = {
+	  k256: null,
+	  p224: null,
+	  p192: null,
+	  p25519: null
+	};
+
+	// Pseudo-Mersenne prime
+	function MPrime(name, p) {
+	  // P = 2 ^ N - K
+	  this.name = name;
+	  this.p = new BN(p, 16);
+	  this.n = this.p.bitLength();
+	  this.k = new BN(1).ishln(this.n).isub(this.p);
+
+	  this.tmp = this._tmp();
+	}
+
+	MPrime.prototype._tmp = function _tmp() {
+	  var tmp = new BN(null);
+	  tmp.words = new Array(Math.ceil(this.n / 13));
+	  return tmp;
+	};
+
+	MPrime.prototype.ireduce = function ireduce(num) {
+	  // Assumes that `num` is less than `P^2`
+	  // num = HI * (2 ^ N - K) + HI * K + LO = HI * K + LO (mod P)
+	  var r = num;
+	  var rlen;
+
+	  do {
+	    this.split(r, this.tmp);
+	    r = this.imulK(r);
+	    r = r.iadd(this.tmp);
+	    rlen = r.bitLength();
+	  } while (rlen > this.n);
+
+	  var cmp = rlen < this.n ? -1 : r.ucmp(this.p);
+	  if (cmp === 0) {
+	    r.words[0] = 0;
+	    r.length = 1;
+	  } else if (cmp > 0) {
+	    r.isub(this.p);
+	  } else {
+	    r.strip();
+	  }
+
+	  return r;
+	};
+
+	MPrime.prototype.split = function split(input, out) {
+	  input.ishrn(this.n, 0, out);
+	};
+
+	MPrime.prototype.imulK = function imulK(num) {
+	  return num.imul(this.k);
+	};
+
+	function K256() {
+	  MPrime.call(
+	    this,
+	    'k256',
+	    'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f');
+	}
+	inherits(K256, MPrime);
+
+	K256.prototype.split = function split(input, output) {
+	  // 256 = 9 * 26 + 22
+	  var mask = 0x3fffff;
+
+	  var outLen = Math.min(input.length, 9);
+	  for (var i = 0; i < outLen; i++)
+	    output.words[i] = input.words[i];
+	  output.length = outLen;
+
+	  if (input.length <= 9) {
+	    input.words[0] = 0;
+	    input.length = 1;
+	    return;
+	  }
+
+	  // Shift by 9 limbs
+	  var prev = input.words[9];
+	  output.words[output.length++] = prev & mask;
+
+	  for (var i = 10; i < input.length; i++) {
+	    var next = input.words[i];
+	    input.words[i - 10] = ((next & mask) << 4) | (prev >>> 22);
+	    prev = next;
+	  }
+	  input.words[i - 10] = prev >>> 22;
+	  input.length -= 9;
+	};
+
+	K256.prototype.imulK = function imulK(num) {
+	  // K = 0x1000003d1 = [ 0x40, 0x3d1 ]
+	  num.words[num.length] = 0;
+	  num.words[num.length + 1] = 0;
+	  num.length += 2;
+
+	  // bounded at: 0x40 * 0x3ffffff + 0x3d0 = 0x100000390
+	  var hi;
+	  var lo = 0;
+	  for (var i = 0; i < num.length; i++) {
+	    var w = num.words[i];
+	    hi = w * 0x40;
+	    lo += w * 0x3d1;
+	    hi += (lo / 0x4000000) | 0;
+	    lo &= 0x3ffffff;
+
+	    num.words[i] = lo;
+
+	    lo = hi;
+	  }
+
+	  // Fast length reduction
+	  if (num.words[num.length - 1] === 0) {
+	    num.length--;
+	    if (num.words[num.length - 1] === 0)
+	      num.length--;
+	  }
+	  return num;
+	};
+
+	function P224() {
+	  MPrime.call(
+	    this,
+	    'p224',
+	    'ffffffff ffffffff ffffffff ffffffff 00000000 00000000 00000001');
+	}
+	inherits(P224, MPrime);
+
+	function P192() {
+	  MPrime.call(
+	    this,
+	    'p192',
+	    'ffffffff ffffffff ffffffff fffffffe ffffffff ffffffff');
+	}
+	inherits(P192, MPrime);
+
+	function P25519() {
+	  // 2 ^ 255 - 19
+	  MPrime.call(
+	    this,
+	    '25519',
+	    '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed');
+	}
+	inherits(P25519, MPrime);
+
+	P25519.prototype.imulK = function imulK(num) {
+	  // K = 0x13
+	  var carry = 0;
+	  for (var i = 0; i < num.length; i++) {
+	    var hi = num.words[i] * 0x13 + carry;
+	    var lo = hi & 0x3ffffff;
+	    hi >>>= 26;
+
+	    num.words[i] = lo;
+	    carry = hi;
+	  }
+	  if (carry !== 0)
+	    num.words[num.length++] = carry;
+	  return num;
+	};
+
+	// Exported mostly for testing purposes, use plain name instead
+	BN._prime = function prime(name) {
+	  // Cached version of prime
+	  if (primes[name])
+	    return primes[name];
+
+	  var prime;
+	  if (name === 'k256')
+	    prime = new K256();
+	  else if (name === 'p224')
+	    prime = new P224();
+	  else if (name === 'p192')
+	    prime = new P192();
+	  else if (name === 'p25519')
+	    prime = new P25519();
+	  else
+	    throw new Error('Unknown prime ' + name);
+	  primes[name] = prime;
+
+	  return prime;
+	};
+
+	//
+	// Base reduction engine
+	//
+	function Red(m) {
+	  if (typeof m === 'string') {
+	    var prime = BN._prime(m);
+	    this.m = prime.p;
+	    this.prime = prime;
+	  } else {
+	    this.m = m;
+	    this.prime = null;
+	  }
+	}
+
+	Red.prototype._verify1 = function _verify1(a) {
+	  assert(!a.sign, 'red works only with positives');
+	  assert(a.red, 'red works only with red numbers');
+	};
+
+	Red.prototype._verify2 = function _verify2(a, b) {
+	  assert(!a.sign && !b.sign, 'red works only with positives');
+	  assert(a.red && a.red === b.red,
+	         'red works only with red numbers');
+	};
+
+	Red.prototype.imod = function imod(a) {
+	  if (this.prime)
+	    return this.prime.ireduce(a)._forceRed(this);
+	  return a.mod(this.m)._forceRed(this);
+	};
+
+	Red.prototype.neg = function neg(a) {
+	  var r = a.clone();
+	  r.sign = !r.sign;
+	  return r.iadd(this.m)._forceRed(this);
+	};
+
+	Red.prototype.add = function add(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.add(b);
+	  if (res.cmp(this.m) >= 0)
+	    res.isub(this.m);
+	  return res._forceRed(this);
+	};
+
+	Red.prototype.iadd = function iadd(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.iadd(b);
+	  if (res.cmp(this.m) >= 0)
+	    res.isub(this.m);
+	  return res;
+	};
+
+	Red.prototype.sub = function sub(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.sub(b);
+	  if (res.cmpn(0) < 0)
+	    res.iadd(this.m);
+	  return res._forceRed(this);
+	};
+
+	Red.prototype.isub = function isub(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.isub(b);
+	  if (res.cmpn(0) < 0)
+	    res.iadd(this.m);
+	  return res;
+	};
+
+	Red.prototype.shl = function shl(a, num) {
+	  this._verify1(a);
+	  return this.imod(a.shln(num));
+	};
+
+	Red.prototype.imul = function imul(a, b) {
+	  this._verify2(a, b);
+	  return this.imod(a.imul(b));
+	};
+
+	Red.prototype.mul = function mul(a, b) {
+	  this._verify2(a, b);
+	  return this.imod(a.mul(b));
+	};
+
+	Red.prototype.isqr = function isqr(a) {
+	  return this.imul(a, a);
+	};
+
+	Red.prototype.sqr = function sqr(a) {
+	  return this.mul(a, a);
+	};
+
+	Red.prototype.sqrt = function sqrt(a) {
+	  if (a.cmpn(0) === 0)
+	    return a.clone();
+
+	  var mod3 = this.m.andln(3);
+	  assert(mod3 % 2 === 1);
+
+	  // Fast case
+	  if (mod3 === 3) {
+	    var pow = this.m.add(new BN(1)).ishrn(2);
+	    var r = this.pow(a, pow);
+	    return r;
+	  }
+
+	  // Tonelli-Shanks algorithm (Totally unoptimized and slow)
+	  //
+	  // Find Q and S, that Q * 2 ^ S = (P - 1)
+	  var q = this.m.subn(1);
+	  var s = 0;
+	  while (q.cmpn(0) !== 0 && q.andln(1) === 0) {
+	    s++;
+	    q.ishrn(1);
+	  }
+	  assert(q.cmpn(0) !== 0);
+
+	  var one = new BN(1).toRed(this);
+	  var nOne = one.redNeg();
+
+	  // Find quadratic non-residue
+	  // NOTE: Max is such because of generalized Riemann hypothesis.
+	  var lpow = this.m.subn(1).ishrn(1);
+	  var z = this.m.bitLength();
+	  z = new BN(2 * z * z).toRed(this);
+	  while (this.pow(z, lpow).cmp(nOne) !== 0)
+	    z.redIAdd(nOne);
+
+	  var c = this.pow(z, q);
+	  var r = this.pow(a, q.addn(1).ishrn(1));
+	  var t = this.pow(a, q);
+	  var m = s;
+	  while (t.cmp(one) !== 0) {
+	    var tmp = t;
+	    for (var i = 0; tmp.cmp(one) !== 0; i++)
+	      tmp = tmp.redSqr();
+	    assert(i < m);
+	    var b = this.pow(c, new BN(1).ishln(m - i - 1));
+
+	    r = r.redMul(b);
+	    c = b.redSqr();
+	    t = t.redMul(c);
+	    m = i;
+	  }
+
+	  return r;
+	};
+
+	Red.prototype.invm = function invm(a) {
+	  var inv = a._invmp(this.m);
+	  if (inv.sign) {
+	    inv.sign = false;
+	    return this.imod(inv).redNeg();
+	  } else {
+	    return this.imod(inv);
+	  }
+	};
+
+	Red.prototype.pow = function pow(a, num) {
+	  var w = [];
+
+	  if (num.cmpn(0) === 0)
+	    return new BN(1);
+
+	  var q = num.clone();
+
+	  while (q.cmpn(0) !== 0) {
+	    w.push(q.andln(1));
+	    q.ishrn(1);
+	  }
+
+	  // Skip leading zeroes
+	  var res = a;
+	  for (var i = 0; i < w.length; i++, res = this.sqr(res))
+	    if (w[i] !== 0)
+	      break;
+
+	  if (++i < w.length) {
+	    for (var q = this.sqr(res); i < w.length; i++, q = this.sqr(q)) {
+	      if (w[i] === 0)
+	        continue;
+	      res = this.mul(res, q);
+	    }
+	  }
+
+	  return res;
+	};
+
+	Red.prototype.convertTo = function convertTo(num) {
+	  var r = num.mod(this.m);
+	  if (r === num)
+	    return r.clone();
+	  else
+	    return r;
+	};
+
+	Red.prototype.convertFrom = function convertFrom(num) {
+	  var res = num.clone();
+	  res.red = null;
+	  return res;
+	};
+
+	//
+	// Montgomery method engine
+	//
+
+	BN.mont = function mont(num) {
+	  return new Mont(num);
+	};
+
+	function Mont(m) {
+	  Red.call(this, m);
+
+	  this.shift = this.m.bitLength();
+	  if (this.shift % 26 !== 0)
+	    this.shift += 26 - (this.shift % 26);
+	  this.r = new BN(1).ishln(this.shift);
+	  this.r2 = this.imod(this.r.sqr());
+	  this.rinv = this.r._invmp(this.m);
+
+	  this.minv = this.rinv.mul(this.r).isubn(1).div(this.m);
+	  this.minv.sign = true;
+	  this.minv = this.minv.mod(this.r);
+	}
+	inherits(Mont, Red);
+
+	Mont.prototype.convertTo = function convertTo(num) {
+	  return this.imod(num.shln(this.shift));
+	};
+
+	Mont.prototype.convertFrom = function convertFrom(num) {
+	  var r = this.imod(num.mul(this.rinv));
+	  r.red = null;
+	  return r;
+	};
+
+	Mont.prototype.imul = function imul(a, b) {
+	  if (a.cmpn(0) === 0 || b.cmpn(0) === 0) {
+	    a.words[0] = 0;
+	    a.length = 1;
+	    return a;
+	  }
+
+	  var t = a.imul(b);
+	  var c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m);
+	  var u = t.isub(c).ishrn(this.shift);
+	  var res = u;
+	  if (u.cmp(this.m) >= 0)
+	    res = u.isub(this.m);
+	  else if (u.cmpn(0) < 0)
+	    res = u.iadd(this.m);
+
+	  return res._forceRed(this);
+	};
+
+	Mont.prototype.mul = function mul(a, b) {
+	  if (a.cmpn(0) === 0 || b.cmpn(0) === 0)
+	    return new BN(0)._forceRed(this);
+
+	  var t = a.mul(b);
+	  var c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m);
+	  var u = t.isub(c).ishrn(this.shift);
+	  var res = u;
+	  if (u.cmp(this.m) >= 0)
+	    res = u.isub(this.m);
+	  else if (u.cmpn(0) < 0)
+	    res = u.iadd(this.m);
+
+	  return res._forceRed(this);
+	};
+
+	Mont.prototype.invm = function invm(a) {
+	  // (AR)^-1 * R^2 = (A^-1 * R^-1) * R^2 = A^-1 * R
+	  var res = this.imod(a._invmp(this.m).mul(this.r2));
+	  return res._forceRed(this);
+	};
+
+	})(typeof module === 'undefined' || module, this);
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(18)(module)))
+
+/***/ }),
+/* 104 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var asn1 = __webpack_require__(102);
+	var inherits = __webpack_require__(27);
+
+	var api = exports;
+
+	api.define = function define(name, body) {
+	  return new Entity(name, body);
+	};
+
+	function Entity(name, body) {
+	  this.name = name;
+	  this.body = body;
+
+	  this.decoders = {};
+	  this.encoders = {};
+	};
+
+	Entity.prototype._createNamed = function createNamed(base) {
+	  var named;
+	  try {
+	    named = __webpack_require__(105).runInThisContext(
+	      '(function ' + this.name + '(entity) {\n' +
+	      '  this._initNamed(entity);\n' +
+	      '})'
+	    );
+	  } catch (e) {
+	    named = function (entity) {
+	      this._initNamed(entity);
+	    };
+	  }
+	  inherits(named, base);
+	  named.prototype._initNamed = function initnamed(entity) {
+	    base.call(this, entity);
+	  };
+
+	  return new named(this);
+	};
+
+	Entity.prototype._getDecoder = function _getDecoder(enc) {
+	  // Lazily create decoder
+	  if (!this.decoders.hasOwnProperty(enc))
+	    this.decoders[enc] = this._createNamed(asn1.decoders[enc]);
+	  return this.decoders[enc];
+	};
+
+	Entity.prototype.decode = function decode(data, enc, options) {
+	  return this._getDecoder(enc).decode(data, options);
+	};
+
+	Entity.prototype._getEncoder = function _getEncoder(enc) {
+	  // Lazily create encoder
+	  if (!this.encoders.hasOwnProperty(enc))
+	    this.encoders[enc] = this._createNamed(asn1.encoders[enc]);
+	  return this.encoders[enc];
+	};
+
+	Entity.prototype.encode = function encode(data, enc, /* internal */ reporter) {
+	  return this._getEncoder(enc).encode(data, reporter);
+	};
+
+
+/***/ }),
+/* 105 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var indexOf = __webpack_require__(106);
+
+	var Object_keys = function (obj) {
+	    if (Object.keys) return Object.keys(obj)
+	    else {
+	        var res = [];
+	        for (var key in obj) res.push(key)
+	        return res;
+	    }
+	};
+
+	var forEach = function (xs, fn) {
+	    if (xs.forEach) return xs.forEach(fn)
+	    else for (var i = 0; i < xs.length; i++) {
+	        fn(xs[i], i, xs);
+	    }
+	};
+
+	var defineProp = (function() {
+	    try {
+	        Object.defineProperty({}, '_', {});
+	        return function(obj, name, value) {
+	            Object.defineProperty(obj, name, {
+	                writable: true,
+	                enumerable: false,
+	                configurable: true,
+	                value: value
+	            })
+	        };
+	    } catch(e) {
+	        return function(obj, name, value) {
+	            obj[name] = value;
+	        };
+	    }
+	}());
+
+	var globals = ['Array', 'Boolean', 'Date', 'Error', 'EvalError', 'Function',
+	'Infinity', 'JSON', 'Math', 'NaN', 'Number', 'Object', 'RangeError',
+	'ReferenceError', 'RegExp', 'String', 'SyntaxError', 'TypeError', 'URIError',
+	'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'escape',
+	'eval', 'isFinite', 'isNaN', 'parseFloat', 'parseInt', 'undefined', 'unescape'];
+
+	function Context() {}
+	Context.prototype = {};
+
+	var Script = exports.Script = function NodeScript (code) {
+	    if (!(this instanceof Script)) return new Script(code);
+	    this.code = code;
+	};
+
+	Script.prototype.runInContext = function (context) {
+	    if (!(context instanceof Context)) {
+	        throw new TypeError("needs a 'context' argument.");
+	    }
+	    
+	    var iframe = document.createElement('iframe');
+	    if (!iframe.style) iframe.style = {};
+	    iframe.style.display = 'none';
+	    
+	    document.body.appendChild(iframe);
+	    
+	    var win = iframe.contentWindow;
+	    var wEval = win.eval, wExecScript = win.execScript;
+
+	    if (!wEval && wExecScript) {
+	        // win.eval() magically appears when this is called in IE:
+	        wExecScript.call(win, 'null');
+	        wEval = win.eval;
+	    }
+	    
+	    forEach(Object_keys(context), function (key) {
+	        win[key] = context[key];
+	    });
+	    forEach(globals, function (key) {
+	        if (context[key]) {
+	            win[key] = context[key];
+	        }
+	    });
+	    
+	    var winKeys = Object_keys(win);
+
+	    var res = wEval.call(win, this.code);
+	    
+	    forEach(Object_keys(win), function (key) {
+	        // Avoid copying circular objects like `top` and `window` by only
+	        // updating existing context properties or new properties in the `win`
+	        // that was only introduced after the eval.
+	        if (key in context || indexOf(winKeys, key) === -1) {
+	            context[key] = win[key];
+	        }
+	    });
+
+	    forEach(globals, function (key) {
+	        if (!(key in context)) {
+	            defineProp(context, key, win[key]);
+	        }
+	    });
+	    
+	    document.body.removeChild(iframe);
+	    
+	    return res;
+	};
+
+	Script.prototype.runInThisContext = function () {
+	    return eval(this.code); // maybe...
+	};
+
+	Script.prototype.runInNewContext = function (context) {
+	    var ctx = Script.createContext(context);
+	    var res = this.runInContext(ctx);
+
+	    forEach(Object_keys(ctx), function (key) {
+	        context[key] = ctx[key];
+	    });
+
+	    return res;
+	};
+
+	forEach(Object_keys(Script.prototype), function (name) {
+	    exports[name] = Script[name] = function (code) {
+	        var s = Script(code);
+	        return s[name].apply(s, [].slice.call(arguments, 1));
+	    };
+	});
+
+	exports.createScript = function (code) {
+	    return exports.Script(code);
+	};
+
+	exports.createContext = Script.createContext = function (context) {
+	    var copy = new Context();
+	    if(typeof context === 'object') {
+	        forEach(Object_keys(context), function (key) {
+	            copy[key] = context[key];
+	        });
+	    }
+	    return copy;
+	};
+
+
+/***/ }),
+/* 106 */
+/***/ (function(module, exports) {
+
+	
+	var indexOf = [].indexOf;
+
+	module.exports = function(arr, obj){
+	  if (indexOf) return arr.indexOf(obj);
+	  for (var i = 0; i < arr.length; ++i) {
+	    if (arr[i] === obj) return i;
+	  }
+	  return -1;
+	};
+
+/***/ }),
+/* 107 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var base = exports;
+
+	base.Reporter = __webpack_require__(108).Reporter;
+	base.DecoderBuffer = __webpack_require__(109).DecoderBuffer;
+	base.EncoderBuffer = __webpack_require__(109).EncoderBuffer;
+	base.Node = __webpack_require__(110);
+
+
+/***/ }),
+/* 108 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+
+	function Reporter(options) {
+	  this._reporterState = {
+	    obj: null,
+	    path: [],
+	    options: options || {},
+	    errors: []
+	  };
+	}
+	exports.Reporter = Reporter;
+
+	Reporter.prototype.isError = function isError(obj) {
+	  return obj instanceof ReporterError;
+	};
+
+	Reporter.prototype.save = function save() {
+	  var state = this._reporterState;
+
+	  return { obj: state.obj, pathLen: state.path.length };
+	};
+
+	Reporter.prototype.restore = function restore(data) {
+	  var state = this._reporterState;
+
+	  state.obj = data.obj;
+	  state.path = state.path.slice(0, data.pathLen);
+	};
+
+	Reporter.prototype.enterKey = function enterKey(key) {
+	  return this._reporterState.path.push(key);
+	};
+
+	Reporter.prototype.leaveKey = function leaveKey(index, key, value) {
+	  var state = this._reporterState;
+
+	  state.path = state.path.slice(0, index - 1);
+	  if (state.obj !== null)
+	    state.obj[key] = value;
+	};
+
+	Reporter.prototype.enterObject = function enterObject() {
+	  var state = this._reporterState;
+
+	  var prev = state.obj;
+	  state.obj = {};
+	  return prev;
+	};
+
+	Reporter.prototype.leaveObject = function leaveObject(prev) {
+	  var state = this._reporterState;
+
+	  var now = state.obj;
+	  state.obj = prev;
+	  return now;
+	};
+
+	Reporter.prototype.error = function error(msg) {
+	  var err;
+	  var state = this._reporterState;
+
+	  var inherited = msg instanceof ReporterError;
+	  if (inherited) {
+	    err = msg;
+	  } else {
+	    err = new ReporterError(state.path.map(function(elem) {
+	      return '[' + JSON.stringify(elem) + ']';
+	    }).join(''), msg.message || msg, msg.stack);
+	  }
+
+	  if (!state.options.partial)
+	    throw err;
+
+	  if (!inherited)
+	    state.errors.push(err);
+
+	  return err;
+	};
+
+	Reporter.prototype.wrapResult = function wrapResult(result) {
+	  var state = this._reporterState;
+	  if (!state.options.partial)
+	    return result;
+
+	  return {
+	    result: this.isError(result) ? null : result,
+	    errors: state.errors
+	  };
+	};
+
+	function ReporterError(path, msg) {
+	  this.path = path;
+	  this.rethrow(msg);
+	};
+	inherits(ReporterError, Error);
+
+	ReporterError.prototype.rethrow = function rethrow(msg) {
+	  this.message = msg + ' at: ' + (this.path || '(shallow)');
+	  Error.captureStackTrace(this, ReporterError);
+
+	  return this;
+	};
+
+
+/***/ }),
+/* 109 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+	var Reporter = __webpack_require__(107).Reporter;
+	var Buffer = __webpack_require__(19).Buffer;
+
+	function DecoderBuffer(base, options) {
+	  Reporter.call(this, options);
+	  if (!Buffer.isBuffer(base)) {
+	    this.error('Input not Buffer');
+	    return;
+	  }
+
+	  this.base = base;
+	  this.offset = 0;
+	  this.length = base.length;
+	}
+	inherits(DecoderBuffer, Reporter);
+	exports.DecoderBuffer = DecoderBuffer;
+
+	DecoderBuffer.prototype.save = function save() {
+	  return { offset: this.offset, reporter: Reporter.prototype.save.call(this) };
+	};
+
+	DecoderBuffer.prototype.restore = function restore(save) {
+	  // Return skipped data
+	  var res = new DecoderBuffer(this.base);
+	  res.offset = save.offset;
+	  res.length = this.offset;
+
+	  this.offset = save.offset;
+	  Reporter.prototype.restore.call(this, save.reporter);
+
+	  return res;
+	};
+
+	DecoderBuffer.prototype.isEmpty = function isEmpty() {
+	  return this.offset === this.length;
+	};
+
+	DecoderBuffer.prototype.readUInt8 = function readUInt8(fail) {
+	  if (this.offset + 1 <= this.length)
+	    return this.base.readUInt8(this.offset++, true);
+	  else
+	    return this.error(fail || 'DecoderBuffer overrun');
+	}
+
+	DecoderBuffer.prototype.skip = function skip(bytes, fail) {
+	  if (!(this.offset + bytes <= this.length))
+	    return this.error(fail || 'DecoderBuffer overrun');
+
+	  var res = new DecoderBuffer(this.base);
+
+	  // Share reporter state
+	  res._reporterState = this._reporterState;
+
+	  res.offset = this.offset;
+	  res.length = this.offset + bytes;
+	  this.offset += bytes;
+	  return res;
+	}
+
+	DecoderBuffer.prototype.raw = function raw(save) {
+	  return this.base.slice(save ? save.offset : this.offset, this.length);
+	}
+
+	function EncoderBuffer(value, reporter) {
+	  if (Array.isArray(value)) {
+	    this.length = 0;
+	    this.value = value.map(function(item) {
+	      if (!(item instanceof EncoderBuffer))
+	        item = new EncoderBuffer(item, reporter);
+	      this.length += item.length;
+	      return item;
+	    }, this);
+	  } else if (typeof value === 'number') {
+	    if (!(0 <= value && value <= 0xff))
+	      return reporter.error('non-byte EncoderBuffer value');
+	    this.value = value;
+	    this.length = 1;
+	  } else if (typeof value === 'string') {
+	    this.value = value;
+	    this.length = Buffer.byteLength(value);
+	  } else if (Buffer.isBuffer(value)) {
+	    this.value = value;
+	    this.length = value.length;
+	  } else {
+	    return reporter.error('Unsupported type: ' + typeof value);
+	  }
+	}
+	exports.EncoderBuffer = EncoderBuffer;
+
+	EncoderBuffer.prototype.join = function join(out, offset) {
+	  if (!out)
+	    out = new Buffer(this.length);
+	  if (!offset)
+	    offset = 0;
+
+	  if (this.length === 0)
+	    return out;
+
+	  if (Array.isArray(this.value)) {
+	    this.value.forEach(function(item) {
+	      item.join(out, offset);
+	      offset += item.length;
+	    });
+	  } else {
+	    if (typeof this.value === 'number')
+	      out[offset] = this.value;
+	    else if (typeof this.value === 'string')
+	      out.write(this.value, offset);
+	    else if (Buffer.isBuffer(this.value))
+	      this.value.copy(out, offset);
+	    offset += this.length;
+	  }
+
+	  return out;
+	};
+
+
+/***/ }),
+/* 110 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var Reporter = __webpack_require__(107).Reporter;
+	var EncoderBuffer = __webpack_require__(107).EncoderBuffer;
+	var assert = __webpack_require__(20);
+
+	// Supported tags
+	var tags = [
+	  'seq', 'seqof', 'set', 'setof', 'octstr', 'bitstr', 'objid', 'bool',
+	  'gentime', 'utctime', 'null_', 'enum', 'int', 'ia5str', 'utf8str'
+	];
+
+	// Public methods list
+	var methods = [
+	  'key', 'obj', 'use', 'optional', 'explicit', 'implicit', 'def', 'choice',
+	  'any'
+	].concat(tags);
+
+	// Overrided methods list
+	var overrided = [
+	  '_peekTag', '_decodeTag', '_use',
+	  '_decodeStr', '_decodeObjid', '_decodeTime',
+	  '_decodeNull', '_decodeInt', '_decodeBool', '_decodeList',
+
+	  '_encodeComposite', '_encodeStr', '_encodeObjid', '_encodeTime',
+	  '_encodeNull', '_encodeInt', '_encodeBool'
+	];
+
+	function Node(enc, parent) {
+	  var state = {};
+	  this._baseState = state;
+
+	  state.enc = enc;
+
+	  state.parent = parent || null;
+	  state.children = null;
+
+	  // State
+	  state.tag = null;
+	  state.args = null;
+	  state.reverseArgs = null;
+	  state.choice = null;
+	  state.optional = false;
+	  state.any = false;
+	  state.obj = false;
+	  state.use = null;
+	  state.useDecoder = null;
+	  state.key = null;
+	  state['default'] = null;
+	  state.explicit = null;
+	  state.implicit = null;
+
+	  // Should create new instance on each method
+	  if (!state.parent) {
+	    state.children = [];
+	    this._wrap();
+	  }
+	}
+	module.exports = Node;
+
+	var stateProps = [
+	  'enc', 'parent', 'children', 'tag', 'args', 'reverseArgs', 'choice',
+	  'optional', 'any', 'obj', 'use', 'alteredUse', 'key', 'default', 'explicit',
+	  'implicit'
+	];
+
+	Node.prototype.clone = function clone() {
+	  var state = this._baseState;
+	  var cstate = {};
+	  stateProps.forEach(function(prop) {
+	    cstate[prop] = state[prop];
+	  });
+	  var res = new this.constructor(cstate.parent);
+	  res._baseState = cstate;
+	  return res;
+	};
+
+	Node.prototype._wrap = function wrap() {
+	  var state = this._baseState;
+	  methods.forEach(function(method) {
+	    this[method] = function _wrappedMethod() {
+	      var clone = new this.constructor(this);
+	      state.children.push(clone);
+	      return clone[method].apply(clone, arguments);
+	    };
+	  }, this);
+	};
+
+	Node.prototype._init = function init(body) {
+	  var state = this._baseState;
+
+	  assert(state.parent === null);
+	  body.call(this);
+
+	  // Filter children
+	  state.children = state.children.filter(function(child) {
+	    return child._baseState.parent === this;
+	  }, this);
+	  assert.equal(state.children.length, 1, 'Root node can have only one child');
+	};
+
+	Node.prototype._useArgs = function useArgs(args) {
+	  var state = this._baseState;
+
+	  // Filter children and args
+	  var children = args.filter(function(arg) {
+	    return arg instanceof this.constructor;
+	  }, this);
+	  args = args.filter(function(arg) {
+	    return !(arg instanceof this.constructor);
+	  }, this);
+
+	  if (children.length !== 0) {
+	    assert(state.children === null);
+	    state.children = children;
+
+	    // Replace parent to maintain backward link
+	    children.forEach(function(child) {
+	      child._baseState.parent = this;
+	    }, this);
+	  }
+	  if (args.length !== 0) {
+	    assert(state.args === null);
+	    state.args = args;
+	    state.reverseArgs = args.map(function(arg) {
+	      if (typeof arg !== 'object' || arg.constructor !== Object)
+	        return arg;
+
+	      var res = {};
+	      Object.keys(arg).forEach(function(key) {
+	        if (key == (key | 0))
+	          key |= 0;
+	        var value = arg[key];
+	        res[value] = key;
+	      });
+	      return res;
+	    });
+	  }
+	};
+
+	//
+	// Overrided methods
+	//
+
+	overrided.forEach(function(method) {
+	  Node.prototype[method] = function _overrided() {
+	    var state = this._baseState;
+	    throw new Error(method + ' not implemented for encoding: ' + state.enc);
+	  };
+	});
+
+	//
+	// Public methods
+	//
+
+	tags.forEach(function(tag) {
+	  Node.prototype[tag] = function _tagMethod() {
+	    var state = this._baseState;
+	    var args = Array.prototype.slice.call(arguments);
+
+	    assert(state.tag === null);
+	    state.tag = tag;
+
+	    this._useArgs(args);
+
+	    return this;
+	  };
+	});
+
+	Node.prototype.use = function use(item) {
+	  var state = this._baseState;
+
+	  assert(state.use === null);
+	  state.use = item;
+
+	  return this;
+	};
+
+	Node.prototype.optional = function optional() {
+	  var state = this._baseState;
+
+	  state.optional = true;
+
+	  return this;
+	};
+
+	Node.prototype.def = function def(val) {
+	  var state = this._baseState;
+
+	  assert(state['default'] === null);
+	  state['default'] = val;
+	  state.optional = true;
+
+	  return this;
+	};
+
+	Node.prototype.explicit = function explicit(num) {
+	  var state = this._baseState;
+
+	  assert(state.explicit === null && state.implicit === null);
+	  state.explicit = num;
+
+	  return this;
+	};
+
+	Node.prototype.implicit = function implicit(num) {
+	  var state = this._baseState;
+
+	  assert(state.explicit === null && state.implicit === null);
+	  state.implicit = num;
+
+	  return this;
+	};
+
+	Node.prototype.obj = function obj() {
+	  var state = this._baseState;
+	  var args = Array.prototype.slice.call(arguments);
+
+	  state.obj = true;
+
+	  if (args.length !== 0)
+	    this._useArgs(args);
+
+	  return this;
+	};
+
+	Node.prototype.key = function key(newKey) {
+	  var state = this._baseState;
+
+	  assert(state.key === null);
+	  state.key = newKey;
+
+	  return this;
+	};
+
+	Node.prototype.any = function any() {
+	  var state = this._baseState;
+
+	  state.any = true;
+
+	  return this;
+	};
+
+	Node.prototype.choice = function choice(obj) {
+	  var state = this._baseState;
+
+	  assert(state.choice === null);
+	  state.choice = obj;
+	  this._useArgs(Object.keys(obj).map(function(key) {
+	    return obj[key];
+	  }));
+
+	  return this;
+	};
+
+	//
+	// Decoding
+	//
+
+	Node.prototype._decode = function decode(input) {
+	  var state = this._baseState;
+
+	  // Decode root node
+	  if (state.parent === null)
+	    return input.wrapResult(state.children[0]._decode(input));
+
+	  var result = state['default'];
+	  var present = true;
+
+	  var prevKey;
+	  if (state.key !== null)
+	    prevKey = input.enterKey(state.key);
+
+	  // Check if tag is there
+	  if (state.optional) {
+	    var tag = null;
+	    if (state.explicit !== null)
+	      tag = state.explicit;
+	    else if (state.implicit !== null)
+	      tag = state.implicit;
+	    else if (state.tag !== null)
+	      tag = state.tag;
+
+	    if (tag === null && !state.any) {
+	      // Trial and Error
+	      var save = input.save();
+	      try {
+	        if (state.choice === null)
+	          this._decodeGeneric(state.tag, input);
+	        else
+	          this._decodeChoice(input);
+	        present = true;
+	      } catch (e) {
+	        present = false;
+	      }
+	      input.restore(save);
+	    } else {
+	      present = this._peekTag(input, tag, state.any);
+
+	      if (input.isError(present))
+	        return present;
+	    }
+	  }
+
+	  // Push object on stack
+	  var prevObj;
+	  if (state.obj && present)
+	    prevObj = input.enterObject();
+
+	  if (present) {
+	    // Unwrap explicit values
+	    if (state.explicit !== null) {
+	      var explicit = this._decodeTag(input, state.explicit);
+	      if (input.isError(explicit))
+	        return explicit;
+	      input = explicit;
+	    }
+
+	    // Unwrap implicit and normal values
+	    if (state.use === null && state.choice === null) {
+	      if (state.any)
+	        var save = input.save();
+	      var body = this._decodeTag(
+	        input,
+	        state.implicit !== null ? state.implicit : state.tag,
+	        state.any
+	      );
+	      if (input.isError(body))
+	        return body;
+
+	      if (state.any)
+	        result = input.raw(save);
+	      else
+	        input = body;
+	    }
+
+	    // Select proper method for tag
+	    if (state.any)
+	      result = result;
+	    else if (state.choice === null)
+	      result = this._decodeGeneric(state.tag, input);
+	    else
+	      result = this._decodeChoice(input);
+
+	    if (input.isError(result))
+	      return result;
+
+	    // Decode children
+	    if (!state.any && state.choice === null && state.children !== null) {
+	      var fail = state.children.some(function decodeChildren(child) {
+	        // NOTE: We are ignoring errors here, to let parser continue with other
+	        // parts of encoded data
+	        child._decode(input);
+	      });
+	      if (fail)
+	        return err;
+	    }
+	  }
+
+	  // Pop object
+	  if (state.obj && present)
+	    result = input.leaveObject(prevObj);
+
+	  // Set key
+	  if (state.key !== null && (result !== null || present === true))
+	    input.leaveKey(prevKey, state.key, result);
+
+	  return result;
+	};
+
+	Node.prototype._decodeGeneric = function decodeGeneric(tag, input) {
+	  var state = this._baseState;
+
+	  if (tag === 'seq' || tag === 'set')
+	    return null;
+	  if (tag === 'seqof' || tag === 'setof')
+	    return this._decodeList(input, tag, state.args[0]);
+	  else if (tag === 'octstr' || tag === 'bitstr')
+	    return this._decodeStr(input, tag);
+	  else if (tag === 'ia5str' || tag === 'utf8str')
+	    return this._decodeStr(input, tag);
+	  else if (tag === 'objid' && state.args)
+	    return this._decodeObjid(input, state.args[0], state.args[1]);
+	  else if (tag === 'objid')
+	    return this._decodeObjid(input, null, null);
+	  else if (tag === 'gentime' || tag === 'utctime')
+	    return this._decodeTime(input, tag);
+	  else if (tag === 'null_')
+	    return this._decodeNull(input);
+	  else if (tag === 'bool')
+	    return this._decodeBool(input);
+	  else if (tag === 'int' || tag === 'enum')
+	    return this._decodeInt(input, state.args && state.args[0]);
+	  else if (state.use !== null)
+	    return this._getUse(state.use, input._reporterState.obj)._decode(input);
+	  else
+	    return input.error('unknown tag: ' + tag);
+
+	  return null;
+	};
+
+	Node.prototype._getUse = function _getUse(entity, obj) {
+
+	  var state = this._baseState;
+	  // Create altered use decoder if implicit is set
+	  state.useDecoder = this._use(entity, obj);
+	  assert(state.useDecoder._baseState.parent === null);
+	  state.useDecoder = state.useDecoder._baseState.children[0];
+	  if (state.implicit !== state.useDecoder._baseState.implicit) {
+	    state.useDecoder = state.useDecoder.clone();
+	    state.useDecoder._baseState.implicit = state.implicit;
+	  }
+	  return state.useDecoder;
+	};
+
+	Node.prototype._decodeChoice = function decodeChoice(input) {
+	  var state = this._baseState;
+	  var result = null;
+	  var match = false;
+
+	  Object.keys(state.choice).some(function(key) {
+	    var save = input.save();
+	    var node = state.choice[key];
+	    try {
+	      var value = node._decode(input);
+	      if (input.isError(value))
+	        return false;
+
+	      result = { type: key, value: value };
+	      match = true;
+	    } catch (e) {
+	      input.restore(save);
+	      return false;
+	    }
+	    return true;
+	  }, this);
+
+	  if (!match)
+	    return input.error('Choice not matched');
+
+	  return result;
+	};
+
+	//
+	// Encoding
+	//
+
+	Node.prototype._createEncoderBuffer = function createEncoderBuffer(data) {
+	  return new EncoderBuffer(data, this.reporter);
+	};
+
+	Node.prototype._encode = function encode(data, reporter, parent) {
+	  var state = this._baseState;
+	  if (state['default'] !== null && state['default'] === data)
+	    return;
+
+	  var result = this._encodeValue(data, reporter, parent);
+	  if (result === undefined)
+	    return;
+
+	  if (this._skipDefault(result, reporter, parent))
+	    return;
+
+	  return result;
+	};
+
+	Node.prototype._encodeValue = function encode(data, reporter, parent) {
+	  var state = this._baseState;
+
+	  // Decode root node
+	  if (state.parent === null)
+	    return state.children[0]._encode(data, reporter || new Reporter());
+
+	  var result = null;
+	  var present = true;
+
+	  // Set reporter to share it with a child class
+	  this.reporter = reporter;
+
+	  // Check if data is there
+	  if (state.optional && data === undefined) {
+	    if (state['default'] !== null)
+	      data = state['default']
+	    else
+	      return;
+	  }
+
+	  // For error reporting
+	  var prevKey;
+
+	  // Encode children first
+	  var content = null;
+	  var primitive = false;
+	  if (state.any) {
+	    // Anything that was given is translated to buffer
+	    result = this._createEncoderBuffer(data);
+	  } else if (state.choice) {
+	    result = this._encodeChoice(data, reporter);
+	  } else if (state.children) {
+	    content = state.children.map(function(child) {
+	      if (child._baseState.tag === 'null_')
+	        return child._encode(null, reporter, data);
+
+	      if (child._baseState.key === null)
+	        return reporter.error('Child should have a key');
+	      var prevKey = reporter.enterKey(child._baseState.key);
+
+	      if (typeof data !== 'object')
+	        return reporter.error('Child expected, but input is not object');
+
+	      var res = child._encode(data[child._baseState.key], reporter, data);
+	      reporter.leaveKey(prevKey);
+
+	      return res;
+	    }, this).filter(function(child) {
+	      return child;
+	    });
+
+	    content = this._createEncoderBuffer(content);
+	  } else {
+	    if (state.tag === 'seqof' || state.tag === 'setof') {
+	      // TODO(indutny): this should be thrown on DSL level
+	      if (!(state.args && state.args.length === 1))
+	        return reporter.error('Too many args for : ' + state.tag);
+
+	      if (!Array.isArray(data))
+	        return reporter.error('seqof/setof, but data is not Array');
+
+	      var child = this.clone();
+	      child._baseState.implicit = null;
+	      content = this._createEncoderBuffer(data.map(function(item) {
+	        var state = this._baseState;
+
+	        return this._getUse(state.args[0], data)._encode(item, reporter);
+	      }, child));
+	    } else if (state.use !== null) {
+	      result = this._getUse(state.use, parent)._encode(data, reporter);
+	    } else {
+	      content = this._encodePrimitive(state.tag, data);
+	      primitive = true;
+	    }
+	  }
+
+	  // Encode data itself
+	  var result;
+	  if (!state.any && state.choice === null) {
+	    var tag = state.implicit !== null ? state.implicit : state.tag;
+	    var cls = state.implicit === null ? 'universal' : 'context';
+
+	    if (tag === null) {
+	      if (state.use === null)
+	        reporter.error('Tag could be ommited only for .use()');
+	    } else {
+	      if (state.use === null)
+	        result = this._encodeComposite(tag, primitive, cls, content);
+	    }
+	  }
+
+	  // Wrap in explicit
+	  if (state.explicit !== null)
+	    result = this._encodeComposite(state.explicit, false, 'context', result);
+
+	  return result;
+	};
+
+	Node.prototype._encodeChoice = function encodeChoice(data, reporter) {
+	  var state = this._baseState;
+
+	  var node = state.choice[data.type];
+	  if (!node) {
+	    assert(
+	        false,
+	        data.type + ' not found in ' +
+	            JSON.stringify(Object.keys(state.choice)));
+	  }
+	  return node._encode(data.value, reporter);
+	};
+
+	Node.prototype._encodePrimitive = function encodePrimitive(tag, data) {
+	  var state = this._baseState;
+
+	  if (tag === 'octstr' || tag === 'bitstr' || tag === 'ia5str')
+	    return this._encodeStr(data, tag);
+	  else if (tag === 'utf8str')
+	    return this._encodeStr(data, tag);
+	  else if (tag === 'objid' && state.args)
+	    return this._encodeObjid(data, state.reverseArgs[0], state.args[1]);
+	  else if (tag === 'objid')
+	    return this._encodeObjid(data, null, null);
+	  else if (tag === 'gentime' || tag === 'utctime')
+	    return this._encodeTime(data, tag);
+	  else if (tag === 'null_')
+	    return this._encodeNull();
+	  else if (tag === 'int' || tag === 'enum')
+	    return this._encodeInt(data, state.args && state.reverseArgs[0]);
+	  else if (tag === 'bool')
+	    return this._encodeBool(data);
+	  else
+	    throw new Error('Unsupported tag: ' + tag);
+	};
+
+
+/***/ }),
+/* 111 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var constants = exports;
+
+	// Helper
+	constants._reverse = function reverse(map) {
+	  var res = {};
+
+	  Object.keys(map).forEach(function(key) {
+	    // Convert key to integer if it is stringified
+	    if ((key | 0) == key)
+	      key = key | 0;
+
+	    var value = map[key];
+	    res[value] = key;
+	  });
+
+	  return res;
+	};
+
+	constants.der = __webpack_require__(112);
+
+
+/***/ }),
+/* 112 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var constants = __webpack_require__(111);
+
+	exports.tagClass = {
+	  0: 'universal',
+	  1: 'application',
+	  2: 'context',
+	  3: 'private'
+	};
+	exports.tagClassByName = constants._reverse(exports.tagClass);
+
+	exports.tag = {
+	  0x00: 'end',
+	  0x01: 'bool',
+	  0x02: 'int',
+	  0x03: 'bitstr',
+	  0x04: 'octstr',
+	  0x05: 'null_',
+	  0x06: 'objid',
+	  0x07: 'objDesc',
+	  0x08: 'external',
+	  0x09: 'real',
+	  0x0a: 'enum',
+	  0x0b: 'embed',
+	  0x0c: 'utf8str',
+	  0x0d: 'relativeOid',
+	  0x10: 'seq',
+	  0x11: 'set',
+	  0x12: 'numstr',
+	  0x13: 'printstr',
+	  0x14: 't61str',
+	  0x15: 'videostr',
+	  0x16: 'ia5str',
+	  0x17: 'utctime',
+	  0x18: 'gentime',
+	  0x19: 'graphstr',
+	  0x1a: 'iso646str',
+	  0x1b: 'genstr',
+	  0x1c: 'unistr',
+	  0x1d: 'charstr',
+	  0x1e: 'bmpstr'
+	};
+	exports.tagByName = constants._reverse(exports.tag);
+
+
+/***/ }),
+/* 113 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var decoders = exports;
+
+	decoders.der = __webpack_require__(114);
+	decoders.pem = __webpack_require__(115);
+
+
+/***/ }),
+/* 114 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+
+	var asn1 = __webpack_require__(102);
+	var base = asn1.base;
+	var bignum = asn1.bignum;
+
+	// Import DER constants
+	var der = asn1.constants.der;
+
+	function DERDecoder(entity) {
+	  this.enc = 'der';
+	  this.name = entity.name;
+	  this.entity = entity;
+
+	  // Construct base tree
+	  this.tree = new DERNode();
+	  this.tree._init(entity.body);
+	};
+	module.exports = DERDecoder;
+
+	DERDecoder.prototype.decode = function decode(data, options) {
+	  if (!(data instanceof base.DecoderBuffer))
+	    data = new base.DecoderBuffer(data, options);
+
+	  return this.tree._decode(data, options);
+	};
+
+	// Tree methods
+
+	function DERNode(parent) {
+	  base.Node.call(this, 'der', parent);
+	}
+	inherits(DERNode, base.Node);
+
+	DERNode.prototype._peekTag = function peekTag(buffer, tag, any) {
+	  if (buffer.isEmpty())
+	    return false;
+
+	  var state = buffer.save();
+	  var decodedTag = derDecodeTag(buffer, 'Failed to peek tag: "' + tag + '"');
+	  if (buffer.isError(decodedTag))
+	    return decodedTag;
+
+	  buffer.restore(state);
+
+	  return decodedTag.tag === tag || decodedTag.tagStr === tag || any;
+	};
+
+	DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
+	  var decodedTag = derDecodeTag(buffer,
+	                                'Failed to decode tag of "' + tag + '"');
+	  if (buffer.isError(decodedTag))
+	    return decodedTag;
+
+	  var len = derDecodeLen(buffer,
+	                         decodedTag.primitive,
+	                         'Failed to get length of "' + tag + '"');
+
+	  // Failure
+	  if (buffer.isError(len))
+	    return len;
+
+	  if (!any &&
+	      decodedTag.tag !== tag &&
+	      decodedTag.tagStr !== tag &&
+	      decodedTag.tagStr + 'of' !== tag) {
+	    return buffer.error('Failed to match tag: "' + tag + '"');
+	  }
+
+	  if (decodedTag.primitive || len !== null)
+	    return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+
+	  // Indefinite length... find END tag
+	  var state = buffer.save();
+	  var res = this._skipUntilEnd(
+	      buffer,
+	      'Failed to skip indefinite length body: "' + this.tag + '"');
+	  if (buffer.isError(res))
+	    return res;
+
+	  len = buffer.offset - state.offset;
+	  buffer.restore(state);
+	  return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+	};
+
+	DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
+	  while (true) {
+	    var tag = derDecodeTag(buffer, fail);
+	    if (buffer.isError(tag))
+	      return tag;
+	    var len = derDecodeLen(buffer, tag.primitive, fail);
+	    if (buffer.isError(len))
+	      return len;
+
+	    var res;
+	    if (tag.primitive || len !== null)
+	      res = buffer.skip(len)
+	    else
+	      res = this._skipUntilEnd(buffer, fail);
+
+	    // Failure
+	    if (buffer.isError(res))
+	      return res;
+
+	    if (tag.tagStr === 'end')
+	      break;
+	  }
+	};
+
+	DERNode.prototype._decodeList = function decodeList(buffer, tag, decoder) {
+	  var result = [];
+	  while (!buffer.isEmpty()) {
+	    var possibleEnd = this._peekTag(buffer, 'end');
+	    if (buffer.isError(possibleEnd))
+	      return possibleEnd;
+
+	    var res = decoder.decode(buffer, 'der');
+	    if (buffer.isError(res) && possibleEnd)
+	      break;
+	    result.push(res);
+	  }
+	  return result;
+	};
+
+	DERNode.prototype._decodeStr = function decodeStr(buffer, tag) {
+	  if (tag === 'octstr') {
+	    return buffer.raw();
+	  } else if (tag === 'bitstr') {
+	    var unused = buffer.readUInt8();
+	    if (buffer.isError(unused))
+	      return unused;
+
+	    return { unused: unused, data: buffer.raw() };
+	  } else if (tag === 'ia5str' || tag === 'utf8str') {
+	    return buffer.raw().toString();
+	  } else {
+	    return this.error('Decoding of string type: ' + tag + ' unsupported');
+	  }
+	};
+
+	DERNode.prototype._decodeObjid = function decodeObjid(buffer, values, relative) {
+	  var identifiers = [];
+	  var ident = 0;
+	  while (!buffer.isEmpty()) {
+	    var subident = buffer.readUInt8();
+	    ident <<= 7;
+	    ident |= subident & 0x7f;
+	    if ((subident & 0x80) === 0) {
+	      identifiers.push(ident);
+	      ident = 0;
+	    }
+	  }
+	  if (subident & 0x80)
+	    identifiers.push(ident);
+
+	  var first = (identifiers[0] / 40) | 0;
+	  var second = identifiers[0] % 40;
+
+	  if (relative)
+	    result = identifiers;
+	  else
+	    result = [first, second].concat(identifiers.slice(1));
+
+	  if (values)
+	    result = values[result.join(' ')];
+
+	  return result;
+	};
+
+	DERNode.prototype._decodeTime = function decodeTime(buffer, tag) {
+	  var str = buffer.raw().toString();
+	  if (tag === 'gentime') {
+	    var year = str.slice(0, 4) | 0;
+	    var mon = str.slice(4, 6) | 0;
+	    var day = str.slice(6, 8) | 0;
+	    var hour = str.slice(8, 10) | 0;
+	    var min = str.slice(10, 12) | 0;
+	    var sec = str.slice(12, 14) | 0;
+	  } else if (tag === 'utctime') {
+	    var year = str.slice(0, 2) | 0;
+	    var mon = str.slice(2, 4) | 0;
+	    var day = str.slice(4, 6) | 0;
+	    var hour = str.slice(6, 8) | 0;
+	    var min = str.slice(8, 10) | 0;
+	    var sec = str.slice(10, 12) | 0;
+	    if (year < 70)
+	      year = 2000 + year;
+	    else
+	      year = 1900 + year;
+	  } else {
+	    return this.error('Decoding ' + tag + ' time is not supported yet');
+	  }
+
+	  return Date.UTC(year, mon - 1, day, hour, min, sec, 0);
+	};
+
+	DERNode.prototype._decodeNull = function decodeNull(buffer) {
+	  return null;
+	};
+
+	DERNode.prototype._decodeBool = function decodeBool(buffer) {
+	  var res = buffer.readUInt8();
+	  if (buffer.isError(res))
+	    return res;
+	  else
+	    return res !== 0;
+	};
+
+	DERNode.prototype._decodeInt = function decodeInt(buffer, values) {
+	  // Bigint, return as it is (assume big endian)
+	  var raw = buffer.raw();
+	  var res = new bignum(raw);
+
+	  if (values)
+	    res = values[res.toString(10)] || res;
+
+	  return res;
+	};
+
+	DERNode.prototype._use = function use(entity, obj) {
+	  if (typeof entity === 'function')
+	    entity = entity(obj);
+	  return entity._getDecoder('der').tree;
+	};
+
+	// Utility methods
+
+	function derDecodeTag(buf, fail) {
+	  var tag = buf.readUInt8(fail);
+	  if (buf.isError(tag))
+	    return tag;
+
+	  var cls = der.tagClass[tag >> 6];
+	  var primitive = (tag & 0x20) === 0;
+
+	  // Multi-octet tag - load
+	  if ((tag & 0x1f) === 0x1f) {
+	    var oct = tag;
+	    tag = 0;
+	    while ((oct & 0x80) === 0x80) {
+	      oct = buf.readUInt8(fail);
+	      if (buf.isError(oct))
+	        return oct;
+
+	      tag <<= 7;
+	      tag |= oct & 0x7f;
+	    }
+	  } else {
+	    tag &= 0x1f;
+	  }
+	  var tagStr = der.tag[tag];
+
+	  return {
+	    cls: cls,
+	    primitive: primitive,
+	    tag: tag,
+	    tagStr: tagStr
+	  };
+	}
+
+	function derDecodeLen(buf, primitive, fail) {
+	  var len = buf.readUInt8(fail);
+	  if (buf.isError(len))
+	    return len;
+
+	  // Indefinite form
+	  if (!primitive && len === 0x80)
+	    return null;
+
+	  // Definite form
+	  if ((len & 0x80) === 0) {
+	    // Short form
+	    return len;
+	  }
+
+	  // Long form
+	  var num = len & 0x7f;
+	  if (num >= 4)
+	    return buf.error('length octect is too long');
+
+	  len = 0;
+	  for (var i = 0; i < num; i++) {
+	    len <<= 8;
+	    var j = buf.readUInt8(fail);
+	    if (buf.isError(j))
+	      return j;
+	    len |= j;
+	  }
+
+	  return len;
+	}
+
+
+/***/ }),
+/* 115 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+	var Buffer = __webpack_require__(19).Buffer;
+
+	var asn1 = __webpack_require__(102);
+	var DERDecoder = __webpack_require__(114);
+
+	function PEMDecoder(entity) {
+	  DERDecoder.call(this, entity);
+	  this.enc = 'pem';
+	};
+	inherits(PEMDecoder, DERDecoder);
+	module.exports = PEMDecoder;
+
+	PEMDecoder.prototype.decode = function decode(data, options) {
+	  var lines = data.toString().split(/[\r\n]+/g);
+
+	  var label = options.label.toUpperCase();
+
+	  var re = /^-----(BEGIN|END) ([^-]+)-----$/;
+	  var start = -1;
+	  var end = -1;
+	  for (var i = 0; i < lines.length; i++) {
+	    var match = lines[i].match(re);
+	    if (match === null)
+	      continue;
+
+	    if (match[2] !== label)
+	      continue;
+
+	    if (start === -1) {
+	      if (match[1] !== 'BEGIN')
+	        break;
+	      start = i;
+	    } else {
+	      if (match[1] !== 'END')
+	        break;
+	      end = i;
+	      break;
+	    }
+	  }
+	  if (start === -1 || end === -1)
+	    throw new Error('PEM section not found for: ' + label);
+
+	  var base64 = lines.slice(start + 1, end).join('');
+	  // Remove excessive symbols
+	  base64.replace(/[^a-z0-9\+\/=]+/gi, '');
+
+	  var input = new Buffer(base64, 'base64');
+	  return DERDecoder.prototype.decode.call(this, input, options);
+	};
+
+
+/***/ }),
+/* 116 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var encoders = exports;
+
+	encoders.der = __webpack_require__(117);
+	encoders.pem = __webpack_require__(118);
+
+
+/***/ }),
+/* 117 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+	var Buffer = __webpack_require__(19).Buffer;
+
+	var asn1 = __webpack_require__(102);
+	var base = asn1.base;
+	var bignum = asn1.bignum;
+
+	// Import DER constants
+	var der = asn1.constants.der;
+
+	function DEREncoder(entity) {
+	  this.enc = 'der';
+	  this.name = entity.name;
+	  this.entity = entity;
+
+	  // Construct base tree
+	  this.tree = new DERNode();
+	  this.tree._init(entity.body);
+	};
+	module.exports = DEREncoder;
+
+	DEREncoder.prototype.encode = function encode(data, reporter) {
+	  return this.tree._encode(data, reporter).join();
+	};
+
+	// Tree methods
+
+	function DERNode(parent) {
+	  base.Node.call(this, 'der', parent);
+	}
+	inherits(DERNode, base.Node);
+
+	DERNode.prototype._encodeComposite = function encodeComposite(tag,
+	                                                              primitive,
+	                                                              cls,
+	                                                              content) {
+	  var encodedTag = encodeTag(tag, primitive, cls, this.reporter);
+
+	  // Short form
+	  if (content.length < 0x80) {
+	    var header = new Buffer(2);
+	    header[0] = encodedTag;
+	    header[1] = content.length;
+	    return this._createEncoderBuffer([ header, content ]);
+	  }
+
+	  // Long form
+	  // Count octets required to store length
+	  var lenOctets = 1;
+	  for (var i = content.length; i >= 0x100; i >>= 8)
+	    lenOctets++;
+
+	  var header = new Buffer(1 + 1 + lenOctets);
+	  header[0] = encodedTag;
+	  header[1] = 0x80 | lenOctets;
+
+	  for (var i = 1 + lenOctets, j = content.length; j > 0; i--, j >>= 8)
+	    header[i] = j & 0xff;
+
+	  return this._createEncoderBuffer([ header, content ]);
+	};
+
+	DERNode.prototype._encodeStr = function encodeStr(str, tag) {
+	  if (tag === 'octstr')
+	    return this._createEncoderBuffer(str);
+	  else if (tag === 'bitstr')
+	    return this._createEncoderBuffer([ str.unused | 0, str.data ]);
+	  else if (tag === 'ia5str' || tag === 'utf8str')
+	    return this._createEncoderBuffer(str);
+	  return this.reporter.error('Encoding of string type: ' + tag +
+	                             ' unsupported');
+	};
+
+	DERNode.prototype._encodeObjid = function encodeObjid(id, values, relative) {
+	  if (typeof id === 'string') {
+	    if (!values)
+	      return this.reporter.error('string objid given, but no values map found');
+	    if (!values.hasOwnProperty(id))
+	      return this.reporter.error('objid not found in values map');
+	    id = values[id].split(/[\s\.]+/g);
+	    for (var i = 0; i < id.length; i++)
+	      id[i] |= 0;
+	  } else if (Array.isArray(id)) {
+	    id = id.slice();
+	    for (var i = 0; i < id.length; i++)
+	      id[i] |= 0;
+	  }
+
+	  if (!Array.isArray(id)) {
+	    return this.reporter.error('objid() should be either array or string, ' +
+	                               'got: ' + JSON.stringify(id));
+	  }
+
+	  if (!relative) {
+	    if (id[1] >= 40)
+	      return this.reporter.error('Second objid identifier OOB');
+	    id.splice(0, 2, id[0] * 40 + id[1]);
+	  }
+
+	  // Count number of octets
+	  var size = 0;
+	  for (var i = 0; i < id.length; i++) {
+	    var ident = id[i];
+	    for (size++; ident >= 0x80; ident >>= 7)
+	      size++;
+	  }
+
+	  var objid = new Buffer(size);
+	  var offset = objid.length - 1;
+	  for (var i = id.length - 1; i >= 0; i--) {
+	    var ident = id[i];
+	    objid[offset--] = ident & 0x7f;
+	    while ((ident >>= 7) > 0)
+	      objid[offset--] = 0x80 | (ident & 0x7f);
+	  }
+
+	  return this._createEncoderBuffer(objid);
+	};
+
+	function two(num) {
+	  if (num < 10)
+	    return '0' + num;
+	  else
+	    return num;
+	}
+
+	DERNode.prototype._encodeTime = function encodeTime(time, tag) {
+	  var str;
+	  var date = new Date(time);
+
+	  if (tag === 'gentime') {
+	    str = [
+	      two(date.getFullYear()),
+	      two(date.getUTCMonth() + 1),
+	      two(date.getUTCDate()),
+	      two(date.getUTCHours()),
+	      two(date.getUTCMinutes()),
+	      two(date.getUTCSeconds()),
+	      'Z'
+	    ].join('');
+	  } else if (tag === 'utctime') {
+	    str = [
+	      two(date.getFullYear() % 100),
+	      two(date.getUTCMonth() + 1),
+	      two(date.getUTCDate()),
+	      two(date.getUTCHours()),
+	      two(date.getUTCMinutes()),
+	      two(date.getUTCSeconds()),
+	      'Z'
+	    ].join('');
+	  } else {
+	    this.reporter.error('Encoding ' + tag + ' time is not supported yet');
+	  }
+
+	  return this._encodeStr(str, 'octstr');
+	};
+
+	DERNode.prototype._encodeNull = function encodeNull() {
+	  return this._createEncoderBuffer('');
+	};
+
+	DERNode.prototype._encodeInt = function encodeInt(num, values) {
+	  if (typeof num === 'string') {
+	    if (!values)
+	      return this.reporter.error('String int or enum given, but no values map');
+	    if (!values.hasOwnProperty(num)) {
+	      return this.reporter.error('Values map doesn\'t contain: ' +
+	                                 JSON.stringify(num));
+	    }
+	    num = values[num];
+	  }
+
+	  // Bignum, assume big endian
+	  if (typeof num !== 'number' && !Buffer.isBuffer(num)) {
+	    var numArray = num.toArray();
+	    if (num.sign === false && numArray[0] & 0x80) {
+	      numArray.unshift(0);
+	    }
+	    num = new Buffer(numArray);
+	  }
+
+	  if (Buffer.isBuffer(num)) {
+	    var size = num.length;
+	    if (num.length === 0)
+	      size++;
+
+	    var out = new Buffer(size);
+	    num.copy(out);
+	    if (num.length === 0)
+	      out[0] = 0
+	    return this._createEncoderBuffer(out);
+	  }
+
+	  if (num < 0x80)
+	    return this._createEncoderBuffer(num);
+
+	  if (num < 0x100)
+	    return this._createEncoderBuffer([0, num]);
+
+	  var size = 1;
+	  for (var i = num; i >= 0x100; i >>= 8)
+	    size++;
+
+	  var out = new Array(size);
+	  for (var i = out.length - 1; i >= 0; i--) {
+	    out[i] = num & 0xff;
+	    num >>= 8;
+	  }
+	  if(out[0] & 0x80) {
+	    out.unshift(0);
+	  }
+
+	  return this._createEncoderBuffer(new Buffer(out));
+	};
+
+	DERNode.prototype._encodeBool = function encodeBool(value) {
+	  return this._createEncoderBuffer(value ? 0xff : 0);
+	};
+
+	DERNode.prototype._use = function use(entity, obj) {
+	  if (typeof entity === 'function')
+	    entity = entity(obj);
+	  return entity._getEncoder('der').tree;
+	};
+
+	DERNode.prototype._skipDefault = function skipDefault(dataBuffer, reporter, parent) {
+	  var state = this._baseState;
+	  var i;
+	  if (state['default'] === null)
+	    return false;
+
+	  var data = dataBuffer.join();
+	  if (state.defaultBuffer === undefined)
+	    state.defaultBuffer = this._encodeValue(state['default'], reporter, parent).join();
+
+	  if (data.length !== state.defaultBuffer.length)
+	    return false;
+
+	  for (i=0; i < data.length; i++)
+	    if (data[i] !== state.defaultBuffer[i])
+	      return false;
+
+	  return true;
+	};
+
+	// Utility methods
+
+	function encodeTag(tag, primitive, cls, reporter) {
+	  var res;
+
+	  if (tag === 'seqof')
+	    tag = 'seq';
+	  else if (tag === 'setof')
+	    tag = 'set';
+
+	  if (der.tagByName.hasOwnProperty(tag))
+	    res = der.tagByName[tag];
+	  else if (typeof tag === 'number' && (tag | 0) === tag)
+	    res = tag;
+	  else
+	    return reporter.error('Unknown tag: ' + tag);
+
+	  if (res >= 0x1f)
+	    return reporter.error('Multi-octet tag encoding unsupported');
+
+	  if (!primitive)
+	    res |= 0x20;
+
+	  res |= (der.tagClassByName[cls || 'universal'] << 6);
+
+	  return res;
+	}
+
+
+/***/ }),
+/* 118 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+	var Buffer = __webpack_require__(19).Buffer;
+
+	var asn1 = __webpack_require__(102);
+	var DEREncoder = __webpack_require__(117);
+
+	function PEMEncoder(entity) {
+	  DEREncoder.call(this, entity);
+	  this.enc = 'pem';
+	};
+	inherits(PEMEncoder, DEREncoder);
+	module.exports = PEMEncoder;
+
+	PEMEncoder.prototype.encode = function encode(data, options) {
+	  var buf = DEREncoder.prototype.encode.call(this, data);
+
+	  var p = buf.toString('base64');
+	  var out = [ '-----BEGIN ' + options.label + '-----' ];
+	  for (var i = 0; i < p.length; i += 64)
+	    out.push(p.slice(i, i + 64));
+	  out.push('-----END ' + options.label + '-----');
+	  return out.join('\n');
+	};
+
+
+/***/ }),
+/* 119 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(module) {(function (module, exports) {
+
+	'use strict';
+
+	// Utils
+
+	function assert(val, msg) {
+	  if (!val)
+	    throw new Error(msg || 'Assertion failed');
+	}
+
+	// Could use `inherits` module, but don't want to move from single file
+	// architecture yet.
+	function inherits(ctor, superCtor) {
+	  ctor.super_ = superCtor;
+	  var TempCtor = function () {};
+	  TempCtor.prototype = superCtor.prototype;
+	  ctor.prototype = new TempCtor();
+	  ctor.prototype.constructor = ctor;
+	}
+
+	// BN
+
+	function BN(number, base, endian) {
+	  // May be `new BN(bn)` ?
+	  if (number !== null &&
+	      typeof number === 'object' &&
+	      Array.isArray(number.words)) {
+	    return number;
+	  }
+
+	  this.sign = false;
+	  this.words = null;
+	  this.length = 0;
+
+	  // Reduction context
+	  this.red = null;
+
+	  if (base === 'le' || base === 'be') {
+	    endian = base;
+	    base = 10;
+	  }
+
+	  if (number !== null)
+	    this._init(number || 0, base || 10, endian || 'be');
+	}
+	if (typeof module === 'object')
+	  module.exports = BN;
+	else
+	  exports.BN = BN;
+
+	BN.BN = BN;
+	BN.wordSize = 26;
+
+	BN.max = function max(left, right) {
+	  if (left.cmp(right) > 0)
+	    return left;
+	  else
+	    return right;
+	};
+
+	BN.min = function min(left, right) {
+	  if (left.cmp(right) < 0)
+	    return left;
+	  else
+	    return right;
+	};
+
+	BN.prototype._init = function init(number, base, endian) {
+	  if (typeof number === 'number') {
+	    return this._initNumber(number, base, endian);
+	  } else if (typeof number === 'object') {
+	    return this._initArray(number, base, endian);
+	  }
+	  if (base === 'hex')
+	    base = 16;
+	  assert(base === (base | 0) && base >= 2 && base <= 36);
+
+	  number = number.toString().replace(/\s+/g, '');
+	  var start = 0;
+	  if (number[0] === '-')
+	    start++;
+
+	  if (base === 16)
+	    this._parseHex(number, start);
+	  else
+	    this._parseBase(number, base, start);
+
+	  if (number[0] === '-')
+	    this.sign = true;
+
+	  this.strip();
+
+	  if (endian !== 'le')
+	    return;
+
+	  this._initArray(this.toArray(), base, endian);
+	};
+
+	BN.prototype._initNumber = function _initNumber(number, base, endian) {
+	  if (number < 0) {
+	    this.sign = true;
+	    number = -number;
+	  }
+	  if (number < 0x4000000) {
+	    this.words = [ number & 0x3ffffff ];
+	    this.length = 1;
+	  } else if (number < 0x10000000000000) {
+	    this.words = [
+	      number & 0x3ffffff,
+	      (number / 0x4000000) & 0x3ffffff
+	    ];
+	    this.length = 2;
+	  } else {
+	    assert(number < 0x20000000000000); // 2 ^ 53 (unsafe)
+	    this.words = [
+	      number & 0x3ffffff,
+	      (number / 0x4000000) & 0x3ffffff,
+	      1
+	    ];
+	    this.length = 3;
+	  }
+
+	  if (endian !== 'le')
+	    return;
+
+	  // Reverse the bytes
+	  this._initArray(this.toArray(), base, endian);
+	};
+
+	BN.prototype._initArray = function _initArray(number, base, endian) {
+	  // Perhaps a Uint8Array
+	  assert(typeof number.length === 'number');
+	  if (number.length <= 0) {
+	    this.words = [ 0 ];
+	    this.length = 1;
+	    return this;
+	  }
+
+	  this.length = Math.ceil(number.length / 3);
+	  this.words = new Array(this.length);
+	  for (var i = 0; i < this.length; i++)
+	    this.words[i] = 0;
+
+	  var off = 0;
+	  if (endian === 'be') {
+	    for (var i = number.length - 1, j = 0; i >= 0; i -= 3) {
+	      var w = number[i] | (number[i - 1] << 8) | (number[i - 2] << 16);
+	      this.words[j] |= (w << off) & 0x3ffffff;
+	      this.words[j + 1] = (w >>> (26 - off)) & 0x3ffffff;
+	      off += 24;
+	      if (off >= 26) {
+	        off -= 26;
+	        j++;
+	      }
+	    }
+	  } else if (endian === 'le') {
+	    for (var i = 0, j = 0; i < number.length; i += 3) {
+	      var w = number[i] | (number[i + 1] << 8) | (number[i + 2] << 16);
+	      this.words[j] |= (w << off) & 0x3ffffff;
+	      this.words[j + 1] = (w >>> (26 - off)) & 0x3ffffff;
+	      off += 24;
+	      if (off >= 26) {
+	        off -= 26;
+	        j++;
+	      }
+	    }
+	  }
+	  return this.strip();
+	};
+
+	function parseHex(str, start, end) {
+	  var r = 0;
+	  var len = Math.min(str.length, end);
+	  for (var i = start; i < len; i++) {
+	    var c = str.charCodeAt(i) - 48;
+
+	    r <<= 4;
+
+	    // 'a' - 'f'
+	    if (c >= 49 && c <= 54)
+	      r |= c - 49 + 0xa;
+
+	    // 'A' - 'F'
+	    else if (c >= 17 && c <= 22)
+	      r |= c - 17 + 0xa;
+
+	    // '0' - '9'
+	    else
+	      r |= c & 0xf;
+	  }
+	  return r;
+	}
+
+	BN.prototype._parseHex = function _parseHex(number, start) {
+	  // Create possibly bigger array to ensure that it fits the number
+	  this.length = Math.ceil((number.length - start) / 6);
+	  this.words = new Array(this.length);
+	  for (var i = 0; i < this.length; i++)
+	    this.words[i] = 0;
+
+	  // Scan 24-bit chunks and add them to the number
+	  var off = 0;
+	  for (var i = number.length - 6, j = 0; i >= start; i -= 6) {
+	    var w = parseHex(number, i, i + 6);
+	    this.words[j] |= (w << off) & 0x3ffffff;
+	    this.words[j + 1] |= w >>> (26 - off) & 0x3fffff;
+	    off += 24;
+	    if (off >= 26) {
+	      off -= 26;
+	      j++;
+	    }
+	  }
+	  if (i + 6 !== start) {
+	    var w = parseHex(number, start, i + 6);
+	    this.words[j] |= (w << off) & 0x3ffffff;
+	    this.words[j + 1] |= w >>> (26 - off) & 0x3fffff;
+	  }
+	  this.strip();
+	};
+
+	function parseBase(str, start, end, mul) {
+	  var r = 0;
+	  var len = Math.min(str.length, end);
+	  for (var i = start; i < len; i++) {
+	    var c = str.charCodeAt(i) - 48;
+
+	    r *= mul;
+
+	    // 'a'
+	    if (c >= 49)
+	      r += c - 49 + 0xa;
+
+	    // 'A'
+	    else if (c >= 17)
+	      r += c - 17 + 0xa;
+
+	    // '0' - '9'
+	    else
+	      r += c;
+	  }
+	  return r;
+	}
+
+	BN.prototype._parseBase = function _parseBase(number, base, start) {
+	  // Initialize as zero
+	  this.words = [ 0 ];
+	  this.length = 1;
+
+	  // Find length of limb in base
+	  for (var limbLen = 0, limbPow = 1; limbPow <= 0x3ffffff; limbPow *= base)
+	    limbLen++;
+	  limbLen--;
+	  limbPow = (limbPow / base) | 0;
+
+	  var total = number.length - start;
+	  var mod = total % limbLen;
+	  var end = Math.min(total, total - mod) + start;
+
+	  var word = 0;
+	  for (var i = start; i < end; i += limbLen) {
+	    word = parseBase(number, i, i + limbLen, base);
+
+	    this.imuln(limbPow);
+	    if (this.words[0] + word < 0x4000000)
+	      this.words[0] += word;
+	    else
+	      this._iaddn(word);
+	  }
+
+	  if (mod !== 0) {
+	    var pow = 1;
+	    var word = parseBase(number, i, number.length, base);
+
+	    for (var i = 0; i < mod; i++)
+	      pow *= base;
+	    this.imuln(pow);
+	    if (this.words[0] + word < 0x4000000)
+	      this.words[0] += word;
+	    else
+	      this._iaddn(word);
+	  }
+	};
+
+	BN.prototype.copy = function copy(dest) {
+	  dest.words = new Array(this.length);
+	  for (var i = 0; i < this.length; i++)
+	    dest.words[i] = this.words[i];
+	  dest.length = this.length;
+	  dest.sign = this.sign;
+	  dest.red = this.red;
+	};
+
+	BN.prototype.clone = function clone() {
+	  var r = new BN(null);
+	  this.copy(r);
+	  return r;
+	};
+
+	// Remove leading `0` from `this`
+	BN.prototype.strip = function strip() {
+	  while (this.length > 1 && this.words[this.length - 1] === 0)
+	    this.length--;
+	  return this._normSign();
+	};
+
+	BN.prototype._normSign = function _normSign() {
+	  // -0 = 0
+	  if (this.length === 1 && this.words[0] === 0)
+	    this.sign = false;
+	  return this;
+	};
+
+	BN.prototype.inspect = function inspect() {
+	  return (this.red ? '<BN-R: ' : '<BN: ') + this.toString(16) + '>';
+	};
+
+	/*
+
+	var zeros = [];
+	var groupSizes = [];
+	var groupBases = [];
+
+	var s = '';
+	var i = -1;
+	while (++i < BN.wordSize) {
+	  zeros[i] = s;
+	  s += '0';
+	}
+	groupSizes[0] = 0;
+	groupSizes[1] = 0;
+	groupBases[0] = 0;
+	groupBases[1] = 0;
+	var base = 2 - 1;
+	while (++base < 36 + 1) {
+	  var groupSize = 0;
+	  var groupBase = 1;
+	  while (groupBase < (1 << BN.wordSize) / base) {
+	    groupBase *= base;
+	    groupSize += 1;
+	  }
+	  groupSizes[base] = groupSize;
+	  groupBases[base] = groupBase;
+	}
+
+	*/
+
+	var zeros = [
+	  '',
+	  '0',
+	  '00',
+	  '000',
+	  '0000',
+	  '00000',
+	  '000000',
+	  '0000000',
+	  '00000000',
+	  '000000000',
+	  '0000000000',
+	  '00000000000',
+	  '000000000000',
+	  '0000000000000',
+	  '00000000000000',
+	  '000000000000000',
+	  '0000000000000000',
+	  '00000000000000000',
+	  '000000000000000000',
+	  '0000000000000000000',
+	  '00000000000000000000',
+	  '000000000000000000000',
+	  '0000000000000000000000',
+	  '00000000000000000000000',
+	  '000000000000000000000000',
+	  '0000000000000000000000000'
+	];
+
+	var groupSizes = [
+	  0, 0,
+	  25, 16, 12, 11, 10, 9, 8,
+	  8, 7, 7, 7, 7, 6, 6,
+	  6, 6, 6, 6, 6, 5, 5,
+	  5, 5, 5, 5, 5, 5, 5,
+	  5, 5, 5, 5, 5, 5, 5
+	];
+
+	var groupBases = [
+	  0, 0,
+	  33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216,
+	  43046721, 10000000, 19487171, 35831808, 62748517, 7529536, 11390625,
+	  16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632,
+	  6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149,
+	  24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176
+	];
+
+	BN.prototype.toString = function toString(base, padding) {
+	  base = base || 10;
+	  var padding = padding | 0 || 1;
+	  if (base === 16 || base === 'hex') {
+	    var out = '';
+	    var off = 0;
+	    var carry = 0;
+	    for (var i = 0; i < this.length; i++) {
+	      var w = this.words[i];
+	      var word = (((w << off) | carry) & 0xffffff).toString(16);
+	      carry = (w >>> (24 - off)) & 0xffffff;
+	      if (carry !== 0 || i !== this.length - 1)
+	        out = zeros[6 - word.length] + word + out;
+	      else
+	        out = word + out;
+	      off += 2;
+	      if (off >= 26) {
+	        off -= 26;
+	        i--;
+	      }
+	    }
+	    if (carry !== 0)
+	      out = carry.toString(16) + out;
+	    while (out.length % padding !== 0)
+	      out = '0' + out;
+	    if (this.sign)
+	      out = '-' + out;
+	    return out;
+	  } else if (base === (base | 0) && base >= 2 && base <= 36) {
+	    // var groupSize = Math.floor(BN.wordSize * Math.LN2 / Math.log(base));
+	    var groupSize = groupSizes[base];
+	    // var groupBase = Math.pow(base, groupSize);
+	    var groupBase = groupBases[base];
+	    var out = '';
+	    var c = this.clone();
+	    c.sign = false;
+	    while (c.cmpn(0) !== 0) {
+	      var r = c.modn(groupBase).toString(base);
+	      c = c.idivn(groupBase);
+
+	      if (c.cmpn(0) !== 0)
+	        out = zeros[groupSize - r.length] + r + out;
+	      else
+	        out = r + out;
+	    }
+	    if (this.cmpn(0) === 0)
+	      out = '0' + out;
+	    while (out.length % padding !== 0)
+	      out = '0' + out;
+	    if (this.sign)
+	      out = '-' + out;
+	    return out;
+	  } else {
+	    assert(false, 'Base should be between 2 and 36');
+	  }
+	};
+
+	BN.prototype.toJSON = function toJSON() {
+	  return this.toString(16);
+	};
+
+	BN.prototype.toArray = function toArray(endian, length) {
+	  this.strip();
+	  var littleEndian = endian === 'le';
+	  var res = new Array(this.byteLength());
+	  res[0] = 0;
+
+	  var q = this.clone();
+	  if (!littleEndian) {
+	    // Assume big-endian
+	    for (var i = 0; q.cmpn(0) !== 0; i++) {
+	      var b = q.andln(0xff);
+	      q.iushrn(8);
+
+	      res[res.length - i - 1] = b;
+	    }
+	  } else {
+	    for (var i = 0; q.cmpn(0) !== 0; i++) {
+	      var b = q.andln(0xff);
+	      q.iushrn(8);
+
+	      res[i] = b;
+	    }
+	  }
+
+	  if (length) {
+	    assert(res.length <= length, 'byte array longer than desired length');
+
+	    while (res.length < length) {
+	      if (littleEndian)
+	        res.push(0);
+	      else
+	        res.unshift(0);
+	    }
+	  }
+
+	  return res;
+	};
+
+	if (Math.clz32) {
+	  BN.prototype._countBits = function _countBits(w) {
+	    return 32 - Math.clz32(w);
+	  };
+	} else {
+	  BN.prototype._countBits = function _countBits(w) {
+	    var t = w;
+	    var r = 0;
+	    if (t >= 0x1000) {
+	      r += 13;
+	      t >>>= 13;
+	    }
+	    if (t >= 0x40) {
+	      r += 7;
+	      t >>>= 7;
+	    }
+	    if (t >= 0x8) {
+	      r += 4;
+	      t >>>= 4;
+	    }
+	    if (t >= 0x02) {
+	      r += 2;
+	      t >>>= 2;
+	    }
+	    return r + t;
+	  };
+	}
+
+	BN.prototype._zeroBits = function _zeroBits(w) {
+	  // Short-cut
+	  if (w === 0)
+	    return 26;
+
+	  var t = w;
+	  var r = 0;
+	  if ((t & 0x1fff) === 0) {
+	    r += 13;
+	    t >>>= 13;
+	  }
+	  if ((t & 0x7f) === 0) {
+	    r += 7;
+	    t >>>= 7;
+	  }
+	  if ((t & 0xf) === 0) {
+	    r += 4;
+	    t >>>= 4;
+	  }
+	  if ((t & 0x3) === 0) {
+	    r += 2;
+	    t >>>= 2;
+	  }
+	  if ((t & 0x1) === 0)
+	    r++;
+	  return r;
+	};
+
+	// Return number of used bits in a BN
+	BN.prototype.bitLength = function bitLength() {
+	  var hi = 0;
+	  var w = this.words[this.length - 1];
+	  var hi = this._countBits(w);
+	  return (this.length - 1) * 26 + hi;
+	};
+
+	function toBitArray(num) {
+	  var w = new Array(num.bitLength());
+
+	  for (var bit = 0; bit < w.length; bit++) {
+	    var off = (bit / 26) | 0;
+	    var wbit = bit % 26;
+
+	    w[bit] = (num.words[off] & (1 << wbit)) >>> wbit;
+	  }
+
+	  return w;
+	}
+
+	// Number of trailing zero bits
+	BN.prototype.zeroBits = function zeroBits() {
+	  if (this.cmpn(0) === 0)
+	    return 0;
+
+	  var r = 0;
+	  for (var i = 0; i < this.length; i++) {
+	    var b = this._zeroBits(this.words[i]);
+	    r += b;
+	    if (b !== 26)
+	      break;
+	  }
+	  return r;
+	};
+
+	BN.prototype.byteLength = function byteLength() {
+	  return Math.ceil(this.bitLength() / 8);
+	};
+
+	// Return negative clone of `this`
+	BN.prototype.neg = function neg() {
+	  if (this.cmpn(0) === 0)
+	    return this.clone();
+
+	  var r = this.clone();
+	  r.sign = !this.sign;
+	  return r;
+	};
+
+
+	// Or `num` with `this` in-place
+	BN.prototype.iuor = function iuor(num) {
+	  while (this.length < num.length)
+	    this.words[this.length++] = 0;
+
+	  for (var i = 0; i < num.length; i++)
+	    this.words[i] = this.words[i] | num.words[i];
+
+	  return this.strip();
+	};
+
+	BN.prototype.ior = function ior(num) {
+	  assert(!this.sign && !num.sign);
+	  return this.iuor(num);
+	};
+
+
+	// Or `num` with `this`
+	BN.prototype.or = function or(num) {
+	  if (this.length > num.length)
+	    return this.clone().ior(num);
+	  else
+	    return num.clone().ior(this);
+	};
+
+	BN.prototype.uor = function uor(num) {
+	  if (this.length > num.length)
+	    return this.clone().iuor(num);
+	  else
+	    return num.clone().iuor(this);
+	};
+
+
+	// And `num` with `this` in-place
+	BN.prototype.iuand = function iuand(num) {
+	  // b = min-length(num, this)
+	  var b;
+	  if (this.length > num.length)
+	    b = num;
+	  else
+	    b = this;
+
+	  for (var i = 0; i < b.length; i++)
+	    this.words[i] = this.words[i] & num.words[i];
+
+	  this.length = b.length;
+
+	  return this.strip();
+	};
+
+	BN.prototype.iand = function iand(num) {
+	  assert(!this.sign && !num.sign);
+	  return this.iuand(num);
+	};
+
+
+	// And `num` with `this`
+	BN.prototype.and = function and(num) {
+	  if (this.length > num.length)
+	    return this.clone().iand(num);
+	  else
+	    return num.clone().iand(this);
+	};
+
+	BN.prototype.uand = function uand(num) {
+	  if (this.length > num.length)
+	    return this.clone().iuand(num);
+	  else
+	    return num.clone().iuand(this);
+	};
+
+
+	// Xor `num` with `this` in-place
+	BN.prototype.iuxor = function iuxor(num) {
+	  // a.length > b.length
+	  var a;
+	  var b;
+	  if (this.length > num.length) {
+	    a = this;
+	    b = num;
+	  } else {
+	    a = num;
+	    b = this;
+	  }
+
+	  for (var i = 0; i < b.length; i++)
+	    this.words[i] = a.words[i] ^ b.words[i];
+
+	  if (this !== a)
+	    for (; i < a.length; i++)
+	      this.words[i] = a.words[i];
+
+	  this.length = a.length;
+
+	  return this.strip();
+	};
+
+	BN.prototype.ixor = function ixor(num) {
+	  assert(!this.sign && !num.sign);
+	  return this.iuxor(num);
+	};
+
+
+	// Xor `num` with `this`
+	BN.prototype.xor = function xor(num) {
+	  if (this.length > num.length)
+	    return this.clone().ixor(num);
+	  else
+	    return num.clone().ixor(this);
+	};
+
+	BN.prototype.uxor = function uxor(num) {
+	  if (this.length > num.length)
+	    return this.clone().iuxor(num);
+	  else
+	    return num.clone().iuxor(this);
+	};
+
+
+	// Set `bit` of `this`
+	BN.prototype.setn = function setn(bit, val) {
+	  assert(typeof bit === 'number' && bit >= 0);
+
+	  var off = (bit / 26) | 0;
+	  var wbit = bit % 26;
+
+	  while (this.length <= off)
+	    this.words[this.length++] = 0;
+
+	  if (val)
+	    this.words[off] = this.words[off] | (1 << wbit);
+	  else
+	    this.words[off] = this.words[off] & ~(1 << wbit);
+
+	  return this.strip();
+	};
+
+
+	// Add `num` to `this` in-place
+	BN.prototype.iadd = function iadd(num) {
+	  // negative + positive
+	  if (this.sign && !num.sign) {
+	    this.sign = false;
+	    var r = this.isub(num);
+	    this.sign = !this.sign;
+	    return this._normSign();
+
+	  // positive + negative
+	  } else if (!this.sign && num.sign) {
+	    num.sign = false;
+	    var r = this.isub(num);
+	    num.sign = true;
+	    return r._normSign();
+	  }
+
+	  // a.length > b.length
+	  var a;
+	  var b;
+	  if (this.length > num.length) {
+	    a = this;
+	    b = num;
+	  } else {
+	    a = num;
+	    b = this;
+	  }
+
+	  var carry = 0;
+	  for (var i = 0; i < b.length; i++) {
+	    var r = a.words[i] + b.words[i] + carry;
+	    this.words[i] = r & 0x3ffffff;
+	    carry = r >>> 26;
+	  }
+	  for (; carry !== 0 && i < a.length; i++) {
+	    var r = a.words[i] + carry;
+	    this.words[i] = r & 0x3ffffff;
+	    carry = r >>> 26;
+	  }
+
+	  this.length = a.length;
+	  if (carry !== 0) {
+	    this.words[this.length] = carry;
+	    this.length++;
+	  // Copy the rest of the words
+	  } else if (a !== this) {
+	    for (; i < a.length; i++)
+	      this.words[i] = a.words[i];
+	  }
+
+	  return this;
+	};
+
+	// Add `num` to `this`
+	BN.prototype.add = function add(num) {
+	  if (num.sign && !this.sign) {
+	    num.sign = false;
+	    var res = this.sub(num);
+	    num.sign = true;
+	    return res;
+	  } else if (!num.sign && this.sign) {
+	    this.sign = false;
+	    var res = num.sub(this);
+	    this.sign = true;
+	    return res;
+	  }
+
+	  if (this.length > num.length)
+	    return this.clone().iadd(num);
+	  else
+	    return num.clone().iadd(this);
+	};
+
+	// Subtract `num` from `this` in-place
+	BN.prototype.isub = function isub(num) {
+	  // this - (-num) = this + num
+	  if (num.sign) {
+	    num.sign = false;
+	    var r = this.iadd(num);
+	    num.sign = true;
+	    return r._normSign();
+
+	  // -this - num = -(this + num)
+	  } else if (this.sign) {
+	    this.sign = false;
+	    this.iadd(num);
+	    this.sign = true;
+	    return this._normSign();
+	  }
+
+	  // At this point both numbers are positive
+	  var cmp = this.cmp(num);
+
+	  // Optimization - zeroify
+	  if (cmp === 0) {
+	    this.sign = false;
+	    this.length = 1;
+	    this.words[0] = 0;
+	    return this;
+	  }
+
+	  // a > b
+	  var a;
+	  var b;
+	  if (cmp > 0) {
+	    a = this;
+	    b = num;
+	  } else {
+	    a = num;
+	    b = this;
+	  }
+
+	  var carry = 0;
+	  for (var i = 0; i < b.length; i++) {
+	    var r = a.words[i] - b.words[i] + carry;
+	    carry = r >> 26;
+	    this.words[i] = r & 0x3ffffff;
+	  }
+	  for (; carry !== 0 && i < a.length; i++) {
+	    var r = a.words[i] + carry;
+	    carry = r >> 26;
+	    this.words[i] = r & 0x3ffffff;
+	  }
+
+	  // Copy rest of the words
+	  if (carry === 0 && i < a.length && a !== this)
+	    for (; i < a.length; i++)
+	      this.words[i] = a.words[i];
+	  this.length = Math.max(this.length, i);
+
+	  if (a !== this)
+	    this.sign = true;
+
+	  return this.strip();
+	};
+
+	// Subtract `num` from `this`
+	BN.prototype.sub = function sub(num) {
+	  return this.clone().isub(num);
+	};
+
+	/*
+	// NOTE: This could be potentionally used to generate loop-less multiplications
+	function _genCombMulTo(alen, blen) {
+	  var len = alen + blen - 1;
+	  var src = [
+	    'var a = this.words, b = num.words, o = out.words, c = 0, w, ' +
+	        'mask = 0x3ffffff, shift = 0x4000000;',
+	    'out.length = ' + len + ';'
+	  ];
+	  for (var k = 0; k < len; k++) {
+	    var minJ = Math.max(0, k - alen + 1);
+	    var maxJ = Math.min(k, blen - 1);
+
+	    for (var j = minJ; j <= maxJ; j++) {
+	      var i = k - j;
+	      var mul = 'a[' + i + '] * b[' + j + ']';
+
+	      if (j === minJ) {
+	        src.push('w = ' + mul + ' + c;');
+	        src.push('c = (w / shift) | 0;');
+	      } else {
+	        src.push('w += ' + mul + ';');
+	        src.push('c += (w / shift) | 0;');
+	      }
+	      src.push('w &= mask;');
+	    }
+	    src.push('o[' + k + '] = w;');
+	  }
+	  src.push('if (c !== 0) {',
+	           '  o[' + k + '] = c;',
+	           '  out.length++;',
+	           '}',
+	           'return out;');
+
+	  return src.join('\n');
+	}
+	*/
+
+	BN.prototype._smallMulTo = function _smallMulTo(num, out) {
+	  out.sign = num.sign !== this.sign;
+	  out.length = this.length + num.length;
+
+	  var carry = 0;
+	  for (var k = 0; k < out.length - 1; k++) {
+	    // Sum all words with the same `i + j = k` and accumulate `ncarry`,
+	    // note that ncarry could be >= 0x3ffffff
+	    var ncarry = carry >>> 26;
+	    var rword = carry & 0x3ffffff;
+	    var maxJ = Math.min(k, num.length - 1);
+	    for (var j = Math.max(0, k - this.length + 1); j <= maxJ; j++) {
+	      var i = k - j;
+	      var a = this.words[i] | 0;
+	      var b = num.words[j] | 0;
+	      var r = a * b;
+
+	      var lo = r & 0x3ffffff;
+	      ncarry = (ncarry + ((r / 0x4000000) | 0)) | 0;
+	      lo = (lo + rword) | 0;
+	      rword = lo & 0x3ffffff;
+	      ncarry = (ncarry + (lo >>> 26)) | 0;
+	    }
+	    out.words[k] = rword;
+	    carry = ncarry;
+	  }
+	  if (carry !== 0) {
+	    out.words[k] = carry;
+	  } else {
+	    out.length--;
+	  }
+
+	  return out.strip();
+	};
+
+	BN.prototype._bigMulTo = function _bigMulTo(num, out) {
+	  out.sign = num.sign !== this.sign;
+	  out.length = this.length + num.length;
+
+	  var carry = 0;
+	  var hncarry = 0;
+	  for (var k = 0; k < out.length - 1; k++) {
+	    // Sum all words with the same `i + j = k` and accumulate `ncarry`,
+	    // note that ncarry could be >= 0x3ffffff
+	    var ncarry = hncarry;
+	    hncarry = 0;
+	    var rword = carry & 0x3ffffff;
+	    var maxJ = Math.min(k, num.length - 1);
+	    for (var j = Math.max(0, k - this.length + 1); j <= maxJ; j++) {
+	      var i = k - j;
+	      var a = this.words[i] | 0;
+	      var b = num.words[j] | 0;
+	      var r = a * b;
+
+	      var lo = r & 0x3ffffff;
+	      ncarry = (ncarry + ((r / 0x4000000) | 0)) | 0;
+	      lo = (lo + rword) | 0;
+	      rword = lo & 0x3ffffff;
+	      ncarry = (ncarry + (lo >>> 26)) | 0;
+
+	      hncarry += ncarry >>> 26;
+	      ncarry &= 0x3ffffff;
+	    }
+	    out.words[k] = rword;
+	    carry = ncarry;
+	    ncarry = hncarry;
+	  }
+	  if (carry !== 0) {
+	    out.words[k] = carry;
+	  } else {
+	    out.length--;
+	  }
+
+	  return out.strip();
+	};
+
+	BN.prototype.mulTo = function mulTo(num, out) {
+	  var res;
+	  if (this.length + num.length < 63)
+	    res = this._smallMulTo(num, out);
+	  else
+	    res = this._bigMulTo(num, out);
+	  return res;
+	};
+
+	// Multiply `this` by `num`
+	BN.prototype.mul = function mul(num) {
+	  var out = new BN(null);
+	  out.words = new Array(this.length + num.length);
+	  return this.mulTo(num, out);
+	};
+
+	// In-place Multiplication
+	BN.prototype.imul = function imul(num) {
+	  if (this.cmpn(0) === 0 || num.cmpn(0) === 0) {
+	    this.words[0] = 0;
+	    this.length = 1;
+	    return this;
+	  }
+
+	  var tlen = this.length;
+	  var nlen = num.length;
+
+	  this.sign = num.sign !== this.sign;
+	  this.length = this.length + num.length;
+	  this.words[this.length - 1] = 0;
+
+	  for (var k = this.length - 2; k >= 0; k--) {
+	    // Sum all words with the same `i + j = k` and accumulate `carry`,
+	    // note that carry could be >= 0x3ffffff
+	    var carry = 0;
+	    var rword = 0;
+	    var maxJ = Math.min(k, nlen - 1);
+	    for (var j = Math.max(0, k - tlen + 1); j <= maxJ; j++) {
+	      var i = k - j;
+	      var a = this.words[i];
+	      var b = num.words[j];
+	      var r = a * b;
+
+	      var lo = r & 0x3ffffff;
+	      carry += (r / 0x4000000) | 0;
+	      lo += rword;
+	      rword = lo & 0x3ffffff;
+	      carry += lo >>> 26;
+	    }
+	    this.words[k] = rword;
+	    this.words[k + 1] += carry;
+	    carry = 0;
+	  }
+
+	  // Propagate overflows
+	  var carry = 0;
+	  for (var i = 1; i < this.length; i++) {
+	    var w = this.words[i] + carry;
+	    this.words[i] = w & 0x3ffffff;
+	    carry = w >>> 26;
+	  }
+
+	  return this.strip();
+	};
+
+	BN.prototype.imuln = function imuln(num) {
+	  assert(typeof num === 'number');
+
+	  // Carry
+	  var carry = 0;
+	  for (var i = 0; i < this.length; i++) {
+	    var w = this.words[i] * num;
+	    var lo = (w & 0x3ffffff) + (carry & 0x3ffffff);
+	    carry >>= 26;
+	    carry += (w / 0x4000000) | 0;
+	    // NOTE: lo is 27bit maximum
+	    carry += lo >>> 26;
+	    this.words[i] = lo & 0x3ffffff;
+	  }
+
+	  if (carry !== 0) {
+	    this.words[i] = carry;
+	    this.length++;
+	  }
+
+	  return this;
+	};
+
+	BN.prototype.muln = function muln(num) {
+	  return this.clone().imuln(num);
+	};
+
+	// `this` * `this`
+	BN.prototype.sqr = function sqr() {
+	  return this.mul(this);
+	};
+
+	// `this` * `this` in-place
+	BN.prototype.isqr = function isqr() {
+	  return this.mul(this);
+	};
+
+	// Math.pow(`this`, `num`)
+	BN.prototype.pow = function pow(num) {
+	  var w = toBitArray(num);
+	  if (w.length === 0)
+	    return new BN(1);
+
+	  // Skip leading zeroes
+	  var res = this;
+	  for (var i = 0; i < w.length; i++, res = res.sqr())
+	    if (w[i] !== 0)
+	      break;
+
+	  if (++i < w.length) {
+	    for (var q = res.sqr(); i < w.length; i++, q = q.sqr()) {
+	      if (w[i] === 0)
+	        continue;
+	      res = res.mul(q);
+	    }
+	  }
+
+	  return res;
+	};
+
+	// Shift-left in-place
+	BN.prototype.iushln = function iushln(bits) {
+	  assert(typeof bits === 'number' && bits >= 0);
+	  var r = bits % 26;
+	  var s = (bits - r) / 26;
+	  var carryMask = (0x3ffffff >>> (26 - r)) << (26 - r);
+
+	  if (r !== 0) {
+	    var carry = 0;
+	    for (var i = 0; i < this.length; i++) {
+	      var newCarry = this.words[i] & carryMask;
+	      var c = (this.words[i] - newCarry) << r;
+	      this.words[i] = c | carry;
+	      carry = newCarry >>> (26 - r);
+	    }
+	    if (carry) {
+	      this.words[i] = carry;
+	      this.length++;
+	    }
+	  }
+
+	  if (s !== 0) {
+	    for (var i = this.length - 1; i >= 0; i--)
+	      this.words[i + s] = this.words[i];
+	    for (var i = 0; i < s; i++)
+	      this.words[i] = 0;
+	    this.length += s;
+	  }
+
+	  return this.strip();
+	};
+
+	BN.prototype.ishln = function ishln(bits) {
+	  // TODO(indutny): implement me
+	  assert(!this.sign);
+	  return this.iushln(bits);
+	};
+
+	// Shift-right in-place
+	// NOTE: `hint` is a lowest bit before trailing zeroes
+	// NOTE: if `extended` is present - it will be filled with destroyed bits
+	BN.prototype.iushrn = function iushrn(bits, hint, extended) {
+	  assert(typeof bits === 'number' && bits >= 0);
+	  var h;
+	  if (hint)
+	    h = (hint - (hint % 26)) / 26;
+	  else
+	    h = 0;
+
+	  var r = bits % 26;
+	  var s = Math.min((bits - r) / 26, this.length);
+	  var mask = 0x3ffffff ^ ((0x3ffffff >>> r) << r);
+	  var maskedWords = extended;
+
+	  h -= s;
+	  h = Math.max(0, h);
+
+	  // Extended mode, copy masked part
+	  if (maskedWords) {
+	    for (var i = 0; i < s; i++)
+	      maskedWords.words[i] = this.words[i];
+	    maskedWords.length = s;
+	  }
+
+	  if (s === 0) {
+	    // No-op, we should not move anything at all
+	  } else if (this.length > s) {
+	    this.length -= s;
+	    for (var i = 0; i < this.length; i++)
+	      this.words[i] = this.words[i + s];
+	  } else {
+	    this.words[0] = 0;
+	    this.length = 1;
+	  }
+
+	  var carry = 0;
+	  for (var i = this.length - 1; i >= 0 && (carry !== 0 || i >= h); i--) {
+	    var word = this.words[i];
+	    this.words[i] = (carry << (26 - r)) | (word >>> r);
+	    carry = word & mask;
+	  }
+
+	  // Push carried bits as a mask
+	  if (maskedWords && carry !== 0)
+	    maskedWords.words[maskedWords.length++] = carry;
+
+	  if (this.length === 0) {
+	    this.words[0] = 0;
+	    this.length = 1;
+	  }
+
+	  this.strip();
+
+	  return this;
+	};
+
+	BN.prototype.ishrn = function ishrn(bits, hint, extended) {
+	  // TODO(indutny): implement me
+	  assert(!this.sign);
+	  return this.iushrn(bits, hint, extended);
+	};
+
+	// Shift-left
+	BN.prototype.shln = function shln(bits) {
+	  return this.clone().ishln(bits);
+	};
+
+	BN.prototype.ushln = function ushln(bits) {
+	  return this.clone().iushln(bits);
+	};
+
+	// Shift-right
+	BN.prototype.shrn = function shrn(bits) {
+	  return this.clone().ishrn(bits);
+	};
+
+	BN.prototype.ushrn = function ushrn(bits) {
+	  return this.clone().iushrn(bits);
+	};
+
+	// Test if n bit is set
+	BN.prototype.testn = function testn(bit) {
+	  assert(typeof bit === 'number' && bit >= 0);
+	  var r = bit % 26;
+	  var s = (bit - r) / 26;
+	  var q = 1 << r;
+
+	  // Fast case: bit is much higher than all existing words
+	  if (this.length <= s) {
+	    return false;
+	  }
+
+	  // Check bit and return
+	  var w = this.words[s];
+
+	  return !!(w & q);
+	};
+
+	// Return only lowers bits of number (in-place)
+	BN.prototype.imaskn = function imaskn(bits) {
+	  assert(typeof bits === 'number' && bits >= 0);
+	  var r = bits % 26;
+	  var s = (bits - r) / 26;
+
+	  assert(!this.sign, 'imaskn works only with positive numbers');
+
+	  if (r !== 0)
+	    s++;
+	  this.length = Math.min(s, this.length);
+
+	  if (r !== 0) {
+	    var mask = 0x3ffffff ^ ((0x3ffffff >>> r) << r);
+	    this.words[this.length - 1] &= mask;
+	  }
+
+	  return this.strip();
+	};
+
+	// Return only lowers bits of number
+	BN.prototype.maskn = function maskn(bits) {
+	  return this.clone().imaskn(bits);
+	};
+
+	// Add plain number `num` to `this`
+	BN.prototype.iaddn = function iaddn(num) {
+	  assert(typeof num === 'number');
+	  if (num < 0)
+	    return this.isubn(-num);
+
+	  // Possible sign change
+	  if (this.sign) {
+	    if (this.length === 1 && this.words[0] < num) {
+	      this.words[0] = num - this.words[0];
+	      this.sign = false;
+	      return this;
+	    }
+
+	    this.sign = false;
+	    this.isubn(num);
+	    this.sign = true;
+	    return this;
+	  }
+
+	  // Add without checks
+	  return this._iaddn(num);
+	};
+
+	BN.prototype._iaddn = function _iaddn(num) {
+	  this.words[0] += num;
+
+	  // Carry
+	  for (var i = 0; i < this.length && this.words[i] >= 0x4000000; i++) {
+	    this.words[i] -= 0x4000000;
+	    if (i === this.length - 1)
+	      this.words[i + 1] = 1;
+	    else
+	      this.words[i + 1]++;
+	  }
+	  this.length = Math.max(this.length, i + 1);
+
+	  return this;
+	};
+
+	// Subtract plain number `num` from `this`
+	BN.prototype.isubn = function isubn(num) {
+	  assert(typeof num === 'number');
+	  if (num < 0)
+	    return this.iaddn(-num);
+
+	  if (this.sign) {
+	    this.sign = false;
+	    this.iaddn(num);
+	    this.sign = true;
+	    return this;
+	  }
+
+	  this.words[0] -= num;
+
+	  // Carry
+	  for (var i = 0; i < this.length && this.words[i] < 0; i++) {
+	    this.words[i] += 0x4000000;
+	    this.words[i + 1] -= 1;
+	  }
+
+	  return this.strip();
+	};
+
+	BN.prototype.addn = function addn(num) {
+	  return this.clone().iaddn(num);
+	};
+
+	BN.prototype.subn = function subn(num) {
+	  return this.clone().isubn(num);
+	};
+
+	BN.prototype.iabs = function iabs() {
+	  this.sign = false;
+
+	  return this;
+	};
+
+	BN.prototype.abs = function abs() {
+	  return this.clone().iabs();
+	};
+
+	BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
+	  // Bigger storage is needed
+	  var len = num.length + shift;
+	  var i;
+	  if (this.words.length < len) {
+	    var t = new Array(len);
+	    for (var i = 0; i < this.length; i++)
+	      t[i] = this.words[i];
+	    this.words = t;
+	  } else {
+	    i = this.length;
+	  }
+
+	  // Zeroify rest
+	  this.length = Math.max(this.length, len);
+	  for (; i < this.length; i++)
+	    this.words[i] = 0;
+
+	  var carry = 0;
+	  for (var i = 0; i < num.length; i++) {
+	    var w = this.words[i + shift] + carry;
+	    var right = num.words[i] * mul;
+	    w -= right & 0x3ffffff;
+	    carry = (w >> 26) - ((right / 0x4000000) | 0);
+	    this.words[i + shift] = w & 0x3ffffff;
+	  }
+	  for (; i < this.length - shift; i++) {
+	    var w = this.words[i + shift] + carry;
+	    carry = w >> 26;
+	    this.words[i + shift] = w & 0x3ffffff;
+	  }
+
+	  if (carry === 0)
+	    return this.strip();
+
+	  // Subtraction overflow
+	  assert(carry === -1);
+	  carry = 0;
+	  for (var i = 0; i < this.length; i++) {
+	    var w = -this.words[i] + carry;
+	    carry = w >> 26;
+	    this.words[i] = w & 0x3ffffff;
+	  }
+	  this.sign = true;
+
+	  return this.strip();
+	};
+
+	BN.prototype._wordDiv = function _wordDiv(num, mode) {
+	  var shift = this.length - num.length;
+
+	  var a = this.clone();
+	  var b = num;
+
+	  // Normalize
+	  var bhi = b.words[b.length - 1];
+	  var bhiBits = this._countBits(bhi);
+	  shift = 26 - bhiBits;
+	  if (shift !== 0) {
+	    b = b.ushln(shift);
+	    a.iushln(shift);
+	    bhi = b.words[b.length - 1];
+	  }
+
+	  // Initialize quotient
+	  var m = a.length - b.length;
+	  var q;
+
+	  if (mode !== 'mod') {
+	    q = new BN(null);
+	    q.length = m + 1;
+	    q.words = new Array(q.length);
+	    for (var i = 0; i < q.length; i++)
+	      q.words[i] = 0;
+	  }
+
+	  var diff = a.clone()._ishlnsubmul(b, 1, m);
+	  if (!diff.sign) {
+	    a = diff;
+	    if (q)
+	      q.words[m] = 1;
+	  }
+
+	  for (var j = m - 1; j >= 0; j--) {
+	    var qj = a.words[b.length + j] * 0x4000000 + a.words[b.length + j - 1];
+
+	    // NOTE: (qj / bhi) is (0x3ffffff * 0x4000000 + 0x3ffffff) / 0x2000000 max
+	    // (0x7ffffff)
+	    qj = Math.min((qj / bhi) | 0, 0x3ffffff);
+
+	    a._ishlnsubmul(b, qj, j);
+	    while (a.sign) {
+	      qj--;
+	      a.sign = false;
+	      a._ishlnsubmul(b, 1, j);
+	      if (a.cmpn(0) !== 0)
+	        a.sign = !a.sign;
+	    }
+	    if (q)
+	      q.words[j] = qj;
+	  }
+	  if (q)
+	    q.strip();
+	  a.strip();
+
+	  // Denormalize
+	  if (mode !== 'div' && shift !== 0)
+	    a.iushrn(shift);
+	  return { div: q ? q : null, mod: a };
+	};
+
+	BN.prototype.divmod = function divmod(num, mode, positive) {
+	  assert(num.cmpn(0) !== 0);
+
+	  if (this.sign && !num.sign) {
+	    var res = this.neg().divmod(num, mode);
+	    var div;
+	    var mod;
+	    if (mode !== 'mod')
+	      div = res.div.neg();
+	    if (mode !== 'div') {
+	      mod = res.mod.neg();
+	      if (positive && mod.neg)
+	        mod = mod.add(num);
+	    }
+	    return {
+	      div: div,
+	      mod: mod
+	    };
+	  } else if (!this.sign && num.sign) {
+	    var res = this.divmod(num.neg(), mode);
+	    var div;
+	    if (mode !== 'mod')
+	      div = res.div.neg();
+	    return { div: div, mod: res.mod };
+	  } else if (this.sign && num.sign) {
+	    var res = this.neg().divmod(num.neg(), mode);
+	    var mod;
+	    if (mode !== 'div') {
+	      mod = res.mod.neg();
+	      if (positive && mod.neg)
+	        mod = mod.isub(num);
+	    }
+	    return {
+	      div: res.div,
+	      mod: mod
+	    };
+	  }
+
+	  // Both numbers are positive at this point
+
+	  // Strip both numbers to approximate shift value
+	  if (num.length > this.length || this.cmp(num) < 0)
+	    return { div: new BN(0), mod: this };
+
+	  // Very short reduction
+	  if (num.length === 1) {
+	    if (mode === 'div')
+	      return { div: this.divn(num.words[0]), mod: null };
+	    else if (mode === 'mod')
+	      return { div: null, mod: new BN(this.modn(num.words[0])) };
+	    return {
+	      div: this.divn(num.words[0]),
+	      mod: new BN(this.modn(num.words[0]))
+	    };
+	  }
+
+	  return this._wordDiv(num, mode);
+	};
+
+	// Find `this` / `num`
+	BN.prototype.div = function div(num) {
+	  return this.divmod(num, 'div', false).div;
+	};
+
+	// Find `this` % `num`
+	BN.prototype.mod = function mod(num) {
+	  return this.divmod(num, 'mod', false).mod;
+	};
+
+	BN.prototype.umod = function umod(num) {
+	  return this.divmod(num, 'mod', true).mod;
+	};
+
+	// Find Round(`this` / `num`)
+	BN.prototype.divRound = function divRound(num) {
+	  var dm = this.divmod(num);
+
+	  // Fast case - exact division
+	  if (dm.mod.cmpn(0) === 0)
+	    return dm.div;
+
+	  var mod = dm.div.sign ? dm.mod.isub(num) : dm.mod;
+
+	  var half = num.ushrn(1);
+	  var r2 = num.andln(1);
+	  var cmp = mod.cmp(half);
+
+	  // Round down
+	  if (cmp < 0 || r2 === 1 && cmp === 0)
+	    return dm.div;
+
+	  // Round up
+	  return dm.div.sign ? dm.div.isubn(1) : dm.div.iaddn(1);
+	};
+
+	BN.prototype.modn = function modn(num) {
+	  assert(num <= 0x3ffffff);
+	  var p = (1 << 26) % num;
+
+	  var acc = 0;
+	  for (var i = this.length - 1; i >= 0; i--)
+	    acc = (p * acc + this.words[i]) % num;
+
+	  return acc;
+	};
+
+	// In-place division by number
+	BN.prototype.idivn = function idivn(num) {
+	  assert(num <= 0x3ffffff);
+
+	  var carry = 0;
+	  for (var i = this.length - 1; i >= 0; i--) {
+	    var w = this.words[i] + carry * 0x4000000;
+	    this.words[i] = (w / num) | 0;
+	    carry = w % num;
+	  }
+
+	  return this.strip();
+	};
+
+	BN.prototype.divn = function divn(num) {
+	  return this.clone().idivn(num);
+	};
+
+	BN.prototype.egcd = function egcd(p) {
+	  assert(!p.sign);
+	  assert(p.cmpn(0) !== 0);
+
+	  var x = this;
+	  var y = p.clone();
+
+	  if (x.sign)
+	    x = x.umod(p);
+	  else
+	    x = x.clone();
+
+	  // A * x + B * y = x
+	  var A = new BN(1);
+	  var B = new BN(0);
+
+	  // C * x + D * y = y
+	  var C = new BN(0);
+	  var D = new BN(1);
+
+	  var g = 0;
+
+	  while (x.isEven() && y.isEven()) {
+	    x.iushrn(1);
+	    y.iushrn(1);
+	    ++g;
+	  }
+
+	  var yp = y.clone();
+	  var xp = x.clone();
+
+	  while (x.cmpn(0) !== 0) {
+	    while (x.isEven()) {
+	      x.iushrn(1);
+	      if (A.isEven() && B.isEven()) {
+	        A.iushrn(1);
+	        B.iushrn(1);
+	      } else {
+	        A.iadd(yp).iushrn(1);
+	        B.isub(xp).iushrn(1);
+	      }
+	    }
+
+	    while (y.isEven()) {
+	      y.iushrn(1);
+	      if (C.isEven() && D.isEven()) {
+	        C.iushrn(1);
+	        D.iushrn(1);
+	      } else {
+	        C.iadd(yp).iushrn(1);
+	        D.isub(xp).iushrn(1);
+	      }
+	    }
+
+	    if (x.cmp(y) >= 0) {
+	      x.isub(y);
+	      A.isub(C);
+	      B.isub(D);
+	    } else {
+	      y.isub(x);
+	      C.isub(A);
+	      D.isub(B);
+	    }
+	  }
+
+	  return {
+	    a: C,
+	    b: D,
+	    gcd: y.iushln(g)
+	  };
+	};
+
+	// This is reduced incarnation of the binary EEA
+	// above, designated to invert members of the
+	// _prime_ fields F(p) at a maximal speed
+	BN.prototype._invmp = function _invmp(p) {
+	  assert(!p.sign);
+	  assert(p.cmpn(0) !== 0);
+
+	  var a = this;
+	  var b = p.clone();
+
+	  if (a.sign)
+	    a = a.umod(p);
+	  else
+	    a = a.clone();
+
+	  var x1 = new BN(1);
+	  var x2 = new BN(0);
+
+	  var delta = b.clone();
+
+	  while (a.cmpn(1) > 0 && b.cmpn(1) > 0) {
+	    while (a.isEven()) {
+	      a.iushrn(1);
+	      if (x1.isEven())
+	        x1.iushrn(1);
+	      else
+	        x1.iadd(delta).iushrn(1);
+	    }
+	    while (b.isEven()) {
+	      b.iushrn(1);
+	      if (x2.isEven())
+	        x2.iushrn(1);
+	      else
+	        x2.iadd(delta).iushrn(1);
+	    }
+	    if (a.cmp(b) >= 0) {
+	      a.isub(b);
+	      x1.isub(x2);
+	    } else {
+	      b.isub(a);
+	      x2.isub(x1);
+	    }
+	  }
+
+	  var res;
+	  if (a.cmpn(1) === 0)
+	    res = x1;
+	  else
+	    res = x2;
+
+	  if (res.cmpn(0) < 0)
+	    res.iadd(p);
+
+	  return res;
+	};
+
+	BN.prototype.gcd = function gcd(num) {
+	  if (this.cmpn(0) === 0)
+	    return num.clone();
+	  if (num.cmpn(0) === 0)
+	    return this.clone();
+
+	  var a = this.clone();
+	  var b = num.clone();
+	  a.sign = false;
+	  b.sign = false;
+
+	  // Remove common factor of two
+	  for (var shift = 0; a.isEven() && b.isEven(); shift++) {
+	    a.iushrn(1);
+	    b.iushrn(1);
+	  }
+
+	  do {
+	    while (a.isEven())
+	      a.iushrn(1);
+	    while (b.isEven())
+	      b.iushrn(1);
+
+	    var r = a.cmp(b);
+	    if (r < 0) {
+	      // Swap `a` and `b` to make `a` always bigger than `b`
+	      var t = a;
+	      a = b;
+	      b = t;
+	    } else if (r === 0 || b.cmpn(1) === 0) {
+	      break;
+	    }
+
+	    a.isub(b);
+	  } while (true);
+
+	  return b.iushln(shift);
+	};
+
+	// Invert number in the field F(num)
+	BN.prototype.invm = function invm(num) {
+	  return this.egcd(num).a.umod(num);
+	};
+
+	BN.prototype.isEven = function isEven() {
+	  return (this.words[0] & 1) === 0;
+	};
+
+	BN.prototype.isOdd = function isOdd() {
+	  return (this.words[0] & 1) === 1;
+	};
+
+	// And first word and num
+	BN.prototype.andln = function andln(num) {
+	  return this.words[0] & num;
+	};
+
+	// Increment at the bit position in-line
+	BN.prototype.bincn = function bincn(bit) {
+	  assert(typeof bit === 'number');
+	  var r = bit % 26;
+	  var s = (bit - r) / 26;
+	  var q = 1 << r;
+
+	  // Fast case: bit is much higher than all existing words
+	  if (this.length <= s) {
+	    for (var i = this.length; i < s + 1; i++)
+	      this.words[i] = 0;
+	    this.words[s] |= q;
+	    this.length = s + 1;
+	    return this;
+	  }
+
+	  // Add bit and propagate, if needed
+	  var carry = q;
+	  for (var i = s; carry !== 0 && i < this.length; i++) {
+	    var w = this.words[i];
+	    w += carry;
+	    carry = w >>> 26;
+	    w &= 0x3ffffff;
+	    this.words[i] = w;
+	  }
+	  if (carry !== 0) {
+	    this.words[i] = carry;
+	    this.length++;
+	  }
+	  return this;
+	};
+
+	BN.prototype.cmpn = function cmpn(num) {
+	  var sign = num < 0;
+	  if (sign)
+	    num = -num;
+
+	  if (this.sign && !sign)
+	    return -1;
+	  else if (!this.sign && sign)
+	    return 1;
+
+	  num &= 0x3ffffff;
+	  this.strip();
+
+	  var res;
+	  if (this.length > 1) {
+	    res = 1;
+	  } else {
+	    var w = this.words[0];
+	    res = w === num ? 0 : w < num ? -1 : 1;
+	  }
+	  if (this.sign)
+	    res = -res;
+	  return res;
+	};
+
+	// Compare two numbers and return:
+	// 1 - if `this` > `num`
+	// 0 - if `this` == `num`
+	// -1 - if `this` < `num`
+	BN.prototype.cmp = function cmp(num) {
+	  if (this.sign && !num.sign)
+	    return -1;
+	  else if (!this.sign && num.sign)
+	    return 1;
+
+	  var res = this.ucmp(num);
+	  if (this.sign)
+	    return -res;
+	  else
+	    return res;
+	};
+
+	// Unsigned comparison
+	BN.prototype.ucmp = function ucmp(num) {
+	  // At this point both numbers have the same sign
+	  if (this.length > num.length)
+	    return 1;
+	  else if (this.length < num.length)
+	    return -1;
+
+	  var res = 0;
+	  for (var i = this.length - 1; i >= 0; i--) {
+	    var a = this.words[i];
+	    var b = num.words[i];
+
+	    if (a === b)
+	      continue;
+	    if (a < b)
+	      res = -1;
+	    else if (a > b)
+	      res = 1;
+	    break;
+	  }
+	  return res;
+	};
+
+	//
+	// A reduce context, could be using montgomery or something better, depending
+	// on the `m` itself.
+	//
+	BN.red = function red(num) {
+	  return new Red(num);
+	};
+
+	BN.prototype.toRed = function toRed(ctx) {
+	  assert(!this.red, 'Already a number in reduction context');
+	  assert(!this.sign, 'red works only with positives');
+	  return ctx.convertTo(this)._forceRed(ctx);
+	};
+
+	BN.prototype.fromRed = function fromRed() {
+	  assert(this.red, 'fromRed works only with numbers in reduction context');
+	  return this.red.convertFrom(this);
+	};
+
+	BN.prototype._forceRed = function _forceRed(ctx) {
+	  this.red = ctx;
+	  return this;
+	};
+
+	BN.prototype.forceRed = function forceRed(ctx) {
+	  assert(!this.red, 'Already a number in reduction context');
+	  return this._forceRed(ctx);
+	};
+
+	BN.prototype.redAdd = function redAdd(num) {
+	  assert(this.red, 'redAdd works only with red numbers');
+	  return this.red.add(this, num);
+	};
+
+	BN.prototype.redIAdd = function redIAdd(num) {
+	  assert(this.red, 'redIAdd works only with red numbers');
+	  return this.red.iadd(this, num);
+	};
+
+	BN.prototype.redSub = function redSub(num) {
+	  assert(this.red, 'redSub works only with red numbers');
+	  return this.red.sub(this, num);
+	};
+
+	BN.prototype.redISub = function redISub(num) {
+	  assert(this.red, 'redISub works only with red numbers');
+	  return this.red.isub(this, num);
+	};
+
+	BN.prototype.redShl = function redShl(num) {
+	  assert(this.red, 'redShl works only with red numbers');
+	  return this.red.ushl(this, num);
+	};
+
+	BN.prototype.redMul = function redMul(num) {
+	  assert(this.red, 'redMul works only with red numbers');
+	  this.red._verify2(this, num);
+	  return this.red.mul(this, num);
+	};
+
+	BN.prototype.redIMul = function redIMul(num) {
+	  assert(this.red, 'redMul works only with red numbers');
+	  this.red._verify2(this, num);
+	  return this.red.imul(this, num);
+	};
+
+	BN.prototype.redSqr = function redSqr() {
+	  assert(this.red, 'redSqr works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.sqr(this);
+	};
+
+	BN.prototype.redISqr = function redISqr() {
+	  assert(this.red, 'redISqr works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.isqr(this);
+	};
+
+	// Square root over p
+	BN.prototype.redSqrt = function redSqrt() {
+	  assert(this.red, 'redSqrt works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.sqrt(this);
+	};
+
+	BN.prototype.redInvm = function redInvm() {
+	  assert(this.red, 'redInvm works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.invm(this);
+	};
+
+	// Return negative clone of `this` % `red modulo`
+	BN.prototype.redNeg = function redNeg() {
+	  assert(this.red, 'redNeg works only with red numbers');
+	  this.red._verify1(this);
+	  return this.red.neg(this);
+	};
+
+	BN.prototype.redPow = function redPow(num) {
+	  assert(this.red && !num.red, 'redPow(normalNum)');
+	  this.red._verify1(this);
+	  return this.red.pow(this, num);
+	};
+
+	// Prime numbers with efficient reduction
+	var primes = {
+	  k256: null,
+	  p224: null,
+	  p192: null,
+	  p25519: null
+	};
+
+	// Pseudo-Mersenne prime
+	function MPrime(name, p) {
+	  // P = 2 ^ N - K
+	  this.name = name;
+	  this.p = new BN(p, 16);
+	  this.n = this.p.bitLength();
+	  this.k = new BN(1).iushln(this.n).isub(this.p);
+
+	  this.tmp = this._tmp();
+	}
+
+	MPrime.prototype._tmp = function _tmp() {
+	  var tmp = new BN(null);
+	  tmp.words = new Array(Math.ceil(this.n / 13));
+	  return tmp;
+	};
+
+	MPrime.prototype.ireduce = function ireduce(num) {
+	  // Assumes that `num` is less than `P^2`
+	  // num = HI * (2 ^ N - K) + HI * K + LO = HI * K + LO (mod P)
+	  var r = num;
+	  var rlen;
+
+	  do {
+	    this.split(r, this.tmp);
+	    r = this.imulK(r);
+	    r = r.iadd(this.tmp);
+	    rlen = r.bitLength();
+	  } while (rlen > this.n);
+
+	  var cmp = rlen < this.n ? -1 : r.ucmp(this.p);
+	  if (cmp === 0) {
+	    r.words[0] = 0;
+	    r.length = 1;
+	  } else if (cmp > 0) {
+	    r.isub(this.p);
+	  } else {
+	    r.strip();
+	  }
+
+	  return r;
+	};
+
+	MPrime.prototype.split = function split(input, out) {
+	  input.iushrn(this.n, 0, out);
+	};
+
+	MPrime.prototype.imulK = function imulK(num) {
+	  return num.imul(this.k);
+	};
+
+	function K256() {
+	  MPrime.call(
+	    this,
+	    'k256',
+	    'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f');
+	}
+	inherits(K256, MPrime);
+
+	K256.prototype.split = function split(input, output) {
+	  // 256 = 9 * 26 + 22
+	  var mask = 0x3fffff;
+
+	  var outLen = Math.min(input.length, 9);
+	  for (var i = 0; i < outLen; i++)
+	    output.words[i] = input.words[i];
+	  output.length = outLen;
+
+	  if (input.length <= 9) {
+	    input.words[0] = 0;
+	    input.length = 1;
+	    return;
+	  }
+
+	  // Shift by 9 limbs
+	  var prev = input.words[9];
+	  output.words[output.length++] = prev & mask;
+
+	  for (var i = 10; i < input.length; i++) {
+	    var next = input.words[i];
+	    input.words[i - 10] = ((next & mask) << 4) | (prev >>> 22);
+	    prev = next;
+	  }
+	  input.words[i - 10] = prev >>> 22;
+	  input.length -= 9;
+	};
+
+	K256.prototype.imulK = function imulK(num) {
+	  // K = 0x1000003d1 = [ 0x40, 0x3d1 ]
+	  num.words[num.length] = 0;
+	  num.words[num.length + 1] = 0;
+	  num.length += 2;
+
+	  // bounded at: 0x40 * 0x3ffffff + 0x3d0 = 0x100000390
+	  var hi;
+	  var lo = 0;
+	  for (var i = 0; i < num.length; i++) {
+	    var w = num.words[i];
+	    hi = w * 0x40;
+	    lo += w * 0x3d1;
+	    hi += (lo / 0x4000000) | 0;
+	    lo &= 0x3ffffff;
+
+	    num.words[i] = lo;
+
+	    lo = hi;
+	  }
+
+	  // Fast length reduction
+	  if (num.words[num.length - 1] === 0) {
+	    num.length--;
+	    if (num.words[num.length - 1] === 0)
+	      num.length--;
+	  }
+	  return num;
+	};
+
+	function P224() {
+	  MPrime.call(
+	    this,
+	    'p224',
+	    'ffffffff ffffffff ffffffff ffffffff 00000000 00000000 00000001');
+	}
+	inherits(P224, MPrime);
+
+	function P192() {
+	  MPrime.call(
+	    this,
+	    'p192',
+	    'ffffffff ffffffff ffffffff fffffffe ffffffff ffffffff');
+	}
+	inherits(P192, MPrime);
+
+	function P25519() {
+	  // 2 ^ 255 - 19
+	  MPrime.call(
+	    this,
+	    '25519',
+	    '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed');
+	}
+	inherits(P25519, MPrime);
+
+	P25519.prototype.imulK = function imulK(num) {
+	  // K = 0x13
+	  var carry = 0;
+	  for (var i = 0; i < num.length; i++) {
+	    var hi = num.words[i] * 0x13 + carry;
+	    var lo = hi & 0x3ffffff;
+	    hi >>>= 26;
+
+	    num.words[i] = lo;
+	    carry = hi;
+	  }
+	  if (carry !== 0)
+	    num.words[num.length++] = carry;
+	  return num;
+	};
+
+	// Exported mostly for testing purposes, use plain name instead
+	BN._prime = function prime(name) {
+	  // Cached version of prime
+	  if (primes[name])
+	    return primes[name];
+
+	  var prime;
+	  if (name === 'k256')
+	    prime = new K256();
+	  else if (name === 'p224')
+	    prime = new P224();
+	  else if (name === 'p192')
+	    prime = new P192();
+	  else if (name === 'p25519')
+	    prime = new P25519();
+	  else
+	    throw new Error('Unknown prime ' + name);
+	  primes[name] = prime;
+
+	  return prime;
+	};
+
+	//
+	// Base reduction engine
+	//
+	function Red(m) {
+	  if (typeof m === 'string') {
+	    var prime = BN._prime(m);
+	    this.m = prime.p;
+	    this.prime = prime;
+	  } else {
+	    this.m = m;
+	    this.prime = null;
+	  }
+	}
+
+	Red.prototype._verify1 = function _verify1(a) {
+	  assert(!a.sign, 'red works only with positives');
+	  assert(a.red, 'red works only with red numbers');
+	};
+
+	Red.prototype._verify2 = function _verify2(a, b) {
+	  assert(!a.sign && !b.sign, 'red works only with positives');
+	  assert(a.red && a.red === b.red,
+	         'red works only with red numbers');
+	};
+
+	Red.prototype.imod = function imod(a) {
+	  if (this.prime)
+	    return this.prime.ireduce(a)._forceRed(this);
+	  return a.umod(this.m)._forceRed(this);
+	};
+
+	Red.prototype.neg = function neg(a) {
+	  var r = a.clone();
+	  r.sign = !r.sign;
+	  return r.iadd(this.m)._forceRed(this);
+	};
+
+	Red.prototype.add = function add(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.add(b);
+	  if (res.cmp(this.m) >= 0)
+	    res.isub(this.m);
+	  return res._forceRed(this);
+	};
+
+	Red.prototype.iadd = function iadd(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.iadd(b);
+	  if (res.cmp(this.m) >= 0)
+	    res.isub(this.m);
+	  return res;
+	};
+
+	Red.prototype.sub = function sub(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.sub(b);
+	  if (res.cmpn(0) < 0)
+	    res.iadd(this.m);
+	  return res._forceRed(this);
+	};
+
+	Red.prototype.isub = function isub(a, b) {
+	  this._verify2(a, b);
+
+	  var res = a.isub(b);
+	  if (res.cmpn(0) < 0)
+	    res.iadd(this.m);
+	  return res;
+	};
+
+	Red.prototype.shl = function shl(a, num) {
+	  this._verify1(a);
+	  return this.imod(a.ushln(num));
+	};
+
+	Red.prototype.imul = function imul(a, b) {
+	  this._verify2(a, b);
+	  return this.imod(a.imul(b));
+	};
+
+	Red.prototype.mul = function mul(a, b) {
+	  this._verify2(a, b);
+	  return this.imod(a.mul(b));
+	};
+
+	Red.prototype.isqr = function isqr(a) {
+	  return this.imul(a, a);
+	};
+
+	Red.prototype.sqr = function sqr(a) {
+	  return this.mul(a, a);
+	};
+
+	Red.prototype.sqrt = function sqrt(a) {
+	  if (a.cmpn(0) === 0)
+	    return a.clone();
+
+	  var mod3 = this.m.andln(3);
+	  assert(mod3 % 2 === 1);
+
+	  // Fast case
+	  if (mod3 === 3) {
+	    var pow = this.m.add(new BN(1)).iushrn(2);
+	    var r = this.pow(a, pow);
+	    return r;
+	  }
+
+	  // Tonelli-Shanks algorithm (Totally unoptimized and slow)
+	  //
+	  // Find Q and S, that Q * 2 ^ S = (P - 1)
+	  var q = this.m.subn(1);
+	  var s = 0;
+	  while (q.cmpn(0) !== 0 && q.andln(1) === 0) {
+	    s++;
+	    q.iushrn(1);
+	  }
+	  assert(q.cmpn(0) !== 0);
+
+	  var one = new BN(1).toRed(this);
+	  var nOne = one.redNeg();
+
+	  // Find quadratic non-residue
+	  // NOTE: Max is such because of generalized Riemann hypothesis.
+	  var lpow = this.m.subn(1).iushrn(1);
+	  var z = this.m.bitLength();
+	  z = new BN(2 * z * z).toRed(this);
+	  while (this.pow(z, lpow).cmp(nOne) !== 0)
+	    z.redIAdd(nOne);
+
+	  var c = this.pow(z, q);
+	  var r = this.pow(a, q.addn(1).iushrn(1));
+	  var t = this.pow(a, q);
+	  var m = s;
+	  while (t.cmp(one) !== 0) {
+	    var tmp = t;
+	    for (var i = 0; tmp.cmp(one) !== 0; i++)
+	      tmp = tmp.redSqr();
+	    assert(i < m);
+	    var b = this.pow(c, new BN(1).iushln(m - i - 1));
+
+	    r = r.redMul(b);
+	    c = b.redSqr();
+	    t = t.redMul(c);
+	    m = i;
+	  }
+
+	  return r;
+	};
+
+	Red.prototype.invm = function invm(a) {
+	  var inv = a._invmp(this.m);
+	  if (inv.sign) {
+	    inv.sign = false;
+	    return this.imod(inv).redNeg();
+	  } else {
+	    return this.imod(inv);
+	  }
+	};
+
+	Red.prototype.pow = function pow(a, num) {
+	  var w = toBitArray(num);
+	  if (w.length === 0)
+	    return new BN(1);
+
+	  // Skip leading zeroes
+	  var res = a;
+	  for (var i = 0; i < w.length; i++, res = this.sqr(res))
+	    if (w[i] !== 0)
+	      break;
+
+	  if (++i < w.length) {
+	    for (var q = this.sqr(res); i < w.length; i++, q = this.sqr(q)) {
+	      if (w[i] === 0)
+	        continue;
+	      res = this.mul(res, q);
+	    }
+	  }
+
+	  return res;
+	};
+
+	Red.prototype.convertTo = function convertTo(num) {
+	  var r = num.umod(this.m);
+	  if (r === num)
+	    return r.clone();
+	  else
+	    return r;
+	};
+
+	Red.prototype.convertFrom = function convertFrom(num) {
+	  var res = num.clone();
+	  res.red = null;
+	  return res;
+	};
+
+	//
+	// Montgomery method engine
+	//
+
+	BN.mont = function mont(num) {
+	  return new Mont(num);
+	};
+
+	function Mont(m) {
+	  Red.call(this, m);
+
+	  this.shift = this.m.bitLength();
+	  if (this.shift % 26 !== 0)
+	    this.shift += 26 - (this.shift % 26);
+	  this.r = new BN(1).iushln(this.shift);
+	  this.r2 = this.imod(this.r.sqr());
+	  this.rinv = this.r._invmp(this.m);
+
+	  this.minv = this.rinv.mul(this.r).isubn(1).div(this.m);
+	  this.minv = this.minv.umod(this.r);
+	  this.minv = this.r.sub(this.minv);
+	}
+	inherits(Mont, Red);
+
+	Mont.prototype.convertTo = function convertTo(num) {
+	  return this.imod(num.ushln(this.shift));
+	};
+
+	Mont.prototype.convertFrom = function convertFrom(num) {
+	  var r = this.imod(num.mul(this.rinv));
+	  r.red = null;
+	  return r;
+	};
+
+	Mont.prototype.imul = function imul(a, b) {
+	  if (a.cmpn(0) === 0 || b.cmpn(0) === 0) {
+	    a.words[0] = 0;
+	    a.length = 1;
+	    return a;
+	  }
+
+	  var t = a.imul(b);
+	  var c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m);
+	  var u = t.isub(c).iushrn(this.shift);
+	  var res = u;
+	  if (u.cmp(this.m) >= 0)
+	    res = u.isub(this.m);
+	  else if (u.cmpn(0) < 0)
+	    res = u.iadd(this.m);
+
+	  return res._forceRed(this);
+	};
+
+	Mont.prototype.mul = function mul(a, b) {
+	  if (a.cmpn(0) === 0 || b.cmpn(0) === 0)
+	    return new BN(0)._forceRed(this);
+
+	  var t = a.mul(b);
+	  var c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m);
+	  var u = t.isub(c).iushrn(this.shift);
+	  var res = u;
+	  if (u.cmp(this.m) >= 0)
+	    res = u.isub(this.m);
+	  else if (u.cmpn(0) < 0)
+	    res = u.iadd(this.m);
+
+	  return res._forceRed(this);
+	};
+
+	Mont.prototype.invm = function invm(a) {
+	  // (AR)^-1 * R^2 = (A^-1 * R^-1) * R^2 = A^-1 * R
+	  var res = this.imod(a._invmp(this.m).mul(this.r2));
+	  return res._forceRed(this);
+	};
+
+	})(typeof module === 'undefined' || module, this);
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(18)(module)))
+
+/***/ }),
+/* 120 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var elliptic = exports;
+
+	elliptic.version = __webpack_require__(121).version;
+	elliptic.utils = __webpack_require__(122);
+	elliptic.rand = __webpack_require__(22);
+	elliptic.hmacDRBG = __webpack_require__(123);
+	elliptic.curve = __webpack_require__(124);
+	elliptic.curves = __webpack_require__(129);
+
+	// Protocols
+	elliptic.ec = __webpack_require__(131);
+	elliptic.eddsa = __webpack_require__(134);
+
+
+/***/ }),
+/* 121 */
+/***/ (function(module, exports) {
+
+	module.exports = {
+		"name": "elliptic",
+		"version": "5.2.1",
+		"description": "EC cryptography",
+		"main": "lib/elliptic.js",
+		"scripts": {
+			"test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+			"coveralls": "cat ./coverage/lcov.info | coveralls"
+		},
+		"repository": {
+			"type": "git",
+			"url": "git@github.com:indutny/elliptic"
+		},
+		"keywords": [
+			"EC",
+			"Elliptic",
+			"curve",
+			"Cryptography"
+		],
+		"author": "Fedor Indutny <fedor@indutny.com>",
+		"license": "MIT",
+		"bugs": {
+			"url": "https://github.com/indutny/elliptic/issues"
+		},
+		"homepage": "https://github.com/indutny/elliptic",
+		"devDependencies": {
+			"browserify": "^3.44.2",
+			"coveralls": "^2.11.3",
+			"istanbul": "^0.3.17",
+			"jscs": "^1.11.3",
+			"jshint": "^2.6.0",
+			"mocha": "^2.1.0",
+			"uglify-js": "^2.4.13"
+		},
+		"dependencies": {
+			"bn.js": "^3.1.1",
+			"brorand": "^1.0.1",
+			"hash.js": "^1.0.0",
+			"inherits": "^2.0.1"
+		}
+	};
+
+/***/ }),
+/* 122 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var utils = exports;
+	var bn = __webpack_require__(119);
+
+	utils.assert = function assert(val, msg) {
+	  if (!val)
+	    throw new Error(msg || 'Assertion failed');
+	};
+
+	function toArray(msg, enc) {
+	  if (Array.isArray(msg))
+	    return msg.slice();
+	  if (!msg)
+	    return [];
+	  var res = [];
+	  if (typeof msg !== 'string') {
+	    for (var i = 0; i < msg.length; i++)
+	      res[i] = msg[i] | 0;
+	    return res;
+	  }
+	  if (!enc) {
+	    for (var i = 0; i < msg.length; i++) {
+	      var c = msg.charCodeAt(i);
+	      var hi = c >> 8;
+	      var lo = c & 0xff;
+	      if (hi)
+	        res.push(hi, lo);
+	      else
+	        res.push(lo);
+	    }
+	  } else if (enc === 'hex') {
+	    msg = msg.replace(/[^a-z0-9]+/ig, '');
+	    if (msg.length % 2 !== 0)
+	      msg = '0' + msg;
+	    for (var i = 0; i < msg.length; i += 2)
+	      res.push(parseInt(msg[i] + msg[i + 1], 16));
+	  }
+	  return res;
+	}
+	utils.toArray = toArray;
+
+	function zero2(word) {
+	  if (word.length === 1)
+	    return '0' + word;
+	  else
+	    return word;
+	}
+	utils.zero2 = zero2;
+
+	function toHex(msg) {
+	  var res = '';
+	  for (var i = 0; i < msg.length; i++)
+	    res += zero2(msg[i].toString(16));
+	  return res;
+	}
+	utils.toHex = toHex;
+
+	utils.encode = function encode(arr, enc) {
+	  if (enc === 'hex')
+	    return toHex(arr);
+	  else
+	    return arr;
+	};
+
+	// Represent num in a w-NAF form
+	function getNAF(num, w) {
+	  var naf = [];
+	  var ws = 1 << (w + 1);
+	  var k = num.clone();
+	  while (k.cmpn(1) >= 0) {
+	    var z;
+	    if (k.isOdd()) {
+	      var mod = k.andln(ws - 1);
+	      if (mod > (ws >> 1) - 1)
+	        z = (ws >> 1) - mod;
+	      else
+	        z = mod;
+	      k.isubn(z);
+	    } else {
+	      z = 0;
+	    }
+	    naf.push(z);
+
+	    // Optimization, shift by word if possible
+	    var shift = (k.cmpn(0) !== 0 && k.andln(ws - 1) === 0) ? (w + 1) : 1;
+	    for (var i = 1; i < shift; i++)
+	      naf.push(0);
+	    k.iushrn(shift);
+	  }
+
+	  return naf;
+	}
+	utils.getNAF = getNAF;
+
+	// Represent k1, k2 in a Joint Sparse Form
+	function getJSF(k1, k2) {
+	  var jsf = [
+	    [],
+	    []
+	  ];
+
+	  k1 = k1.clone();
+	  k2 = k2.clone();
+	  var d1 = 0;
+	  var d2 = 0;
+	  while (k1.cmpn(-d1) > 0 || k2.cmpn(-d2) > 0) {
+
+	    // First phase
+	    var m14 = (k1.andln(3) + d1) & 3;
+	    var m24 = (k2.andln(3) + d2) & 3;
+	    if (m14 === 3)
+	      m14 = -1;
+	    if (m24 === 3)
+	      m24 = -1;
+	    var u1;
+	    if ((m14 & 1) === 0) {
+	      u1 = 0;
+	    } else {
+	      var m8 = (k1.andln(7) + d1) & 7;
+	      if ((m8 === 3 || m8 === 5) && m24 === 2)
+	        u1 = -m14;
+	      else
+	        u1 = m14;
+	    }
+	    jsf[0].push(u1);
+
+	    var u2;
+	    if ((m24 & 1) === 0) {
+	      u2 = 0;
+	    } else {
+	      var m8 = (k2.andln(7) + d2) & 7;
+	      if ((m8 === 3 || m8 === 5) && m14 === 2)
+	        u2 = -m24;
+	      else
+	        u2 = m24;
+	    }
+	    jsf[1].push(u2);
+
+	    // Second phase
+	    if (2 * d1 === u1 + 1)
+	      d1 = 1 - d1;
+	    if (2 * d2 === u2 + 1)
+	      d2 = 1 - d2;
+	    k1.iushrn(1);
+	    k2.iushrn(1);
+	  }
+
+	  return jsf;
+	}
+	utils.getJSF = getJSF;
+
+	function cachedProperty(obj, computer) {
+	  var name = computer.name;
+	  var key = '_' + name;
+	  obj.prototype[name] = function cachedProperty() {
+	    return this[key] !== undefined ? this[key] :
+	           this[key] = computer.call(this);
+	  };
+	}
+	utils.cachedProperty = cachedProperty;
+
+	function parseBytes(bytes) {
+	  return typeof bytes === 'string' ? utils.toArray(bytes, 'hex') :
+	                                     bytes;
+	}
+	utils.parseBytes = parseBytes;
+
+	function intFromLE(bytes) {
+	  return new bn(bytes, 'hex', 'le');
+	}
+	utils.intFromLE = intFromLE;
+
+
+
+/***/ }),
+/* 123 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var hash = __webpack_require__(31);
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+	var assert = utils.assert;
+
+	function HmacDRBG(options) {
+	  if (!(this instanceof HmacDRBG))
+	    return new HmacDRBG(options);
+	  this.hash = options.hash;
+	  this.predResist = !!options.predResist;
+
+	  this.outLen = this.hash.outSize;
+	  this.minEntropy = options.minEntropy || this.hash.hmacStrength;
+
+	  this.reseed = null;
+	  this.reseedInterval = null;
+	  this.K = null;
+	  this.V = null;
+
+	  var entropy = utils.toArray(options.entropy, options.entropyEnc);
+	  var nonce = utils.toArray(options.nonce, options.nonceEnc);
+	  var pers = utils.toArray(options.pers, options.persEnc);
+	  assert(entropy.length >= (this.minEntropy / 8),
+	         'Not enough entropy. Minimum is: ' + this.minEntropy + ' bits');
+	  this._init(entropy, nonce, pers);
+	}
+	module.exports = HmacDRBG;
+
+	HmacDRBG.prototype._init = function init(entropy, nonce, pers) {
+	  var seed = entropy.concat(nonce).concat(pers);
+
+	  this.K = new Array(this.outLen / 8);
+	  this.V = new Array(this.outLen / 8);
+	  for (var i = 0; i < this.V.length; i++) {
+	    this.K[i] = 0x00;
+	    this.V[i] = 0x01;
+	  }
+
+	  this._update(seed);
+	  this.reseed = 1;
+	  this.reseedInterval = 0x1000000000000;  // 2^48
+	};
+
+	HmacDRBG.prototype._hmac = function hmac() {
+	  return new hash.hmac(this.hash, this.K);
+	};
+
+	HmacDRBG.prototype._update = function update(seed) {
+	  var kmac = this._hmac()
+	                 .update(this.V)
+	                 .update([ 0x00 ]);
+	  if (seed)
+	    kmac = kmac.update(seed);
+	  this.K = kmac.digest();
+	  this.V = this._hmac().update(this.V).digest();
+	  if (!seed)
+	    return;
+
+	  this.K = this._hmac()
+	               .update(this.V)
+	               .update([ 0x01 ])
+	               .update(seed)
+	               .digest();
+	  this.V = this._hmac().update(this.V).digest();
+	};
+
+	HmacDRBG.prototype.reseed = function reseed(entropy, entropyEnc, add, addEnc) {
+	  // Optional entropy enc
+	  if (typeof entropyEnc !== 'string') {
+	    addEnc = add;
+	    add = entropyEnc;
+	    entropyEnc = null;
+	  }
+
+	  entropy = utils.toBuffer(entropy, entropyEnc);
+	  add = utils.toBuffer(add, addEnc);
+
+	  assert(entropy.length >= (this.minEntropy / 8),
+	         'Not enough entropy. Minimum is: ' + this.minEntropy + ' bits');
+
+	  this._update(entropy.concat(add || []));
+	  this.reseed = 1;
+	};
+
+	HmacDRBG.prototype.generate = function generate(len, enc, add, addEnc) {
+	  if (this.reseed > this.reseedInterval)
+	    throw new Error('Reseed is required');
+
+	  // Optional encoding
+	  if (typeof enc !== 'string') {
+	    addEnc = add;
+	    add = enc;
+	    enc = null;
+	  }
+
+	  // Optional additional data
+	  if (add) {
+	    add = utils.toArray(add, addEnc);
+	    this._update(add);
+	  }
+
+	  var temp = [];
+	  while (temp.length < len) {
+	    this.V = this._hmac().update(this.V).digest();
+	    temp = temp.concat(this.V);
+	  }
+
+	  var res = temp.slice(0, len);
+	  this._update(add);
+	  this.reseed++;
+	  return utils.encode(res, enc);
+	};
+
+
+/***/ }),
+/* 124 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var curve = exports;
+
+	curve.base = __webpack_require__(125);
+	curve.short = __webpack_require__(126);
+	curve.mont = __webpack_require__(127);
+	curve.edwards = __webpack_require__(128);
+
+
+/***/ }),
+/* 125 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var bn = __webpack_require__(119);
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+	var getNAF = utils.getNAF;
+	var getJSF = utils.getJSF;
+	var assert = utils.assert;
+
+	function BaseCurve(type, conf) {
+	  this.type = type;
+	  this.p = new bn(conf.p, 16);
+
+	  // Use Montgomery, when there is no fast reduction for the prime
+	  this.red = conf.prime ? bn.red(conf.prime) : bn.mont(this.p);
+
+	  // Useful for many curves
+	  this.zero = new bn(0).toRed(this.red);
+	  this.one = new bn(1).toRed(this.red);
+	  this.two = new bn(2).toRed(this.red);
+
+	  // Curve configuration, optional
+	  this.n = conf.n && new bn(conf.n, 16);
+	  this.g = conf.g && this.pointFromJSON(conf.g, conf.gRed);
+
+	  // Temporary arrays
+	  this._wnafT1 = new Array(4);
+	  this._wnafT2 = new Array(4);
+	  this._wnafT3 = new Array(4);
+	  this._wnafT4 = new Array(4);
+	}
+	module.exports = BaseCurve;
+
+	BaseCurve.prototype.point = function point() {
+	  throw new Error('Not implemented');
+	};
+
+	BaseCurve.prototype.validate = function validate() {
+	  throw new Error('Not implemented');
+	};
+
+	BaseCurve.prototype._fixedNafMul = function _fixedNafMul(p, k) {
+	  assert(p.precomputed);
+	  var doubles = p._getDoubles();
+
+	  var naf = getNAF(k, 1);
+	  var I = (1 << (doubles.step + 1)) - (doubles.step % 2 === 0 ? 2 : 1);
+	  I /= 3;
+
+	  // Translate into more windowed form
+	  var repr = [];
+	  for (var j = 0; j < naf.length; j += doubles.step) {
+	    var nafW = 0;
+	    for (var k = j + doubles.step - 1; k >= j; k--)
+	      nafW = (nafW << 1) + naf[k];
+	    repr.push(nafW);
+	  }
+
+	  var a = this.jpoint(null, null, null);
+	  var b = this.jpoint(null, null, null);
+	  for (var i = I; i > 0; i--) {
+	    for (var j = 0; j < repr.length; j++) {
+	      var nafW = repr[j];
+	      if (nafW === i)
+	        b = b.mixedAdd(doubles.points[j]);
+	      else if (nafW === -i)
+	        b = b.mixedAdd(doubles.points[j].neg());
+	    }
+	    a = a.add(b);
+	  }
+	  return a.toP();
+	};
+
+	BaseCurve.prototype._wnafMul = function _wnafMul(p, k) {
+	  var w = 4;
+
+	  // Precompute window
+	  var nafPoints = p._getNAFPoints(w);
+	  w = nafPoints.wnd;
+	  var wnd = nafPoints.points;
+
+	  // Get NAF form
+	  var naf = getNAF(k, w);
+
+	  // Add `this`*(N+1) for every w-NAF index
+	  var acc = this.jpoint(null, null, null);
+	  for (var i = naf.length - 1; i >= 0; i--) {
+	    // Count zeroes
+	    for (var k = 0; i >= 0 && naf[i] === 0; i--)
+	      k++;
+	    if (i >= 0)
+	      k++;
+	    acc = acc.dblp(k);
+
+	    if (i < 0)
+	      break;
+	    var z = naf[i];
+	    assert(z !== 0);
+	    if (p.type === 'affine') {
+	      // J +- P
+	      if (z > 0)
+	        acc = acc.mixedAdd(wnd[(z - 1) >> 1]);
+	      else
+	        acc = acc.mixedAdd(wnd[(-z - 1) >> 1].neg());
+	    } else {
+	      // J +- J
+	      if (z > 0)
+	        acc = acc.add(wnd[(z - 1) >> 1]);
+	      else
+	        acc = acc.add(wnd[(-z - 1) >> 1].neg());
+	    }
+	  }
+	  return p.type === 'affine' ? acc.toP() : acc;
+	};
+
+	BaseCurve.prototype._wnafMulAdd = function _wnafMulAdd(defW,
+	                                                       points,
+	                                                       coeffs,
+	                                                       len) {
+	  var wndWidth = this._wnafT1;
+	  var wnd = this._wnafT2;
+	  var naf = this._wnafT3;
+
+	  // Fill all arrays
+	  var max = 0;
+	  for (var i = 0; i < len; i++) {
+	    var p = points[i];
+	    var nafPoints = p._getNAFPoints(defW);
+	    wndWidth[i] = nafPoints.wnd;
+	    wnd[i] = nafPoints.points;
+	  }
+
+	  // Comb small window NAFs
+	  for (var i = len - 1; i >= 1; i -= 2) {
+	    var a = i - 1;
+	    var b = i;
+	    if (wndWidth[a] !== 1 || wndWidth[b] !== 1) {
+	      naf[a] = getNAF(coeffs[a], wndWidth[a]);
+	      naf[b] = getNAF(coeffs[b], wndWidth[b]);
+	      max = Math.max(naf[a].length, max);
+	      max = Math.max(naf[b].length, max);
+	      continue;
+	    }
+
+	    var comb = [
+	      points[a], /* 1 */
+	      null, /* 3 */
+	      null, /* 5 */
+	      points[b] /* 7 */
+	    ];
+
+	    // Try to avoid Projective points, if possible
+	    if (points[a].y.cmp(points[b].y) === 0) {
+	      comb[1] = points[a].add(points[b]);
+	      comb[2] = points[a].toJ().mixedAdd(points[b].neg());
+	    } else if (points[a].y.cmp(points[b].y.redNeg()) === 0) {
+	      comb[1] = points[a].toJ().mixedAdd(points[b]);
+	      comb[2] = points[a].add(points[b].neg());
+	    } else {
+	      comb[1] = points[a].toJ().mixedAdd(points[b]);
+	      comb[2] = points[a].toJ().mixedAdd(points[b].neg());
+	    }
+
+	    var index = [
+	      -3, /* -1 -1 */
+	      -1, /* -1 0 */
+	      -5, /* -1 1 */
+	      -7, /* 0 -1 */
+	      0, /* 0 0 */
+	      7, /* 0 1 */
+	      5, /* 1 -1 */
+	      1, /* 1 0 */
+	      3  /* 1 1 */
+	    ];
+
+	    var jsf = getJSF(coeffs[a], coeffs[b]);
+	    max = Math.max(jsf[0].length, max);
+	    naf[a] = new Array(max);
+	    naf[b] = new Array(max);
+	    for (var j = 0; j < max; j++) {
+	      var ja = jsf[0][j] | 0;
+	      var jb = jsf[1][j] | 0;
+
+	      naf[a][j] = index[(ja + 1) * 3 + (jb + 1)];
+	      naf[b][j] = 0;
+	      wnd[a] = comb;
+	    }
+	  }
+
+	  var acc = this.jpoint(null, null, null);
+	  var tmp = this._wnafT4;
+	  for (var i = max; i >= 0; i--) {
+	    var k = 0;
+
+	    while (i >= 0) {
+	      var zero = true;
+	      for (var j = 0; j < len; j++) {
+	        tmp[j] = naf[j][i] | 0;
+	        if (tmp[j] !== 0)
+	          zero = false;
+	      }
+	      if (!zero)
+	        break;
+	      k++;
+	      i--;
+	    }
+	    if (i >= 0)
+	      k++;
+	    acc = acc.dblp(k);
+	    if (i < 0)
+	      break;
+
+	    for (var j = 0; j < len; j++) {
+	      var z = tmp[j];
+	      var p;
+	      if (z === 0)
+	        continue;
+	      else if (z > 0)
+	        p = wnd[j][(z - 1) >> 1];
+	      else if (z < 0)
+	        p = wnd[j][(-z - 1) >> 1].neg();
+
+	      if (p.type === 'affine')
+	        acc = acc.mixedAdd(p);
+	      else
+	        acc = acc.add(p);
+	    }
+	  }
+	  // Zeroify references
+	  for (var i = 0; i < len; i++)
+	    wnd[i] = null;
+	  return acc.toP();
+	};
+
+	function BasePoint(curve, type) {
+	  this.curve = curve;
+	  this.type = type;
+	  this.precomputed = null;
+	}
+	BaseCurve.BasePoint = BasePoint;
+
+	BasePoint.prototype.eq = function eq(/*other*/) {
+	  throw new Error('Not implemented');
+	};
+
+	BasePoint.prototype.validate = function validate() {
+	  return this.curve.validate(this);
+	};
+
+	BaseCurve.prototype.decodePoint = function decodePoint(bytes, enc) {
+	  bytes = utils.toArray(bytes, enc);
+
+	  var len = this.p.byteLength();
+	  if (bytes[0] === 0x04 && bytes.length - 1 === 2 * len) {
+	    return this.point(bytes.slice(1, 1 + len),
+	                      bytes.slice(1 + len, 1 + 2 * len));
+	  } else if ((bytes[0] === 0x02 || bytes[0] === 0x03) &&
+	              bytes.length - 1 === len) {
+	    return this.pointFromX(bytes.slice(1, 1 + len), bytes[0] === 0x03);
+	  }
+	  throw new Error('Unknown point format');
+	};
+
+	BasePoint.prototype.encodeCompressed = function encodeCompressed(enc) {
+	  return this.encode(enc, true);
+	};
+
+	BasePoint.prototype._encode = function _encode(compact) {
+	  var len = this.curve.p.byteLength();
+	  var x = this.getX().toArray('be', len);
+
+	  if (compact)
+	    return [ this.getY().isEven() ? 0x02 : 0x03 ].concat(x);
+
+	  return [ 0x04 ].concat(x, this.getY().toArray('be', len)) ;
+	};
+
+	BasePoint.prototype.encode = function encode(enc, compact) {
+	  return utils.encode(this._encode(compact), enc);
+	};
+
+	BasePoint.prototype.precompute = function precompute(power) {
+	  if (this.precomputed)
+	    return this;
+
+	  var precomputed = {
+	    doubles: null,
+	    naf: null,
+	    beta: null
+	  };
+	  precomputed.naf = this._getNAFPoints(8);
+	  precomputed.doubles = this._getDoubles(4, power);
+	  precomputed.beta = this._getBeta();
+	  this.precomputed = precomputed;
+
+	  return this;
+	};
+
+	BasePoint.prototype._hasDoubles = function _hasDoubles(k) {
+	  if (!this.precomputed)
+	    return false;
+
+	  var doubles = this.precomputed.doubles;
+	  if (!doubles)
+	    return false;
+
+	  return doubles.points.length >= Math.ceil((k.bitLength() + 1) / doubles.step);
+	};
+
+	BasePoint.prototype._getDoubles = function _getDoubles(step, power) {
+	  if (this.precomputed && this.precomputed.doubles)
+	    return this.precomputed.doubles;
+
+	  var doubles = [ this ];
+	  var acc = this;
+	  for (var i = 0; i < power; i += step) {
+	    for (var j = 0; j < step; j++)
+	      acc = acc.dbl();
+	    doubles.push(acc);
+	  }
+	  return {
+	    step: step,
+	    points: doubles
+	  };
+	};
+
+	BasePoint.prototype._getNAFPoints = function _getNAFPoints(wnd) {
+	  if (this.precomputed && this.precomputed.naf)
+	    return this.precomputed.naf;
+
+	  var res = [ this ];
+	  var max = (1 << wnd) - 1;
+	  var dbl = max === 1 ? null : this.dbl();
+	  for (var i = 1; i < max; i++)
+	    res[i] = res[i - 1].add(dbl);
+	  return {
+	    wnd: wnd,
+	    points: res
+	  };
+	};
+
+	BasePoint.prototype._getBeta = function _getBeta() {
+	  return null;
+	};
+
+	BasePoint.prototype.dblp = function dblp(k) {
+	  var r = this;
+	  for (var i = 0; i < k; i++)
+	    r = r.dbl();
+	  return r;
+	};
+
+
+/***/ }),
+/* 126 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var curve = __webpack_require__(124);
+	var elliptic = __webpack_require__(120);
+	var bn = __webpack_require__(119);
+	var inherits = __webpack_require__(27);
+	var Base = curve.base;
+
+	var assert = elliptic.utils.assert;
+
+	function ShortCurve(conf) {
+	  Base.call(this, 'short', conf);
+
+	  this.a = new bn(conf.a, 16).toRed(this.red);
+	  this.b = new bn(conf.b, 16).toRed(this.red);
+	  this.tinv = this.two.redInvm();
+
+	  this.zeroA = this.a.fromRed().cmpn(0) === 0;
+	  this.threeA = this.a.fromRed().sub(this.p).cmpn(-3) === 0;
+
+	  // If the curve is endomorphic, precalculate beta and lambda
+	  this.endo = this._getEndomorphism(conf);
+	  this._endoWnafT1 = new Array(4);
+	  this._endoWnafT2 = new Array(4);
+	}
+	inherits(ShortCurve, Base);
+	module.exports = ShortCurve;
+
+	ShortCurve.prototype._getEndomorphism = function _getEndomorphism(conf) {
+	  // No efficient endomorphism
+	  if (!this.zeroA || !this.g || !this.n || this.p.modn(3) !== 1)
+	    return;
+
+	  // Compute beta and lambda, that lambda * P = (beta * Px; Py)
+	  var beta;
+	  var lambda;
+	  if (conf.beta) {
+	    beta = new bn(conf.beta, 16).toRed(this.red);
+	  } else {
+	    var betas = this._getEndoRoots(this.p);
+	    // Choose the smallest beta
+	    beta = betas[0].cmp(betas[1]) < 0 ? betas[0] : betas[1];
+	    beta = beta.toRed(this.red);
+	  }
+	  if (conf.lambda) {
+	    lambda = new bn(conf.lambda, 16);
+	  } else {
+	    // Choose the lambda that is matching selected beta
+	    var lambdas = this._getEndoRoots(this.n);
+	    if (this.g.mul(lambdas[0]).x.cmp(this.g.x.redMul(beta)) === 0) {
+	      lambda = lambdas[0];
+	    } else {
+	      lambda = lambdas[1];
+	      assert(this.g.mul(lambda).x.cmp(this.g.x.redMul(beta)) === 0);
+	    }
+	  }
+
+	  // Get basis vectors, used for balanced length-two representation
+	  var basis;
+	  if (conf.basis) {
+	    basis = conf.basis.map(function(vec) {
+	      return {
+	        a: new bn(vec.a, 16),
+	        b: new bn(vec.b, 16)
+	      };
+	    });
+	  } else {
+	    basis = this._getEndoBasis(lambda);
+	  }
+
+	  return {
+	    beta: beta,
+	    lambda: lambda,
+	    basis: basis
+	  };
+	};
+
+	ShortCurve.prototype._getEndoRoots = function _getEndoRoots(num) {
+	  // Find roots of for x^2 + x + 1 in F
+	  // Root = (-1 +- Sqrt(-3)) / 2
+	  //
+	  var red = num === this.p ? this.red : bn.mont(num);
+	  var tinv = new bn(2).toRed(red).redInvm();
+	  var ntinv = tinv.redNeg();
+
+	  var s = new bn(3).toRed(red).redNeg().redSqrt().redMul(tinv);
+
+	  var l1 = ntinv.redAdd(s).fromRed();
+	  var l2 = ntinv.redSub(s).fromRed();
+	  return [ l1, l2 ];
+	};
+
+	ShortCurve.prototype._getEndoBasis = function _getEndoBasis(lambda) {
+	  // aprxSqrt >= sqrt(this.n)
+	  var aprxSqrt = this.n.ushrn(Math.floor(this.n.bitLength() / 2));
+
+	  // 3.74
+	  // Run EGCD, until r(L + 1) < aprxSqrt
+	  var u = lambda;
+	  var v = this.n.clone();
+	  var x1 = new bn(1);
+	  var y1 = new bn(0);
+	  var x2 = new bn(0);
+	  var y2 = new bn(1);
+
+	  // NOTE: all vectors are roots of: a + b * lambda = 0 (mod n)
+	  var a0;
+	  var b0;
+	  // First vector
+	  var a1;
+	  var b1;
+	  // Second vector
+	  var a2;
+	  var b2;
+
+	  var prevR;
+	  var i = 0;
+	  var r;
+	  var x;
+	  while (u.cmpn(0) !== 0) {
+	    var q = v.div(u);
+	    r = v.sub(q.mul(u));
+	    x = x2.sub(q.mul(x1));
+	    var y = y2.sub(q.mul(y1));
+
+	    if (!a1 && r.cmp(aprxSqrt) < 0) {
+	      a0 = prevR.neg();
+	      b0 = x1;
+	      a1 = r.neg();
+	      b1 = x;
+	    } else if (a1 && ++i === 2) {
+	      break;
+	    }
+	    prevR = r;
+
+	    v = u;
+	    u = r;
+	    x2 = x1;
+	    x1 = x;
+	    y2 = y1;
+	    y1 = y;
+	  }
+	  a2 = r.neg();
+	  b2 = x;
+
+	  var len1 = a1.sqr().add(b1.sqr());
+	  var len2 = a2.sqr().add(b2.sqr());
+	  if (len2.cmp(len1) >= 0) {
+	    a2 = a0;
+	    b2 = b0;
+	  }
+
+	  // Normalize signs
+	  if (a1.sign) {
+	    a1 = a1.neg();
+	    b1 = b1.neg();
+	  }
+	  if (a2.sign) {
+	    a2 = a2.neg();
+	    b2 = b2.neg();
+	  }
+
+	  return [
+	    { a: a1, b: b1 },
+	    { a: a2, b: b2 }
+	  ];
+	};
+
+	ShortCurve.prototype._endoSplit = function _endoSplit(k) {
+	  var basis = this.endo.basis;
+	  var v1 = basis[0];
+	  var v2 = basis[1];
+
+	  var c1 = v2.b.mul(k).divRound(this.n);
+	  var c2 = v1.b.neg().mul(k).divRound(this.n);
+
+	  var p1 = c1.mul(v1.a);
+	  var p2 = c2.mul(v2.a);
+	  var q1 = c1.mul(v1.b);
+	  var q2 = c2.mul(v2.b);
+
+	  // Calculate answer
+	  var k1 = k.sub(p1).sub(p2);
+	  var k2 = q1.add(q2).neg();
+	  return { k1: k1, k2: k2 };
+	};
+
+	ShortCurve.prototype.pointFromX = function pointFromX(x, odd) {
+	  x = new bn(x, 16);
+	  if (!x.red)
+	    x = x.toRed(this.red);
+
+	  var y2 = x.redSqr().redMul(x).redIAdd(x.redMul(this.a)).redIAdd(this.b);
+	  var y = y2.redSqrt();
+
+	  // XXX Is there any way to tell if the number is odd without converting it
+	  // to non-red form?
+	  var isOdd = y.fromRed().isOdd();
+	  if (odd && !isOdd || !odd && isOdd)
+	    y = y.redNeg();
+
+	  return this.point(x, y);
+	};
+
+	ShortCurve.prototype.validate = function validate(point) {
+	  if (point.inf)
+	    return true;
+
+	  var x = point.x;
+	  var y = point.y;
+
+	  var ax = this.a.redMul(x);
+	  var rhs = x.redSqr().redMul(x).redIAdd(ax).redIAdd(this.b);
+	  return y.redSqr().redISub(rhs).cmpn(0) === 0;
+	};
+
+	ShortCurve.prototype._endoWnafMulAdd =
+	    function _endoWnafMulAdd(points, coeffs) {
+	  var npoints = this._endoWnafT1;
+	  var ncoeffs = this._endoWnafT2;
+	  for (var i = 0; i < points.length; i++) {
+	    var split = this._endoSplit(coeffs[i]);
+	    var p = points[i];
+	    var beta = p._getBeta();
+
+	    if (split.k1.sign) {
+	      split.k1.sign = !split.k1.sign;
+	      p = p.neg(true);
+	    }
+	    if (split.k2.sign) {
+	      split.k2.sign = !split.k2.sign;
+	      beta = beta.neg(true);
+	    }
+
+	    npoints[i * 2] = p;
+	    npoints[i * 2 + 1] = beta;
+	    ncoeffs[i * 2] = split.k1;
+	    ncoeffs[i * 2 + 1] = split.k2;
+	  }
+	  var res = this._wnafMulAdd(1, npoints, ncoeffs, i * 2);
+
+	  // Clean-up references to points and coefficients
+	  for (var j = 0; j < i * 2; j++) {
+	    npoints[j] = null;
+	    ncoeffs[j] = null;
+	  }
+	  return res;
+	};
+
+	function Point(curve, x, y, isRed) {
+	  Base.BasePoint.call(this, curve, 'affine');
+	  if (x === null && y === null) {
+	    this.x = null;
+	    this.y = null;
+	    this.inf = true;
+	  } else {
+	    this.x = new bn(x, 16);
+	    this.y = new bn(y, 16);
+	    // Force redgomery representation when loading from JSON
+	    if (isRed) {
+	      this.x.forceRed(this.curve.red);
+	      this.y.forceRed(this.curve.red);
+	    }
+	    if (!this.x.red)
+	      this.x = this.x.toRed(this.curve.red);
+	    if (!this.y.red)
+	      this.y = this.y.toRed(this.curve.red);
+	    this.inf = false;
+	  }
+	}
+	inherits(Point, Base.BasePoint);
+
+	ShortCurve.prototype.point = function point(x, y, isRed) {
+	  return new Point(this, x, y, isRed);
+	};
+
+	ShortCurve.prototype.pointFromJSON = function pointFromJSON(obj, red) {
+	  return Point.fromJSON(this, obj, red);
+	};
+
+	Point.prototype._getBeta = function _getBeta() {
+	  if (!this.curve.endo)
+	    return;
+
+	  var pre = this.precomputed;
+	  if (pre && pre.beta)
+	    return pre.beta;
+
+	  var beta = this.curve.point(this.x.redMul(this.curve.endo.beta), this.y);
+	  if (pre) {
+	    var curve = this.curve;
+	    var endoMul = function(p) {
+	      return curve.point(p.x.redMul(curve.endo.beta), p.y);
+	    };
+	    pre.beta = beta;
+	    beta.precomputed = {
+	      beta: null,
+	      naf: pre.naf && {
+	        wnd: pre.naf.wnd,
+	        points: pre.naf.points.map(endoMul)
+	      },
+	      doubles: pre.doubles && {
+	        step: pre.doubles.step,
+	        points: pre.doubles.points.map(endoMul)
+	      }
+	    };
+	  }
+	  return beta;
+	};
+
+	Point.prototype.toJSON = function toJSON() {
+	  if (!this.precomputed)
+	    return [ this.x, this.y ];
+
+	  return [ this.x, this.y, this.precomputed && {
+	    doubles: this.precomputed.doubles && {
+	      step: this.precomputed.doubles.step,
+	      points: this.precomputed.doubles.points.slice(1)
+	    },
+	    naf: this.precomputed.naf && {
+	      wnd: this.precomputed.naf.wnd,
+	      points: this.precomputed.naf.points.slice(1)
+	    }
+	  } ];
+	};
+
+	Point.fromJSON = function fromJSON(curve, obj, red) {
+	  if (typeof obj === 'string')
+	    obj = JSON.parse(obj);
+	  var res = curve.point(obj[0], obj[1], red);
+	  if (!obj[2])
+	    return res;
+
+	  function obj2point(obj) {
+	    return curve.point(obj[0], obj[1], red);
+	  }
+
+	  var pre = obj[2];
+	  res.precomputed = {
+	    beta: null,
+	    doubles: pre.doubles && {
+	      step: pre.doubles.step,
+	      points: [ res ].concat(pre.doubles.points.map(obj2point))
+	    },
+	    naf: pre.naf && {
+	      wnd: pre.naf.wnd,
+	      points: [ res ].concat(pre.naf.points.map(obj2point))
+	    }
+	  };
+	  return res;
+	};
+
+	Point.prototype.inspect = function inspect() {
+	  if (this.isInfinity())
+	    return '<EC Point Infinity>';
+	  return '<EC Point x: ' + this.x.fromRed().toString(16, 2) +
+	      ' y: ' + this.y.fromRed().toString(16, 2) + '>';
+	};
+
+	Point.prototype.isInfinity = function isInfinity() {
+	  return this.inf;
+	};
+
+	Point.prototype.add = function add(p) {
+	  // O + P = P
+	  if (this.inf)
+	    return p;
+
+	  // P + O = P
+	  if (p.inf)
+	    return this;
+
+	  // P + P = 2P
+	  if (this.eq(p))
+	    return this.dbl();
+
+	  // P + (-P) = O
+	  if (this.neg().eq(p))
+	    return this.curve.point(null, null);
+
+	  // P + Q = O
+	  if (this.x.cmp(p.x) === 0)
+	    return this.curve.point(null, null);
+
+	  var c = this.y.redSub(p.y);
+	  if (c.cmpn(0) !== 0)
+	    c = c.redMul(this.x.redSub(p.x).redInvm());
+	  var nx = c.redSqr().redISub(this.x).redISub(p.x);
+	  var ny = c.redMul(this.x.redSub(nx)).redISub(this.y);
+	  return this.curve.point(nx, ny);
+	};
+
+	Point.prototype.dbl = function dbl() {
+	  if (this.inf)
+	    return this;
+
+	  // 2P = O
+	  var ys1 = this.y.redAdd(this.y);
+	  if (ys1.cmpn(0) === 0)
+	    return this.curve.point(null, null);
+
+	  var a = this.curve.a;
+
+	  var x2 = this.x.redSqr();
+	  var dyinv = ys1.redInvm();
+	  var c = x2.redAdd(x2).redIAdd(x2).redIAdd(a).redMul(dyinv);
+
+	  var nx = c.redSqr().redISub(this.x.redAdd(this.x));
+	  var ny = c.redMul(this.x.redSub(nx)).redISub(this.y);
+	  return this.curve.point(nx, ny);
+	};
+
+	Point.prototype.getX = function getX() {
+	  return this.x.fromRed();
+	};
+
+	Point.prototype.getY = function getY() {
+	  return this.y.fromRed();
+	};
+
+	Point.prototype.mul = function mul(k) {
+	  k = new bn(k, 16);
+
+	  if (this._hasDoubles(k))
+	    return this.curve._fixedNafMul(this, k);
+	  else if (this.curve.endo)
+	    return this.curve._endoWnafMulAdd([ this ], [ k ]);
+	  else
+	    return this.curve._wnafMul(this, k);
+	};
+
+	Point.prototype.mulAdd = function mulAdd(k1, p2, k2) {
+	  var points = [ this, p2 ];
+	  var coeffs = [ k1, k2 ];
+	  if (this.curve.endo)
+	    return this.curve._endoWnafMulAdd(points, coeffs);
+	  else
+	    return this.curve._wnafMulAdd(1, points, coeffs, 2);
+	};
+
+	Point.prototype.eq = function eq(p) {
+	  return this === p ||
+	         this.inf === p.inf &&
+	             (this.inf || this.x.cmp(p.x) === 0 && this.y.cmp(p.y) === 0);
+	};
+
+	Point.prototype.neg = function neg(_precompute) {
+	  if (this.inf)
+	    return this;
+
+	  var res = this.curve.point(this.x, this.y.redNeg());
+	  if (_precompute && this.precomputed) {
+	    var pre = this.precomputed;
+	    var negate = function(p) {
+	      return p.neg();
+	    };
+	    res.precomputed = {
+	      naf: pre.naf && {
+	        wnd: pre.naf.wnd,
+	        points: pre.naf.points.map(negate)
+	      },
+	      doubles: pre.doubles && {
+	        step: pre.doubles.step,
+	        points: pre.doubles.points.map(negate)
+	      }
+	    };
+	  }
+	  return res;
+	};
+
+	Point.prototype.toJ = function toJ() {
+	  if (this.inf)
+	    return this.curve.jpoint(null, null, null);
+
+	  var res = this.curve.jpoint(this.x, this.y, this.curve.one);
+	  return res;
+	};
+
+	function JPoint(curve, x, y, z) {
+	  Base.BasePoint.call(this, curve, 'jacobian');
+	  if (x === null && y === null && z === null) {
+	    this.x = this.curve.one;
+	    this.y = this.curve.one;
+	    this.z = new bn(0);
+	  } else {
+	    this.x = new bn(x, 16);
+	    this.y = new bn(y, 16);
+	    this.z = new bn(z, 16);
+	  }
+	  if (!this.x.red)
+	    this.x = this.x.toRed(this.curve.red);
+	  if (!this.y.red)
+	    this.y = this.y.toRed(this.curve.red);
+	  if (!this.z.red)
+	    this.z = this.z.toRed(this.curve.red);
+
+	  this.zOne = this.z === this.curve.one;
+	}
+	inherits(JPoint, Base.BasePoint);
+
+	ShortCurve.prototype.jpoint = function jpoint(x, y, z) {
+	  return new JPoint(this, x, y, z);
+	};
+
+	JPoint.prototype.toP = function toP() {
+	  if (this.isInfinity())
+	    return this.curve.point(null, null);
+
+	  var zinv = this.z.redInvm();
+	  var zinv2 = zinv.redSqr();
+	  var ax = this.x.redMul(zinv2);
+	  var ay = this.y.redMul(zinv2).redMul(zinv);
+
+	  return this.curve.point(ax, ay);
+	};
+
+	JPoint.prototype.neg = function neg() {
+	  return this.curve.jpoint(this.x, this.y.redNeg(), this.z);
+	};
+
+	JPoint.prototype.add = function add(p) {
+	  // O + P = P
+	  if (this.isInfinity())
+	    return p;
+
+	  // P + O = P
+	  if (p.isInfinity())
+	    return this;
+
+	  // 12M + 4S + 7A
+	  var pz2 = p.z.redSqr();
+	  var z2 = this.z.redSqr();
+	  var u1 = this.x.redMul(pz2);
+	  var u2 = p.x.redMul(z2);
+	  var s1 = this.y.redMul(pz2.redMul(p.z));
+	  var s2 = p.y.redMul(z2.redMul(this.z));
+
+	  var h = u1.redSub(u2);
+	  var r = s1.redSub(s2);
+	  if (h.cmpn(0) === 0) {
+	    if (r.cmpn(0) !== 0)
+	      return this.curve.jpoint(null, null, null);
+	    else
+	      return this.dbl();
+	  }
+
+	  var h2 = h.redSqr();
+	  var h3 = h2.redMul(h);
+	  var v = u1.redMul(h2);
+
+	  var nx = r.redSqr().redIAdd(h3).redISub(v).redISub(v);
+	  var ny = r.redMul(v.redISub(nx)).redISub(s1.redMul(h3));
+	  var nz = this.z.redMul(p.z).redMul(h);
+
+	  return this.curve.jpoint(nx, ny, nz);
+	};
+
+	JPoint.prototype.mixedAdd = function mixedAdd(p) {
+	  // O + P = P
+	  if (this.isInfinity())
+	    return p.toJ();
+
+	  // P + O = P
+	  if (p.isInfinity())
+	    return this;
+
+	  // 8M + 3S + 7A
+	  var z2 = this.z.redSqr();
+	  var u1 = this.x;
+	  var u2 = p.x.redMul(z2);
+	  var s1 = this.y;
+	  var s2 = p.y.redMul(z2).redMul(this.z);
+
+	  var h = u1.redSub(u2);
+	  var r = s1.redSub(s2);
+	  if (h.cmpn(0) === 0) {
+	    if (r.cmpn(0) !== 0)
+	      return this.curve.jpoint(null, null, null);
+	    else
+	      return this.dbl();
+	  }
+
+	  var h2 = h.redSqr();
+	  var h3 = h2.redMul(h);
+	  var v = u1.redMul(h2);
+
+	  var nx = r.redSqr().redIAdd(h3).redISub(v).redISub(v);
+	  var ny = r.redMul(v.redISub(nx)).redISub(s1.redMul(h3));
+	  var nz = this.z.redMul(h);
+
+	  return this.curve.jpoint(nx, ny, nz);
+	};
+
+	JPoint.prototype.dblp = function dblp(pow) {
+	  if (pow === 0)
+	    return this;
+	  if (this.isInfinity())
+	    return this;
+	  if (!pow)
+	    return this.dbl();
+
+	  if (this.curve.zeroA || this.curve.threeA) {
+	    var r = this;
+	    for (var i = 0; i < pow; i++)
+	      r = r.dbl();
+	    return r;
+	  }
+
+	  // 1M + 2S + 1A + N * (4S + 5M + 8A)
+	  // N = 1 => 6M + 6S + 9A
+	  var a = this.curve.a;
+	  var tinv = this.curve.tinv;
+
+	  var jx = this.x;
+	  var jy = this.y;
+	  var jz = this.z;
+	  var jz4 = jz.redSqr().redSqr();
+
+	  // Reuse results
+	  var jyd = jy.redAdd(jy);
+	  for (var i = 0; i < pow; i++) {
+	    var jx2 = jx.redSqr();
+	    var jyd2 = jyd.redSqr();
+	    var jyd4 = jyd2.redSqr();
+	    var c = jx2.redAdd(jx2).redIAdd(jx2).redIAdd(a.redMul(jz4));
+
+	    var t1 = jx.redMul(jyd2);
+	    var nx = c.redSqr().redISub(t1.redAdd(t1));
+	    var t2 = t1.redISub(nx);
+	    var dny = c.redMul(t2);
+	    dny = dny.redIAdd(dny).redISub(jyd4);
+	    var nz = jyd.redMul(jz);
+	    if (i + 1 < pow)
+	      jz4 = jz4.redMul(jyd4);
+
+	    jx = nx;
+	    jz = nz;
+	    jyd = dny;
+	  }
+
+	  return this.curve.jpoint(jx, jyd.redMul(tinv), jz);
+	};
+
+	JPoint.prototype.dbl = function dbl() {
+	  if (this.isInfinity())
+	    return this;
+
+	  if (this.curve.zeroA)
+	    return this._zeroDbl();
+	  else if (this.curve.threeA)
+	    return this._threeDbl();
+	  else
+	    return this._dbl();
+	};
+
+	JPoint.prototype._zeroDbl = function _zeroDbl() {
+	  var nx;
+	  var ny;
+	  var nz;
+	  // Z = 1
+	  if (this.zOne) {
+	    // hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html
+	    //     #doubling-mdbl-2007-bl
+	    // 1M + 5S + 14A
+
+	    // XX = X1^2
+	    var xx = this.x.redSqr();
+	    // YY = Y1^2
+	    var yy = this.y.redSqr();
+	    // YYYY = YY^2
+	    var yyyy = yy.redSqr();
+	    // S = 2 * ((X1 + YY)^2 - XX - YYYY)
+	    var s = this.x.redAdd(yy).redSqr().redISub(xx).redISub(yyyy);
+	    s = s.redIAdd(s);
+	    // M = 3 * XX + a; a = 0
+	    var m = xx.redAdd(xx).redIAdd(xx);
+	    // T = M ^ 2 - 2*S
+	    var t = m.redSqr().redISub(s).redISub(s);
+
+	    // 8 * YYYY
+	    var yyyy8 = yyyy.redIAdd(yyyy);
+	    yyyy8 = yyyy8.redIAdd(yyyy8);
+	    yyyy8 = yyyy8.redIAdd(yyyy8);
+
+	    // X3 = T
+	    nx = t;
+	    // Y3 = M * (S - T) - 8 * YYYY
+	    ny = m.redMul(s.redISub(t)).redISub(yyyy8);
+	    // Z3 = 2*Y1
+	    nz = this.y.redAdd(this.y);
+	  } else {
+	    // hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html
+	    //     #doubling-dbl-2009-l
+	    // 2M + 5S + 13A
+
+	    // A = X1^2
+	    var a = this.x.redSqr();
+	    // B = Y1^2
+	    var b = this.y.redSqr();
+	    // C = B^2
+	    var c = b.redSqr();
+	    // D = 2 * ((X1 + B)^2 - A - C)
+	    var d = this.x.redAdd(b).redSqr().redISub(a).redISub(c);
+	    d = d.redIAdd(d);
+	    // E = 3 * A
+	    var e = a.redAdd(a).redIAdd(a);
+	    // F = E^2
+	    var f = e.redSqr();
+
+	    // 8 * C
+	    var c8 = c.redIAdd(c);
+	    c8 = c8.redIAdd(c8);
+	    c8 = c8.redIAdd(c8);
+
+	    // X3 = F - 2 * D
+	    nx = f.redISub(d).redISub(d);
+	    // Y3 = E * (D - X3) - 8 * C
+	    ny = e.redMul(d.redISub(nx)).redISub(c8);
+	    // Z3 = 2 * Y1 * Z1
+	    nz = this.y.redMul(this.z);
+	    nz = nz.redIAdd(nz);
+	  }
+
+	  return this.curve.jpoint(nx, ny, nz);
+	};
+
+	JPoint.prototype._threeDbl = function _threeDbl() {
+	  var nx;
+	  var ny;
+	  var nz;
+	  // Z = 1
+	  if (this.zOne) {
+	    // hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-3.html
+	    //     #doubling-mdbl-2007-bl
+	    // 1M + 5S + 15A
+
+	    // XX = X1^2
+	    var xx = this.x.redSqr();
+	    // YY = Y1^2
+	    var yy = this.y.redSqr();
+	    // YYYY = YY^2
+	    var yyyy = yy.redSqr();
+	    // S = 2 * ((X1 + YY)^2 - XX - YYYY)
+	    var s = this.x.redAdd(yy).redSqr().redISub(xx).redISub(yyyy);
+	    s = s.redIAdd(s);
+	    // M = 3 * XX + a
+	    var m = xx.redAdd(xx).redIAdd(xx).redIAdd(this.curve.a);
+	    // T = M^2 - 2 * S
+	    var t = m.redSqr().redISub(s).redISub(s);
+	    // X3 = T
+	    nx = t;
+	    // Y3 = M * (S - T) - 8 * YYYY
+	    var yyyy8 = yyyy.redIAdd(yyyy);
+	    yyyy8 = yyyy8.redIAdd(yyyy8);
+	    yyyy8 = yyyy8.redIAdd(yyyy8);
+	    ny = m.redMul(s.redISub(t)).redISub(yyyy8);
+	    // Z3 = 2 * Y1
+	    nz = this.y.redAdd(this.y);
+	  } else {
+	    // hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-3.html#doubling-dbl-2001-b
+	    // 3M + 5S
+
+	    // delta = Z1^2
+	    var delta = this.z.redSqr();
+	    // gamma = Y1^2
+	    var gamma = this.y.redSqr();
+	    // beta = X1 * gamma
+	    var beta = this.x.redMul(gamma);
+	    // alpha = 3 * (X1 - delta) * (X1 + delta)
+	    var alpha = this.x.redSub(delta).redMul(this.x.redAdd(delta));
+	    alpha = alpha.redAdd(alpha).redIAdd(alpha);
+	    // X3 = alpha^2 - 8 * beta
+	    var beta4 = beta.redIAdd(beta);
+	    beta4 = beta4.redIAdd(beta4);
+	    var beta8 = beta4.redAdd(beta4);
+	    nx = alpha.redSqr().redISub(beta8);
+	    // Z3 = (Y1 + Z1)^2 - gamma - delta
+	    nz = this.y.redAdd(this.z).redSqr().redISub(gamma).redISub(delta);
+	    // Y3 = alpha * (4 * beta - X3) - 8 * gamma^2
+	    var ggamma8 = gamma.redSqr();
+	    ggamma8 = ggamma8.redIAdd(ggamma8);
+	    ggamma8 = ggamma8.redIAdd(ggamma8);
+	    ggamma8 = ggamma8.redIAdd(ggamma8);
+	    ny = alpha.redMul(beta4.redISub(nx)).redISub(ggamma8);
+	  }
+
+	  return this.curve.jpoint(nx, ny, nz);
+	};
+
+	JPoint.prototype._dbl = function _dbl() {
+	  var a = this.curve.a;
+
+	  // 4M + 6S + 10A
+	  var jx = this.x;
+	  var jy = this.y;
+	  var jz = this.z;
+	  var jz4 = jz.redSqr().redSqr();
+
+	  var jx2 = jx.redSqr();
+	  var jy2 = jy.redSqr();
+
+	  var c = jx2.redAdd(jx2).redIAdd(jx2).redIAdd(a.redMul(jz4));
+
+	  var jxd4 = jx.redAdd(jx);
+	  jxd4 = jxd4.redIAdd(jxd4);
+	  var t1 = jxd4.redMul(jy2);
+	  var nx = c.redSqr().redISub(t1.redAdd(t1));
+	  var t2 = t1.redISub(nx);
+
+	  var jyd8 = jy2.redSqr();
+	  jyd8 = jyd8.redIAdd(jyd8);
+	  jyd8 = jyd8.redIAdd(jyd8);
+	  jyd8 = jyd8.redIAdd(jyd8);
+	  var ny = c.redMul(t2).redISub(jyd8);
+	  var nz = jy.redAdd(jy).redMul(jz);
+
+	  return this.curve.jpoint(nx, ny, nz);
+	};
+
+	JPoint.prototype.trpl = function trpl() {
+	  if (!this.curve.zeroA)
+	    return this.dbl().add(this);
+
+	  // hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#tripling-tpl-2007-bl
+	  // 5M + 10S + ...
+
+	  // XX = X1^2
+	  var xx = this.x.redSqr();
+	  // YY = Y1^2
+	  var yy = this.y.redSqr();
+	  // ZZ = Z1^2
+	  var zz = this.z.redSqr();
+	  // YYYY = YY^2
+	  var yyyy = yy.redSqr();
+	  // M = 3 * XX + a * ZZ2; a = 0
+	  var m = xx.redAdd(xx).redIAdd(xx);
+	  // MM = M^2
+	  var mm = m.redSqr();
+	  // E = 6 * ((X1 + YY)^2 - XX - YYYY) - MM
+	  var e = this.x.redAdd(yy).redSqr().redISub(xx).redISub(yyyy);
+	  e = e.redIAdd(e);
+	  e = e.redAdd(e).redIAdd(e);
+	  e = e.redISub(mm);
+	  // EE = E^2
+	  var ee = e.redSqr();
+	  // T = 16*YYYY
+	  var t = yyyy.redIAdd(yyyy);
+	  t = t.redIAdd(t);
+	  t = t.redIAdd(t);
+	  t = t.redIAdd(t);
+	  // U = (M + E)^2 - MM - EE - T
+	  var u = m.redIAdd(e).redSqr().redISub(mm).redISub(ee).redISub(t);
+	  // X3 = 4 * (X1 * EE - 4 * YY * U)
+	  var yyu4 = yy.redMul(u);
+	  yyu4 = yyu4.redIAdd(yyu4);
+	  yyu4 = yyu4.redIAdd(yyu4);
+	  var nx = this.x.redMul(ee).redISub(yyu4);
+	  nx = nx.redIAdd(nx);
+	  nx = nx.redIAdd(nx);
+	  // Y3 = 8 * Y1 * (U * (T - U) - E * EE)
+	  var ny = this.y.redMul(u.redMul(t.redISub(u)).redISub(e.redMul(ee)));
+	  ny = ny.redIAdd(ny);
+	  ny = ny.redIAdd(ny);
+	  ny = ny.redIAdd(ny);
+	  // Z3 = (Z1 + E)^2 - ZZ - EE
+	  var nz = this.z.redAdd(e).redSqr().redISub(zz).redISub(ee);
+
+	  return this.curve.jpoint(nx, ny, nz);
+	};
+
+	JPoint.prototype.mul = function mul(k, kbase) {
+	  k = new bn(k, kbase);
+
+	  return this.curve._wnafMul(this, k);
+	};
+
+	JPoint.prototype.eq = function eq(p) {
+	  if (p.type === 'affine')
+	    return this.eq(p.toJ());
+
+	  if (this === p)
+	    return true;
+
+	  // x1 * z2^2 == x2 * z1^2
+	  var z2 = this.z.redSqr();
+	  var pz2 = p.z.redSqr();
+	  if (this.x.redMul(pz2).redISub(p.x.redMul(z2)).cmpn(0) !== 0)
+	    return false;
+
+	  // y1 * z2^3 == y2 * z1^3
+	  var z3 = z2.redMul(this.z);
+	  var pz3 = pz2.redMul(p.z);
+	  return this.y.redMul(pz3).redISub(p.y.redMul(z3)).cmpn(0) === 0;
+	};
+
+	JPoint.prototype.inspect = function inspect() {
+	  if (this.isInfinity())
+	    return '<EC JPoint Infinity>';
+	  return '<EC JPoint x: ' + this.x.toString(16, 2) +
+	      ' y: ' + this.y.toString(16, 2) +
+	      ' z: ' + this.z.toString(16, 2) + '>';
+	};
+
+	JPoint.prototype.isInfinity = function isInfinity() {
+	  // XXX This code assumes that zero is always zero in red
+	  return this.z.cmpn(0) === 0;
+	};
+
+
+/***/ }),
+/* 127 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var curve = __webpack_require__(124);
+	var bn = __webpack_require__(119);
+	var inherits = __webpack_require__(27);
+	var Base = curve.base;
+
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+
+	function MontCurve(conf) {
+	  Base.call(this, 'mont', conf);
+
+	  this.a = new bn(conf.a, 16).toRed(this.red);
+	  this.b = new bn(conf.b, 16).toRed(this.red);
+	  this.i4 = new bn(4).toRed(this.red).redInvm();
+	  this.two = new bn(2).toRed(this.red);
+	  this.a24 = this.i4.redMul(this.a.redAdd(this.two));
+	}
+	inherits(MontCurve, Base);
+	module.exports = MontCurve;
+
+	MontCurve.prototype.validate = function validate(point) {
+	  var x = point.normalize().x;
+	  var x2 = x.redSqr();
+	  var rhs = x2.redMul(x).redAdd(x2.redMul(this.a)).redAdd(x);
+	  var y = rhs.redSqrt();
+
+	  return y.redSqr().cmp(rhs) === 0;
+	};
+
+	function Point(curve, x, z) {
+	  Base.BasePoint.call(this, curve, 'projective');
+	  if (x === null && z === null) {
+	    this.x = this.curve.one;
+	    this.z = this.curve.zero;
+	  } else {
+	    this.x = new bn(x, 16);
+	    this.z = new bn(z, 16);
+	    if (!this.x.red)
+	      this.x = this.x.toRed(this.curve.red);
+	    if (!this.z.red)
+	      this.z = this.z.toRed(this.curve.red);
+	  }
+	}
+	inherits(Point, Base.BasePoint);
+
+	MontCurve.prototype.decodePoint = function decodePoint(bytes, enc) {
+	  return this.point(utils.toArray(bytes, enc), 1);
+	};
+
+	MontCurve.prototype.point = function point(x, z) {
+	  return new Point(this, x, z);
+	};
+
+	MontCurve.prototype.pointFromJSON = function pointFromJSON(obj) {
+	  return Point.fromJSON(this, obj);
+	};
+
+	Point.prototype.precompute = function precompute() {
+	  // No-op
+	};
+
+	Point.prototype._encode = function _encode() {
+	  return this.getX().toArray('be', this.curve.p.byteLength());
+	};
+
+	Point.fromJSON = function fromJSON(curve, obj) {
+	  return new Point(curve, obj[0], obj[1] || curve.one);
+	};
+
+	Point.prototype.inspect = function inspect() {
+	  if (this.isInfinity())
+	    return '<EC Point Infinity>';
+	  return '<EC Point x: ' + this.x.fromRed().toString(16, 2) +
+	      ' z: ' + this.z.fromRed().toString(16, 2) + '>';
+	};
+
+	Point.prototype.isInfinity = function isInfinity() {
+	  // XXX This code assumes that zero is always zero in red
+	  return this.z.cmpn(0) === 0;
+	};
+
+	Point.prototype.dbl = function dbl() {
+	  // http://hyperelliptic.org/EFD/g1p/auto-montgom-xz.html#doubling-dbl-1987-m-3
+	  // 2M + 2S + 4A
+
+	  // A = X1 + Z1
+	  var a = this.x.redAdd(this.z);
+	  // AA = A^2
+	  var aa = a.redSqr();
+	  // B = X1 - Z1
+	  var b = this.x.redSub(this.z);
+	  // BB = B^2
+	  var bb = b.redSqr();
+	  // C = AA - BB
+	  var c = aa.redSub(bb);
+	  // X3 = AA * BB
+	  var nx = aa.redMul(bb);
+	  // Z3 = C * (BB + A24 * C)
+	  var nz = c.redMul(bb.redAdd(this.curve.a24.redMul(c)));
+	  return this.curve.point(nx, nz);
+	};
+
+	Point.prototype.add = function add() {
+	  throw new Error('Not supported on Montgomery curve');
+	};
+
+	Point.prototype.diffAdd = function diffAdd(p, diff) {
+	  // http://hyperelliptic.org/EFD/g1p/auto-montgom-xz.html#diffadd-dadd-1987-m-3
+	  // 4M + 2S + 6A
+
+	  // A = X2 + Z2
+	  var a = this.x.redAdd(this.z);
+	  // B = X2 - Z2
+	  var b = this.x.redSub(this.z);
+	  // C = X3 + Z3
+	  var c = p.x.redAdd(p.z);
+	  // D = X3 - Z3
+	  var d = p.x.redSub(p.z);
+	  // DA = D * A
+	  var da = d.redMul(a);
+	  // CB = C * B
+	  var cb = c.redMul(b);
+	  // X5 = Z1 * (DA + CB)^2
+	  var nx = diff.z.redMul(da.redAdd(cb).redSqr());
+	  // Z5 = X1 * (DA - CB)^2
+	  var nz = diff.x.redMul(da.redISub(cb).redSqr());
+	  return this.curve.point(nx, nz);
+	};
+
+	Point.prototype.mul = function mul(k) {
+	  var t = k.clone();
+	  var a = this; // (N / 2) * Q + Q
+	  var b = this.curve.point(null, null); // (N / 2) * Q
+	  var c = this; // Q
+
+	  for (var bits = []; t.cmpn(0) !== 0; t.iushrn(1))
+	    bits.push(t.andln(1));
+
+	  for (var i = bits.length - 1; i >= 0; i--) {
+	    if (bits[i] === 0) {
+	      // N * Q + Q = ((N / 2) * Q + Q)) + (N / 2) * Q
+	      a = a.diffAdd(b, c);
+	      // N * Q = 2 * ((N / 2) * Q + Q))
+	      b = b.dbl();
+	    } else {
+	      // N * Q = ((N / 2) * Q + Q) + ((N / 2) * Q)
+	      b = a.diffAdd(b, c);
+	      // N * Q + Q = 2 * ((N / 2) * Q + Q)
+	      a = a.dbl();
+	    }
+	  }
+	  return b;
+	};
+
+	Point.prototype.mulAdd = function mulAdd() {
+	  throw new Error('Not supported on Montgomery curve');
+	};
+
+	Point.prototype.eq = function eq(other) {
+	  return this.getX().cmp(other.getX()) === 0;
+	};
+
+	Point.prototype.normalize = function normalize() {
+	  this.x = this.x.redMul(this.z.redInvm());
+	  this.z = this.curve.one;
+	  return this;
+	};
+
+	Point.prototype.getX = function getX() {
+	  // Normalize coordinates
+	  this.normalize();
+
+	  return this.x.fromRed();
+	};
+
+
+/***/ }),
+/* 128 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var curve = __webpack_require__(124);
+	var elliptic = __webpack_require__(120);
+	var bn = __webpack_require__(119);
+	var inherits = __webpack_require__(27);
+	var Base = curve.base;
+
+	var assert = elliptic.utils.assert;
+
+	function EdwardsCurve(conf) {
+	  // NOTE: Important as we are creating point in Base.call()
+	  this.twisted = (conf.a | 0) !== 1;
+	  this.mOneA = this.twisted && (conf.a | 0) === -1;
+	  this.extended = this.mOneA;
+
+	  Base.call(this, 'edwards', conf);
+
+	  this.a = new bn(conf.a, 16).umod(this.red.m);
+	  this.a = this.a.toRed(this.red);
+	  this.c = new bn(conf.c, 16).toRed(this.red);
+	  this.c2 = this.c.redSqr();
+	  this.d = new bn(conf.d, 16).toRed(this.red);
+	  this.dd = this.d.redAdd(this.d);
+
+	  assert(!this.twisted || this.c.fromRed().cmpn(1) === 0);
+	  this.oneC = (conf.c | 0) === 1;
+	}
+	inherits(EdwardsCurve, Base);
+	module.exports = EdwardsCurve;
+
+	EdwardsCurve.prototype._mulA = function _mulA(num) {
+	  if (this.mOneA)
+	    return num.redNeg();
+	  else
+	    return this.a.redMul(num);
+	};
+
+	EdwardsCurve.prototype._mulC = function _mulC(num) {
+	  if (this.oneC)
+	    return num;
+	  else
+	    return this.c.redMul(num);
+	};
+
+	// Just for compatibility with Short curve
+	EdwardsCurve.prototype.jpoint = function jpoint(x, y, z, t) {
+	  return this.point(x, y, z, t);
+	};
+
+	EdwardsCurve.prototype.pointFromX = function pointFromX(x, odd) {
+	  x = new bn(x, 16);
+	  if (!x.red)
+	    x = x.toRed(this.red);
+
+	  var x2 = x.redSqr();
+	  var rhs = this.c2.redSub(this.a.redMul(x2));
+	  var lhs = this.one.redSub(this.c2.redMul(this.d).redMul(x2));
+
+	  var y = rhs.redMul(lhs.redInvm()).redSqrt();
+	  var isOdd = y.fromRed().isOdd();
+	  if (odd && !isOdd || !odd && isOdd)
+	    y = y.redNeg();
+
+	  return this.point(x, y);
+	};
+
+	EdwardsCurve.prototype.pointFromY = function pointFromY(y, odd) {
+	  y = new bn(y, 16);
+	  if (!y.red)
+	    y = y.toRed(this.red);
+
+	  // x^2 = (y^2 - 1) / (d y^2 + 1)
+	  var y2 = y.redSqr();
+	  var lhs = y2.redSub(this.one);
+	  var rhs = y2.redMul(this.d).redAdd(this.one);
+	  var x2 = lhs.redMul(rhs.redInvm());
+
+	  if (x2.cmp(this.zero) === 0) {
+	    if (odd)
+	      throw new Error('invalid point');
+	    else
+	      return this.point(this.zero, y);
+	  }
+
+	  var x = x2.redSqrt();
+	  if (x.redSqr().redSub(x2).cmp(this.zero) !== 0)
+	    throw new Error('invalid point');
+
+	  if (x.isOdd() !== odd)
+	    x = x.redNeg();
+
+	  return this.point(x, y);
+	};
+
+	EdwardsCurve.prototype.validate = function validate(point) {
+	  if (point.isInfinity())
+	    return true;
+
+	  // Curve: A * X^2 + Y^2 = C^2 * (1 + D * X^2 * Y^2)
+	  point.normalize();
+
+	  var x2 = point.x.redSqr();
+	  var y2 = point.y.redSqr();
+	  var lhs = x2.redMul(this.a).redAdd(y2);
+	  var rhs = this.c2.redMul(this.one.redAdd(this.d.redMul(x2).redMul(y2)));
+
+	  return lhs.cmp(rhs) === 0;
+	};
+
+	function Point(curve, x, y, z, t) {
+	  Base.BasePoint.call(this, curve, 'projective');
+	  if (x === null && y === null && z === null) {
+	    this.x = this.curve.zero;
+	    this.y = this.curve.one;
+	    this.z = this.curve.one;
+	    this.t = this.curve.zero;
+	    this.zOne = true;
+	  } else {
+	    this.x = new bn(x, 16);
+	    this.y = new bn(y, 16);
+	    this.z = z ? new bn(z, 16) : this.curve.one;
+	    this.t = t && new bn(t, 16);
+	    if (!this.x.red)
+	      this.x = this.x.toRed(this.curve.red);
+	    if (!this.y.red)
+	      this.y = this.y.toRed(this.curve.red);
+	    if (!this.z.red)
+	      this.z = this.z.toRed(this.curve.red);
+	    if (this.t && !this.t.red)
+	      this.t = this.t.toRed(this.curve.red);
+	    this.zOne = this.z === this.curve.one;
+
+	    // Use extended coordinates
+	    if (this.curve.extended && !this.t) {
+	      this.t = this.x.redMul(this.y);
+	      if (!this.zOne)
+	        this.t = this.t.redMul(this.z.redInvm());
+	    }
+	  }
+	}
+	inherits(Point, Base.BasePoint);
+
+	EdwardsCurve.prototype.pointFromJSON = function pointFromJSON(obj) {
+	  return Point.fromJSON(this, obj);
+	};
+
+	EdwardsCurve.prototype.point = function point(x, y, z, t) {
+	  return new Point(this, x, y, z, t);
+	};
+
+	Point.fromJSON = function fromJSON(curve, obj) {
+	  return new Point(curve, obj[0], obj[1], obj[2]);
+	};
+
+	Point.prototype.inspect = function inspect() {
+	  if (this.isInfinity())
+	    return '<EC Point Infinity>';
+	  return '<EC Point x: ' + this.x.fromRed().toString(16, 2) +
+	      ' y: ' + this.y.fromRed().toString(16, 2) +
+	      ' z: ' + this.z.fromRed().toString(16, 2) + '>';
+	};
+
+	Point.prototype.isInfinity = function isInfinity() {
+	  // XXX This code assumes that zero is always zero in red
+	  return this.x.cmpn(0) === 0 &&
+	         this.y.cmp(this.z) === 0;
+	};
+
+	Point.prototype._extDbl = function _extDbl() {
+	  // hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html
+	  //     #doubling-dbl-2008-hwcd
+	  // 4M + 4S
+
+	  // A = X1^2
+	  var a = this.x.redSqr();
+	  // B = Y1^2
+	  var b = this.y.redSqr();
+	  // C = 2 * Z1^2
+	  var c = this.z.redSqr();
+	  c = c.redIAdd(c);
+	  // D = a * A
+	  var d = this.curve._mulA(a);
+	  // E = (X1 + Y1)^2 - A - B
+	  var e = this.x.redAdd(this.y).redSqr().redISub(a).redISub(b);
+	  // G = D + B
+	  var g = d.redAdd(b);
+	  // F = G - C
+	  var f = g.redSub(c);
+	  // H = D - B
+	  var h = d.redSub(b);
+	  // X3 = E * F
+	  var nx = e.redMul(f);
+	  // Y3 = G * H
+	  var ny = g.redMul(h);
+	  // T3 = E * H
+	  var nt = e.redMul(h);
+	  // Z3 = F * G
+	  var nz = f.redMul(g);
+	  return this.curve.point(nx, ny, nz, nt);
+	};
+
+	Point.prototype._projDbl = function _projDbl() {
+	  // hyperelliptic.org/EFD/g1p/auto-twisted-projective.html
+	  //     #doubling-dbl-2008-bbjlp
+	  //     #doubling-dbl-2007-bl
+	  // and others
+	  // Generally 3M + 4S or 2M + 4S
+
+	  // B = (X1 + Y1)^2
+	  var b = this.x.redAdd(this.y).redSqr();
+	  // C = X1^2
+	  var c = this.x.redSqr();
+	  // D = Y1^2
+	  var d = this.y.redSqr();
+
+	  var nx;
+	  var ny;
+	  var nz;
+	  if (this.curve.twisted) {
+	    // E = a * C
+	    var e = this.curve._mulA(c);
+	    // F = E + D
+	    var f = e.redAdd(d);
+	    if (this.zOne) {
+	      // X3 = (B - C - D) * (F - 2)
+	      nx = b.redSub(c).redSub(d).redMul(f.redSub(this.curve.two));
+	      // Y3 = F * (E - D)
+	      ny = f.redMul(e.redSub(d));
+	      // Z3 = F^2 - 2 * F
+	      nz = f.redSqr().redSub(f).redSub(f);
+	    } else {
+	      // H = Z1^2
+	      var h = this.z.redSqr();
+	      // J = F - 2 * H
+	      var j = f.redSub(h).redISub(h);
+	      // X3 = (B-C-D)*J
+	      nx = b.redSub(c).redISub(d).redMul(j);
+	      // Y3 = F * (E - D)
+	      ny = f.redMul(e.redSub(d));
+	      // Z3 = F * J
+	      nz = f.redMul(j);
+	    }
+	  } else {
+	    // E = C + D
+	    var e = c.redAdd(d);
+	    // H = (c * Z1)^2
+	    var h = this.curve._mulC(this.c.redMul(this.z)).redSqr();
+	    // J = E - 2 * H
+	    var j = e.redSub(h).redSub(h);
+	    // X3 = c * (B - E) * J
+	    nx = this.curve._mulC(b.redISub(e)).redMul(j);
+	    // Y3 = c * E * (C - D)
+	    ny = this.curve._mulC(e).redMul(c.redISub(d));
+	    // Z3 = E * J
+	    nz = e.redMul(j);
+	  }
+	  return this.curve.point(nx, ny, nz);
+	};
+
+	Point.prototype.dbl = function dbl() {
+	  if (this.isInfinity())
+	    return this;
+
+	  // Double in extended coordinates
+	  if (this.curve.extended)
+	    return this._extDbl();
+	  else
+	    return this._projDbl();
+	};
+
+	Point.prototype._extAdd = function _extAdd(p) {
+	  // hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html
+	  //     #addition-add-2008-hwcd-3
+	  // 8M
+
+	  // A = (Y1 - X1) * (Y2 - X2)
+	  var a = this.y.redSub(this.x).redMul(p.y.redSub(p.x));
+	  // B = (Y1 + X1) * (Y2 + X2)
+	  var b = this.y.redAdd(this.x).redMul(p.y.redAdd(p.x));
+	  // C = T1 * k * T2
+	  var c = this.t.redMul(this.curve.dd).redMul(p.t);
+	  // D = Z1 * 2 * Z2
+	  var d = this.z.redMul(p.z.redAdd(p.z));
+	  // E = B - A
+	  var e = b.redSub(a);
+	  // F = D - C
+	  var f = d.redSub(c);
+	  // G = D + C
+	  var g = d.redAdd(c);
+	  // H = B + A
+	  var h = b.redAdd(a);
+	  // X3 = E * F
+	  var nx = e.redMul(f);
+	  // Y3 = G * H
+	  var ny = g.redMul(h);
+	  // T3 = E * H
+	  var nt = e.redMul(h);
+	  // Z3 = F * G
+	  var nz = f.redMul(g);
+	  return this.curve.point(nx, ny, nz, nt);
+	};
+
+	Point.prototype._projAdd = function _projAdd(p) {
+	  // hyperelliptic.org/EFD/g1p/auto-twisted-projective.html
+	  //     #addition-add-2008-bbjlp
+	  //     #addition-add-2007-bl
+	  // 10M + 1S
+
+	  // A = Z1 * Z2
+	  var a = this.z.redMul(p.z);
+	  // B = A^2
+	  var b = a.redSqr();
+	  // C = X1 * X2
+	  var c = this.x.redMul(p.x);
+	  // D = Y1 * Y2
+	  var d = this.y.redMul(p.y);
+	  // E = d * C * D
+	  var e = this.curve.d.redMul(c).redMul(d);
+	  // F = B - E
+	  var f = b.redSub(e);
+	  // G = B + E
+	  var g = b.redAdd(e);
+	  // X3 = A * F * ((X1 + Y1) * (X2 + Y2) - C - D)
+	  var tmp = this.x.redAdd(this.y).redMul(p.x.redAdd(p.y)).redISub(c).redISub(d);
+	  var nx = a.redMul(f).redMul(tmp);
+	  var ny;
+	  var nz;
+	  if (this.curve.twisted) {
+	    // Y3 = A * G * (D - a * C)
+	    ny = a.redMul(g).redMul(d.redSub(this.curve._mulA(c)));
+	    // Z3 = F * G
+	    nz = f.redMul(g);
+	  } else {
+	    // Y3 = A * G * (D - C)
+	    ny = a.redMul(g).redMul(d.redSub(c));
+	    // Z3 = c * F * G
+	    nz = this.curve._mulC(f).redMul(g);
+	  }
+	  return this.curve.point(nx, ny, nz);
+	};
+
+	Point.prototype.add = function add(p) {
+	  if (this.isInfinity())
+	    return p;
+	  if (p.isInfinity())
+	    return this;
+
+	  if (this.curve.extended)
+	    return this._extAdd(p);
+	  else
+	    return this._projAdd(p);
+	};
+
+	Point.prototype.mul = function mul(k) {
+	  if (this._hasDoubles(k))
+	    return this.curve._fixedNafMul(this, k);
+	  else
+	    return this.curve._wnafMul(this, k);
+	};
+
+	Point.prototype.mulAdd = function mulAdd(k1, p, k2) {
+	  return this.curve._wnafMulAdd(1, [ this, p ], [ k1, k2 ], 2);
+	};
+
+	Point.prototype.normalize = function normalize() {
+	  if (this.zOne)
+	    return this;
+
+	  // Normalize coordinates
+	  var zi = this.z.redInvm();
+	  this.x = this.x.redMul(zi);
+	  this.y = this.y.redMul(zi);
+	  if (this.t)
+	    this.t = this.t.redMul(zi);
+	  this.z = this.curve.one;
+	  this.zOne = true;
+	  return this;
+	};
+
+	Point.prototype.neg = function neg() {
+	  return this.curve.point(this.x.redNeg(),
+	                          this.y,
+	                          this.z,
+	                          this.t && this.t.redNeg());
+	};
+
+	Point.prototype.getX = function getX() {
+	  this.normalize();
+	  return this.x.fromRed();
+	};
+
+	Point.prototype.getY = function getY() {
+	  this.normalize();
+	  return this.y.fromRed();
+	};
+
+	Point.prototype.eq = function eq(other) {
+	  return this === other ||
+	         this.getX().cmp(other.getX()) === 0 &&
+	         this.getY().cmp(other.getY()) === 0;
+	};
+
+	// Compatibility with BaseCurve
+	Point.prototype.toP = Point.prototype.normalize;
+	Point.prototype.mixedAdd = Point.prototype.add;
+
+
+/***/ }),
+/* 129 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var curves = exports;
+
+	var hash = __webpack_require__(31);
+	var elliptic = __webpack_require__(120);
+
+	var assert = elliptic.utils.assert;
+
+	function PresetCurve(options) {
+	  if (options.type === 'short')
+	    this.curve = new elliptic.curve.short(options);
+	  else if (options.type === 'edwards')
+	    this.curve = new elliptic.curve.edwards(options);
+	  else
+	    this.curve = new elliptic.curve.mont(options);
+	  this.g = this.curve.g;
+	  this.n = this.curve.n;
+	  this.hash = options.hash;
+
+	  assert(this.g.validate(), 'Invalid curve');
+	  assert(this.g.mul(this.n).isInfinity(), 'Invalid curve, G*N != O');
+	}
+	curves.PresetCurve = PresetCurve;
+
+	function defineCurve(name, options) {
+	  Object.defineProperty(curves, name, {
+	    configurable: true,
+	    enumerable: true,
+	    get: function() {
+	      var curve = new PresetCurve(options);
+	      Object.defineProperty(curves, name, {
+	        configurable: true,
+	        enumerable: true,
+	        value: curve
+	      });
+	      return curve;
+	    }
+	  });
+	}
+
+	defineCurve('p192', {
+	  type: 'short',
+	  prime: 'p192',
+	  p: 'ffffffff ffffffff ffffffff fffffffe ffffffff ffffffff',
+	  a: 'ffffffff ffffffff ffffffff fffffffe ffffffff fffffffc',
+	  b: '64210519 e59c80e7 0fa7e9ab 72243049 feb8deec c146b9b1',
+	  n: 'ffffffff ffffffff ffffffff 99def836 146bc9b1 b4d22831',
+	  hash: hash.sha256,
+	  gRed: false,
+	  g: [
+	    '188da80e b03090f6 7cbf20eb 43a18800 f4ff0afd 82ff1012',
+	    '07192b95 ffc8da78 631011ed 6b24cdd5 73f977a1 1e794811'
+	  ]
+	});
+
+	defineCurve('p224', {
+	  type: 'short',
+	  prime: 'p224',
+	  p: 'ffffffff ffffffff ffffffff ffffffff 00000000 00000000 00000001',
+	  a: 'ffffffff ffffffff ffffffff fffffffe ffffffff ffffffff fffffffe',
+	  b: 'b4050a85 0c04b3ab f5413256 5044b0b7 d7bfd8ba 270b3943 2355ffb4',
+	  n: 'ffffffff ffffffff ffffffff ffff16a2 e0b8f03e 13dd2945 5c5c2a3d',
+	  hash: hash.sha256,
+	  gRed: false,
+	  g: [
+	    'b70e0cbd 6bb4bf7f 321390b9 4a03c1d3 56c21122 343280d6 115c1d21',
+	    'bd376388 b5f723fb 4c22dfe6 cd4375a0 5a074764 44d58199 85007e34'
+	  ]
+	});
+
+	defineCurve('p256', {
+	  type: 'short',
+	  prime: null,
+	  p: 'ffffffff 00000001 00000000 00000000 00000000 ffffffff ffffffff ffffffff',
+	  a: 'ffffffff 00000001 00000000 00000000 00000000 ffffffff ffffffff fffffffc',
+	  b: '5ac635d8 aa3a93e7 b3ebbd55 769886bc 651d06b0 cc53b0f6 3bce3c3e 27d2604b',
+	  n: 'ffffffff 00000000 ffffffff ffffffff bce6faad a7179e84 f3b9cac2 fc632551',
+	  hash: hash.sha256,
+	  gRed: false,
+	  g: [
+	    '6b17d1f2 e12c4247 f8bce6e5 63a440f2 77037d81 2deb33a0 f4a13945 d898c296',
+	    '4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16 2bce3357 6b315ece cbb64068 37bf51f5'
+	  ]
+	});
+
+	defineCurve('p384', {
+	  type: 'short',
+	  prime: null,
+	  p: 'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ' +
+	     'fffffffe ffffffff 00000000 00000000 ffffffff',
+	  a: 'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ' +
+	     'fffffffe ffffffff 00000000 00000000 fffffffc',
+	  b: 'b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112 0314088f ' +
+	     '5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef',
+	  n: 'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff c7634d81 ' +
+	     'f4372ddf 581a0db2 48b0a77a ecec196a ccc52973',
+	  hash: hash.sha384,
+	  gRed: false,
+	  g: [
+	    'aa87ca22 be8b0537 8eb1c71e f320ad74 6e1d3b62 8ba79b98 59f741e0 82542a38 ' +
+	    '5502f25d bf55296c 3a545e38 72760ab7',
+	    '3617de4a 96262c6f 5d9e98bf 9292dc29 f8f41dbd 289a147c e9da3113 b5f0b8c0 ' +
+	    '0a60b1ce 1d7e819d 7a431d7c 90ea0e5f'
+	  ]
+	});
+
+	defineCurve('p521', {
+	  type: 'short',
+	  prime: null,
+	  p: '000001ff ffffffff ffffffff ffffffff ffffffff ffffffff ' +
+	     'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ' +
+	     'ffffffff ffffffff ffffffff ffffffff ffffffff',
+	  a: '000001ff ffffffff ffffffff ffffffff ffffffff ffffffff ' +
+	     'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ' +
+	     'ffffffff ffffffff ffffffff ffffffff fffffffc',
+	  b: '00000051 953eb961 8e1c9a1f 929a21a0 b68540ee a2da725b ' +
+	     '99b315f3 b8b48991 8ef109e1 56193951 ec7e937b 1652c0bd ' +
+	     '3bb1bf07 3573df88 3d2c34f1 ef451fd4 6b503f00',
+	  n: '000001ff ffffffff ffffffff ffffffff ffffffff ffffffff ' +
+	     'ffffffff ffffffff fffffffa 51868783 bf2f966b 7fcc0148 ' +
+	     'f709a5d0 3bb5c9b8 899c47ae bb6fb71e 91386409',
+	  hash: hash.sha512,
+	  gRed: false,
+	  g: [
+	    '000000c6 858e06b7 0404e9cd 9e3ecb66 2395b442 9c648139 ' +
+	    '053fb521 f828af60 6b4d3dba a14b5e77 efe75928 fe1dc127 ' +
+	    'a2ffa8de 3348b3c1 856a429b f97e7e31 c2e5bd66',
+	    '00000118 39296a78 9a3bc004 5c8a5fb4 2c7d1bd9 98f54449 ' +
+	    '579b4468 17afbd17 273e662c 97ee7299 5ef42640 c550b901 ' +
+	    '3fad0761 353c7086 a272c240 88be9476 9fd16650'
+	  ]
+	});
+
+	defineCurve('curve25519', {
+	  type: 'mont',
+	  prime: 'p25519',
+	  p: '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed',
+	  a: '76d06',
+	  b: '0',
+	  n: '1000000000000000 0000000000000000 14def9dea2f79cd6 5812631a5cf5d3ed',
+	  hash: hash.sha256,
+	  gRed: false,
+	  g: [
+	    '9'
+	  ]
+	});
+
+	defineCurve('ed25519', {
+	  type: 'edwards',
+	  prime: 'p25519',
+	  p: '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed',
+	  a: '-1',
+	  c: '1',
+	  // -121665 * (121666^(-1)) (mod P)
+	  d: '52036cee2b6ffe73 8cc740797779e898 00700a4d4141d8ab 75eb4dca135978a3',
+	  n: '1000000000000000 0000000000000000 14def9dea2f79cd6 5812631a5cf5d3ed',
+	  hash: hash.sha256,
+	  gRed: false,
+	  g: [
+	    '216936d3cd6e53fec0a4e231fdd6dc5c692cc7609525a7b2c9562d608f25d51a',
+
+	    // 4/5
+	    '6666666666666666666666666666666666666666666666666666666666666658'
+	  ]
+	});
+
+	var pre;
+	try {
+	  pre = __webpack_require__(130);
+	} catch (e) {
+	  pre = undefined;
+	}
+
+	defineCurve('secp256k1', {
+	  type: 'short',
+	  prime: 'k256',
+	  p: 'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f',
+	  a: '0',
+	  b: '7',
+	  n: 'ffffffff ffffffff ffffffff fffffffe baaedce6 af48a03b bfd25e8c d0364141',
+	  h: '1',
+	  hash: hash.sha256,
+
+	  // Precomputed endomorphism
+	  beta: '7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee',
+	  lambda: '5363ad4cc05c30e0a5261c028812645a122e22ea20816678df02967c1b23bd72',
+	  basis: [
+	    {
+	      a: '3086d221a7d46bcde86c90e49284eb15',
+	      b: '-e4437ed6010e88286f547fa90abfe4c3'
+	    },
+	    {
+	      a: '114ca50f7a8e2f3f657c1108d9d44cfd8',
+	      b: '3086d221a7d46bcde86c90e49284eb15'
+	    }
+	  ],
+
+	  gRed: false,
+	  g: [
+	    '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+	    '483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
+	    pre
+	  ]
+	});
+
+
+/***/ }),
+/* 130 */
+/***/ (function(module, exports) {
+
+	module.exports = {
+	  doubles: {
+	    step: 4,
+	    points: [
+	      [
+	        'e60fce93b59e9ec53011aabc21c23e97b2a31369b87a5ae9c44ee89e2a6dec0a',
+	        'f7e3507399e595929db99f34f57937101296891e44d23f0be1f32cce69616821'
+	      ],
+	      [
+	        '8282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508',
+	        '11f8a8098557dfe45e8256e830b60ace62d613ac2f7b17bed31b6eaff6e26caf'
+	      ],
+	      [
+	        '175e159f728b865a72f99cc6c6fc846de0b93833fd2222ed73fce5b551e5b739',
+	        'd3506e0d9e3c79eba4ef97a51ff71f5eacb5955add24345c6efa6ffee9fed695'
+	      ],
+	      [
+	        '363d90d447b00c9c99ceac05b6262ee053441c7e55552ffe526bad8f83ff4640',
+	        '4e273adfc732221953b445397f3363145b9a89008199ecb62003c7f3bee9de9'
+	      ],
+	      [
+	        '8b4b5f165df3c2be8c6244b5b745638843e4a781a15bcd1b69f79a55dffdf80c',
+	        '4aad0a6f68d308b4b3fbd7813ab0da04f9e336546162ee56b3eff0c65fd4fd36'
+	      ],
+	      [
+	        '723cbaa6e5db996d6bf771c00bd548c7b700dbffa6c0e77bcb6115925232fcda',
+	        '96e867b5595cc498a921137488824d6e2660a0653779494801dc069d9eb39f5f'
+	      ],
+	      [
+	        'eebfa4d493bebf98ba5feec812c2d3b50947961237a919839a533eca0e7dd7fa',
+	        '5d9a8ca3970ef0f269ee7edaf178089d9ae4cdc3a711f712ddfd4fdae1de8999'
+	      ],
+	      [
+	        '100f44da696e71672791d0a09b7bde459f1215a29b3c03bfefd7835b39a48db0',
+	        'cdd9e13192a00b772ec8f3300c090666b7ff4a18ff5195ac0fbd5cd62bc65a09'
+	      ],
+	      [
+	        'e1031be262c7ed1b1dc9227a4a04c017a77f8d4464f3b3852c8acde6e534fd2d',
+	        '9d7061928940405e6bb6a4176597535af292dd419e1ced79a44f18f29456a00d'
+	      ],
+	      [
+	        'feea6cae46d55b530ac2839f143bd7ec5cf8b266a41d6af52d5e688d9094696d',
+	        'e57c6b6c97dce1bab06e4e12bf3ecd5c981c8957cc41442d3155debf18090088'
+	      ],
+	      [
+	        'da67a91d91049cdcb367be4be6ffca3cfeed657d808583de33fa978bc1ec6cb1',
+	        '9bacaa35481642bc41f463f7ec9780e5dec7adc508f740a17e9ea8e27a68be1d'
+	      ],
+	      [
+	        '53904faa0b334cdda6e000935ef22151ec08d0f7bb11069f57545ccc1a37b7c0',
+	        '5bc087d0bc80106d88c9eccac20d3c1c13999981e14434699dcb096b022771c8'
+	      ],
+	      [
+	        '8e7bcd0bd35983a7719cca7764ca906779b53a043a9b8bcaeff959f43ad86047',
+	        '10b7770b2a3da4b3940310420ca9514579e88e2e47fd68b3ea10047e8460372a'
+	      ],
+	      [
+	        '385eed34c1cdff21e6d0818689b81bde71a7f4f18397e6690a841e1599c43862',
+	        '283bebc3e8ea23f56701de19e9ebf4576b304eec2086dc8cc0458fe5542e5453'
+	      ],
+	      [
+	        '6f9d9b803ecf191637c73a4413dfa180fddf84a5947fbc9c606ed86c3fac3a7',
+	        '7c80c68e603059ba69b8e2a30e45c4d47ea4dd2f5c281002d86890603a842160'
+	      ],
+	      [
+	        '3322d401243c4e2582a2147c104d6ecbf774d163db0f5e5313b7e0e742d0e6bd',
+	        '56e70797e9664ef5bfb019bc4ddaf9b72805f63ea2873af624f3a2e96c28b2a0'
+	      ],
+	      [
+	        '85672c7d2de0b7da2bd1770d89665868741b3f9af7643397721d74d28134ab83',
+	        '7c481b9b5b43b2eb6374049bfa62c2e5e77f17fcc5298f44c8e3094f790313a6'
+	      ],
+	      [
+	        '948bf809b1988a46b06c9f1919413b10f9226c60f668832ffd959af60c82a0a',
+	        '53a562856dcb6646dc6b74c5d1c3418c6d4dff08c97cd2bed4cb7f88d8c8e589'
+	      ],
+	      [
+	        '6260ce7f461801c34f067ce0f02873a8f1b0e44dfc69752accecd819f38fd8e8',
+	        'bc2da82b6fa5b571a7f09049776a1ef7ecd292238051c198c1a84e95b2b4ae17'
+	      ],
+	      [
+	        'e5037de0afc1d8d43d8348414bbf4103043ec8f575bfdc432953cc8d2037fa2d',
+	        '4571534baa94d3b5f9f98d09fb990bddbd5f5b03ec481f10e0e5dc841d755bda'
+	      ],
+	      [
+	        'e06372b0f4a207adf5ea905e8f1771b4e7e8dbd1c6a6c5b725866a0ae4fce725',
+	        '7a908974bce18cfe12a27bb2ad5a488cd7484a7787104870b27034f94eee31dd'
+	      ],
+	      [
+	        '213c7a715cd5d45358d0bbf9dc0ce02204b10bdde2a3f58540ad6908d0559754',
+	        '4b6dad0b5ae462507013ad06245ba190bb4850f5f36a7eeddff2c27534b458f2'
+	      ],
+	      [
+	        '4e7c272a7af4b34e8dbb9352a5419a87e2838c70adc62cddf0cc3a3b08fbd53c',
+	        '17749c766c9d0b18e16fd09f6def681b530b9614bff7dd33e0b3941817dcaae6'
+	      ],
+	      [
+	        'fea74e3dbe778b1b10f238ad61686aa5c76e3db2be43057632427e2840fb27b6',
+	        '6e0568db9b0b13297cf674deccb6af93126b596b973f7b77701d3db7f23cb96f'
+	      ],
+	      [
+	        '76e64113f677cf0e10a2570d599968d31544e179b760432952c02a4417bdde39',
+	        'c90ddf8dee4e95cf577066d70681f0d35e2a33d2b56d2032b4b1752d1901ac01'
+	      ],
+	      [
+	        'c738c56b03b2abe1e8281baa743f8f9a8f7cc643df26cbee3ab150242bcbb891',
+	        '893fb578951ad2537f718f2eacbfbbbb82314eef7880cfe917e735d9699a84c3'
+	      ],
+	      [
+	        'd895626548b65b81e264c7637c972877d1d72e5f3a925014372e9f6588f6c14b',
+	        'febfaa38f2bc7eae728ec60818c340eb03428d632bb067e179363ed75d7d991f'
+	      ],
+	      [
+	        'b8da94032a957518eb0f6433571e8761ceffc73693e84edd49150a564f676e03',
+	        '2804dfa44805a1e4d7c99cc9762808b092cc584d95ff3b511488e4e74efdf6e7'
+	      ],
+	      [
+	        'e80fea14441fb33a7d8adab9475d7fab2019effb5156a792f1a11778e3c0df5d',
+	        'eed1de7f638e00771e89768ca3ca94472d155e80af322ea9fcb4291b6ac9ec78'
+	      ],
+	      [
+	        'a301697bdfcd704313ba48e51d567543f2a182031efd6915ddc07bbcc4e16070',
+	        '7370f91cfb67e4f5081809fa25d40f9b1735dbf7c0a11a130c0d1a041e177ea1'
+	      ],
+	      [
+	        '90ad85b389d6b936463f9d0512678de208cc330b11307fffab7ac63e3fb04ed4',
+	        'e507a3620a38261affdcbd9427222b839aefabe1582894d991d4d48cb6ef150'
+	      ],
+	      [
+	        '8f68b9d2f63b5f339239c1ad981f162ee88c5678723ea3351b7b444c9ec4c0da',
+	        '662a9f2dba063986de1d90c2b6be215dbbea2cfe95510bfdf23cbf79501fff82'
+	      ],
+	      [
+	        'e4f3fb0176af85d65ff99ff9198c36091f48e86503681e3e6686fd5053231e11',
+	        '1e63633ad0ef4f1c1661a6d0ea02b7286cc7e74ec951d1c9822c38576feb73bc'
+	      ],
+	      [
+	        '8c00fa9b18ebf331eb961537a45a4266c7034f2f0d4e1d0716fb6eae20eae29e',
+	        'efa47267fea521a1a9dc343a3736c974c2fadafa81e36c54e7d2a4c66702414b'
+	      ],
+	      [
+	        'e7a26ce69dd4829f3e10cec0a9e98ed3143d084f308b92c0997fddfc60cb3e41',
+	        '2a758e300fa7984b471b006a1aafbb18d0a6b2c0420e83e20e8a9421cf2cfd51'
+	      ],
+	      [
+	        'b6459e0ee3662ec8d23540c223bcbdc571cbcb967d79424f3cf29eb3de6b80ef',
+	        '67c876d06f3e06de1dadf16e5661db3c4b3ae6d48e35b2ff30bf0b61a71ba45'
+	      ],
+	      [
+	        'd68a80c8280bb840793234aa118f06231d6f1fc67e73c5a5deda0f5b496943e8',
+	        'db8ba9fff4b586d00c4b1f9177b0e28b5b0e7b8f7845295a294c84266b133120'
+	      ],
+	      [
+	        '324aed7df65c804252dc0270907a30b09612aeb973449cea4095980fc28d3d5d',
+	        '648a365774b61f2ff130c0c35aec1f4f19213b0c7e332843967224af96ab7c84'
+	      ],
+	      [
+	        '4df9c14919cde61f6d51dfdbe5fee5dceec4143ba8d1ca888e8bd373fd054c96',
+	        '35ec51092d8728050974c23a1d85d4b5d506cdc288490192ebac06cad10d5d'
+	      ],
+	      [
+	        '9c3919a84a474870faed8a9c1cc66021523489054d7f0308cbfc99c8ac1f98cd',
+	        'ddb84f0f4a4ddd57584f044bf260e641905326f76c64c8e6be7e5e03d4fc599d'
+	      ],
+	      [
+	        '6057170b1dd12fdf8de05f281d8e06bb91e1493a8b91d4cc5a21382120a959e5',
+	        '9a1af0b26a6a4807add9a2daf71df262465152bc3ee24c65e899be932385a2a8'
+	      ],
+	      [
+	        'a576df8e23a08411421439a4518da31880cef0fba7d4df12b1a6973eecb94266',
+	        '40a6bf20e76640b2c92b97afe58cd82c432e10a7f514d9f3ee8be11ae1b28ec8'
+	      ],
+	      [
+	        '7778a78c28dec3e30a05fe9629de8c38bb30d1f5cf9a3a208f763889be58ad71',
+	        '34626d9ab5a5b22ff7098e12f2ff580087b38411ff24ac563b513fc1fd9f43ac'
+	      ],
+	      [
+	        '928955ee637a84463729fd30e7afd2ed5f96274e5ad7e5cb09eda9c06d903ac',
+	        'c25621003d3f42a827b78a13093a95eeac3d26efa8a8d83fc5180e935bcd091f'
+	      ],
+	      [
+	        '85d0fef3ec6db109399064f3a0e3b2855645b4a907ad354527aae75163d82751',
+	        '1f03648413a38c0be29d496e582cf5663e8751e96877331582c237a24eb1f962'
+	      ],
+	      [
+	        'ff2b0dce97eece97c1c9b6041798b85dfdfb6d8882da20308f5404824526087e',
+	        '493d13fef524ba188af4c4dc54d07936c7b7ed6fb90e2ceb2c951e01f0c29907'
+	      ],
+	      [
+	        '827fbbe4b1e880ea9ed2b2e6301b212b57f1ee148cd6dd28780e5e2cf856e241',
+	        'c60f9c923c727b0b71bef2c67d1d12687ff7a63186903166d605b68baec293ec'
+	      ],
+	      [
+	        'eaa649f21f51bdbae7be4ae34ce6e5217a58fdce7f47f9aa7f3b58fa2120e2b3',
+	        'be3279ed5bbbb03ac69a80f89879aa5a01a6b965f13f7e59d47a5305ba5ad93d'
+	      ],
+	      [
+	        'e4a42d43c5cf169d9391df6decf42ee541b6d8f0c9a137401e23632dda34d24f',
+	        '4d9f92e716d1c73526fc99ccfb8ad34ce886eedfa8d8e4f13a7f7131deba9414'
+	      ],
+	      [
+	        '1ec80fef360cbdd954160fadab352b6b92b53576a88fea4947173b9d4300bf19',
+	        'aeefe93756b5340d2f3a4958a7abbf5e0146e77f6295a07b671cdc1cc107cefd'
+	      ],
+	      [
+	        '146a778c04670c2f91b00af4680dfa8bce3490717d58ba889ddb5928366642be',
+	        'b318e0ec3354028add669827f9d4b2870aaa971d2f7e5ed1d0b297483d83efd0'
+	      ],
+	      [
+	        'fa50c0f61d22e5f07e3acebb1aa07b128d0012209a28b9776d76a8793180eef9',
+	        '6b84c6922397eba9b72cd2872281a68a5e683293a57a213b38cd8d7d3f4f2811'
+	      ],
+	      [
+	        'da1d61d0ca721a11b1a5bf6b7d88e8421a288ab5d5bba5220e53d32b5f067ec2',
+	        '8157f55a7c99306c79c0766161c91e2966a73899d279b48a655fba0f1ad836f1'
+	      ],
+	      [
+	        'a8e282ff0c9706907215ff98e8fd416615311de0446f1e062a73b0610d064e13',
+	        '7f97355b8db81c09abfb7f3c5b2515888b679a3e50dd6bd6cef7c73111f4cc0c'
+	      ],
+	      [
+	        '174a53b9c9a285872d39e56e6913cab15d59b1fa512508c022f382de8319497c',
+	        'ccc9dc37abfc9c1657b4155f2c47f9e6646b3a1d8cb9854383da13ac079afa73'
+	      ],
+	      [
+	        '959396981943785c3d3e57edf5018cdbe039e730e4918b3d884fdff09475b7ba',
+	        '2e7e552888c331dd8ba0386a4b9cd6849c653f64c8709385e9b8abf87524f2fd'
+	      ],
+	      [
+	        'd2a63a50ae401e56d645a1153b109a8fcca0a43d561fba2dbb51340c9d82b151',
+	        'e82d86fb6443fcb7565aee58b2948220a70f750af484ca52d4142174dcf89405'
+	      ],
+	      [
+	        '64587e2335471eb890ee7896d7cfdc866bacbdbd3839317b3436f9b45617e073',
+	        'd99fcdd5bf6902e2ae96dd6447c299a185b90a39133aeab358299e5e9faf6589'
+	      ],
+	      [
+	        '8481bde0e4e4d885b3a546d3e549de042f0aa6cea250e7fd358d6c86dd45e458',
+	        '38ee7b8cba5404dd84a25bf39cecb2ca900a79c42b262e556d64b1b59779057e'
+	      ],
+	      [
+	        '13464a57a78102aa62b6979ae817f4637ffcfed3c4b1ce30bcd6303f6caf666b',
+	        '69be159004614580ef7e433453ccb0ca48f300a81d0942e13f495a907f6ecc27'
+	      ],
+	      [
+	        'bc4a9df5b713fe2e9aef430bcc1dc97a0cd9ccede2f28588cada3a0d2d83f366',
+	        'd3a81ca6e785c06383937adf4b798caa6e8a9fbfa547b16d758d666581f33c1'
+	      ],
+	      [
+	        '8c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa',
+	        '40a30463a3305193378fedf31f7cc0eb7ae784f0451cb9459e71dc73cbef9482'
+	      ],
+	      [
+	        '8ea9666139527a8c1dd94ce4f071fd23c8b350c5a4bb33748c4ba111faccae0',
+	        '620efabbc8ee2782e24e7c0cfb95c5d735b783be9cf0f8e955af34a30e62b945'
+	      ],
+	      [
+	        'dd3625faef5ba06074669716bbd3788d89bdde815959968092f76cc4eb9a9787',
+	        '7a188fa3520e30d461da2501045731ca941461982883395937f68d00c644a573'
+	      ],
+	      [
+	        'f710d79d9eb962297e4f6232b40e8f7feb2bc63814614d692c12de752408221e',
+	        'ea98e67232d3b3295d3b535532115ccac8612c721851617526ae47a9c77bfc82'
+	      ]
+	    ]
+	  },
+	  naf: {
+	    wnd: 7,
+	    points: [
+	      [
+	        'f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9',
+	        '388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672'
+	      ],
+	      [
+	        '2f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4',
+	        'd8ac222636e5e3d6d4dba9dda6c9c426f788271bab0d6840dca87d3aa6ac62d6'
+	      ],
+	      [
+	        '5cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc',
+	        '6aebca40ba255960a3178d6d861a54dba813d0b813fde7b5a5082628087264da'
+	      ],
+	      [
+	        'acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe',
+	        'cc338921b0a7d9fd64380971763b61e9add888a4375f8e0f05cc262ac64f9c37'
+	      ],
+	      [
+	        '774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb',
+	        'd984a032eb6b5e190243dd56d7b7b365372db1e2dff9d6a8301d74c9c953c61b'
+	      ],
+	      [
+	        'f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8',
+	        'ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81'
+	      ],
+	      [
+	        'd7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e',
+	        '581e2872a86c72a683842ec228cc6defea40af2bd896d3a5c504dc9ff6a26b58'
+	      ],
+	      [
+	        'defdea4cdb677750a420fee807eacf21eb9898ae79b9768766e4faa04a2d4a34',
+	        '4211ab0694635168e997b0ead2a93daeced1f4a04a95c0f6cfb199f69e56eb77'
+	      ],
+	      [
+	        '2b4ea0a797a443d293ef5cff444f4979f06acfebd7e86d277475656138385b6c',
+	        '85e89bc037945d93b343083b5a1c86131a01f60c50269763b570c854e5c09b7a'
+	      ],
+	      [
+	        '352bbf4a4cdd12564f93fa332ce333301d9ad40271f8107181340aef25be59d5',
+	        '321eb4075348f534d59c18259dda3e1f4a1b3b2e71b1039c67bd3d8bcf81998c'
+	      ],
+	      [
+	        '2fa2104d6b38d11b0230010559879124e42ab8dfeff5ff29dc9cdadd4ecacc3f',
+	        '2de1068295dd865b64569335bd5dd80181d70ecfc882648423ba76b532b7d67'
+	      ],
+	      [
+	        '9248279b09b4d68dab21a9b066edda83263c3d84e09572e269ca0cd7f5453714',
+	        '73016f7bf234aade5d1aa71bdea2b1ff3fc0de2a887912ffe54a32ce97cb3402'
+	      ],
+	      [
+	        'daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee8729',
+	        'a69dce4a7d6c98e8d4a1aca87ef8d7003f83c230f3afa726ab40e52290be1c55'
+	      ],
+	      [
+	        'c44d12c7065d812e8acf28d7cbb19f9011ecd9e9fdf281b0e6a3b5e87d22e7db',
+	        '2119a460ce326cdc76c45926c982fdac0e106e861edf61c5a039063f0e0e6482'
+	      ],
+	      [
+	        '6a245bf6dc698504c89a20cfded60853152b695336c28063b61c65cbd269e6b4',
+	        'e022cf42c2bd4a708b3f5126f16a24ad8b33ba48d0423b6efd5e6348100d8a82'
+	      ],
+	      [
+	        '1697ffa6fd9de627c077e3d2fe541084ce13300b0bec1146f95ae57f0d0bd6a5',
+	        'b9c398f186806f5d27561506e4557433a2cf15009e498ae7adee9d63d01b2396'
+	      ],
+	      [
+	        '605bdb019981718b986d0f07e834cb0d9deb8360ffb7f61df982345ef27a7479',
+	        '2972d2de4f8d20681a78d93ec96fe23c26bfae84fb14db43b01e1e9056b8c49'
+	      ],
+	      [
+	        '62d14dab4150bf497402fdc45a215e10dcb01c354959b10cfe31c7e9d87ff33d',
+	        '80fc06bd8cc5b01098088a1950eed0db01aa132967ab472235f5642483b25eaf'
+	      ],
+	      [
+	        '80c60ad0040f27dade5b4b06c408e56b2c50e9f56b9b8b425e555c2f86308b6f',
+	        '1c38303f1cc5c30f26e66bad7fe72f70a65eed4cbe7024eb1aa01f56430bd57a'
+	      ],
+	      [
+	        '7a9375ad6167ad54aa74c6348cc54d344cc5dc9487d847049d5eabb0fa03c8fb',
+	        'd0e3fa9eca8726909559e0d79269046bdc59ea10c70ce2b02d499ec224dc7f7'
+	      ],
+	      [
+	        'd528ecd9b696b54c907a9ed045447a79bb408ec39b68df504bb51f459bc3ffc9',
+	        'eecf41253136e5f99966f21881fd656ebc4345405c520dbc063465b521409933'
+	      ],
+	      [
+	        '49370a4b5f43412ea25f514e8ecdad05266115e4a7ecb1387231808f8b45963',
+	        '758f3f41afd6ed428b3081b0512fd62a54c3f3afbb5b6764b653052a12949c9a'
+	      ],
+	      [
+	        '77f230936ee88cbbd73df930d64702ef881d811e0e1498e2f1c13eb1fc345d74',
+	        '958ef42a7886b6400a08266e9ba1b37896c95330d97077cbbe8eb3c7671c60d6'
+	      ],
+	      [
+	        'f2dac991cc4ce4b9ea44887e5c7c0bce58c80074ab9d4dbaeb28531b7739f530',
+	        'e0dedc9b3b2f8dad4da1f32dec2531df9eb5fbeb0598e4fd1a117dba703a3c37'
+	      ],
+	      [
+	        '463b3d9f662621fb1b4be8fbbe2520125a216cdfc9dae3debcba4850c690d45b',
+	        '5ed430d78c296c3543114306dd8622d7c622e27c970a1de31cb377b01af7307e'
+	      ],
+	      [
+	        'f16f804244e46e2a09232d4aff3b59976b98fac14328a2d1a32496b49998f247',
+	        'cedabd9b82203f7e13d206fcdf4e33d92a6c53c26e5cce26d6579962c4e31df6'
+	      ],
+	      [
+	        'caf754272dc84563b0352b7a14311af55d245315ace27c65369e15f7151d41d1',
+	        'cb474660ef35f5f2a41b643fa5e460575f4fa9b7962232a5c32f908318a04476'
+	      ],
+	      [
+	        '2600ca4b282cb986f85d0f1709979d8b44a09c07cb86d7c124497bc86f082120',
+	        '4119b88753c15bd6a693b03fcddbb45d5ac6be74ab5f0ef44b0be9475a7e4b40'
+	      ],
+	      [
+	        '7635ca72d7e8432c338ec53cd12220bc01c48685e24f7dc8c602a7746998e435',
+	        '91b649609489d613d1d5e590f78e6d74ecfc061d57048bad9e76f302c5b9c61'
+	      ],
+	      [
+	        '754e3239f325570cdbbf4a87deee8a66b7f2b33479d468fbc1a50743bf56cc18',
+	        '673fb86e5bda30fb3cd0ed304ea49a023ee33d0197a695d0c5d98093c536683'
+	      ],
+	      [
+	        'e3e6bd1071a1e96aff57859c82d570f0330800661d1c952f9fe2694691d9b9e8',
+	        '59c9e0bba394e76f40c0aa58379a3cb6a5a2283993e90c4167002af4920e37f5'
+	      ],
+	      [
+	        '186b483d056a033826ae73d88f732985c4ccb1f32ba35f4b4cc47fdcf04aa6eb',
+	        '3b952d32c67cf77e2e17446e204180ab21fb8090895138b4a4a797f86e80888b'
+	      ],
+	      [
+	        'df9d70a6b9876ce544c98561f4be4f725442e6d2b737d9c91a8321724ce0963f',
+	        '55eb2dafd84d6ccd5f862b785dc39d4ab157222720ef9da217b8c45cf2ba2417'
+	      ],
+	      [
+	        '5edd5cc23c51e87a497ca815d5dce0f8ab52554f849ed8995de64c5f34ce7143',
+	        'efae9c8dbc14130661e8cec030c89ad0c13c66c0d17a2905cdc706ab7399a868'
+	      ],
+	      [
+	        '290798c2b6476830da12fe02287e9e777aa3fba1c355b17a722d362f84614fba',
+	        'e38da76dcd440621988d00bcf79af25d5b29c094db2a23146d003afd41943e7a'
+	      ],
+	      [
+	        'af3c423a95d9f5b3054754efa150ac39cd29552fe360257362dfdecef4053b45',
+	        'f98a3fd831eb2b749a93b0e6f35cfb40c8cd5aa667a15581bc2feded498fd9c6'
+	      ],
+	      [
+	        '766dbb24d134e745cccaa28c99bf274906bb66b26dcf98df8d2fed50d884249a',
+	        '744b1152eacbe5e38dcc887980da38b897584a65fa06cedd2c924f97cbac5996'
+	      ],
+	      [
+	        '59dbf46f8c94759ba21277c33784f41645f7b44f6c596a58ce92e666191abe3e',
+	        'c534ad44175fbc300f4ea6ce648309a042ce739a7919798cd85e216c4a307f6e'
+	      ],
+	      [
+	        'f13ada95103c4537305e691e74e9a4a8dd647e711a95e73cb62dc6018cfd87b8',
+	        'e13817b44ee14de663bf4bc808341f326949e21a6a75c2570778419bdaf5733d'
+	      ],
+	      [
+	        '7754b4fa0e8aced06d4167a2c59cca4cda1869c06ebadfb6488550015a88522c',
+	        '30e93e864e669d82224b967c3020b8fa8d1e4e350b6cbcc537a48b57841163a2'
+	      ],
+	      [
+	        '948dcadf5990e048aa3874d46abef9d701858f95de8041d2a6828c99e2262519',
+	        'e491a42537f6e597d5d28a3224b1bc25df9154efbd2ef1d2cbba2cae5347d57e'
+	      ],
+	      [
+	        '7962414450c76c1689c7b48f8202ec37fb224cf5ac0bfa1570328a8a3d7c77ab',
+	        '100b610ec4ffb4760d5c1fc133ef6f6b12507a051f04ac5760afa5b29db83437'
+	      ],
+	      [
+	        '3514087834964b54b15b160644d915485a16977225b8847bb0dd085137ec47ca',
+	        'ef0afbb2056205448e1652c48e8127fc6039e77c15c2378b7e7d15a0de293311'
+	      ],
+	      [
+	        'd3cc30ad6b483e4bc79ce2c9dd8bc54993e947eb8df787b442943d3f7b527eaf',
+	        '8b378a22d827278d89c5e9be8f9508ae3c2ad46290358630afb34db04eede0a4'
+	      ],
+	      [
+	        '1624d84780732860ce1c78fcbfefe08b2b29823db913f6493975ba0ff4847610',
+	        '68651cf9b6da903e0914448c6cd9d4ca896878f5282be4c8cc06e2a404078575'
+	      ],
+	      [
+	        '733ce80da955a8a26902c95633e62a985192474b5af207da6df7b4fd5fc61cd4',
+	        'f5435a2bd2badf7d485a4d8b8db9fcce3e1ef8e0201e4578c54673bc1dc5ea1d'
+	      ],
+	      [
+	        '15d9441254945064cf1a1c33bbd3b49f8966c5092171e699ef258dfab81c045c',
+	        'd56eb30b69463e7234f5137b73b84177434800bacebfc685fc37bbe9efe4070d'
+	      ],
+	      [
+	        'a1d0fcf2ec9de675b612136e5ce70d271c21417c9d2b8aaaac138599d0717940',
+	        'edd77f50bcb5a3cab2e90737309667f2641462a54070f3d519212d39c197a629'
+	      ],
+	      [
+	        'e22fbe15c0af8ccc5780c0735f84dbe9a790badee8245c06c7ca37331cb36980',
+	        'a855babad5cd60c88b430a69f53a1a7a38289154964799be43d06d77d31da06'
+	      ],
+	      [
+	        '311091dd9860e8e20ee13473c1155f5f69635e394704eaa74009452246cfa9b3',
+	        '66db656f87d1f04fffd1f04788c06830871ec5a64feee685bd80f0b1286d8374'
+	      ],
+	      [
+	        '34c1fd04d301be89b31c0442d3e6ac24883928b45a9340781867d4232ec2dbdf',
+	        '9414685e97b1b5954bd46f730174136d57f1ceeb487443dc5321857ba73abee'
+	      ],
+	      [
+	        'f219ea5d6b54701c1c14de5b557eb42a8d13f3abbcd08affcc2a5e6b049b8d63',
+	        '4cb95957e83d40b0f73af4544cccf6b1f4b08d3c07b27fb8d8c2962a400766d1'
+	      ],
+	      [
+	        'd7b8740f74a8fbaab1f683db8f45de26543a5490bca627087236912469a0b448',
+	        'fa77968128d9c92ee1010f337ad4717eff15db5ed3c049b3411e0315eaa4593b'
+	      ],
+	      [
+	        '32d31c222f8f6f0ef86f7c98d3a3335ead5bcd32abdd94289fe4d3091aa824bf',
+	        '5f3032f5892156e39ccd3d7915b9e1da2e6dac9e6f26e961118d14b8462e1661'
+	      ],
+	      [
+	        '7461f371914ab32671045a155d9831ea8793d77cd59592c4340f86cbc18347b5',
+	        '8ec0ba238b96bec0cbdddcae0aa442542eee1ff50c986ea6b39847b3cc092ff6'
+	      ],
+	      [
+	        'ee079adb1df1860074356a25aa38206a6d716b2c3e67453d287698bad7b2b2d6',
+	        '8dc2412aafe3be5c4c5f37e0ecc5f9f6a446989af04c4e25ebaac479ec1c8c1e'
+	      ],
+	      [
+	        '16ec93e447ec83f0467b18302ee620f7e65de331874c9dc72bfd8616ba9da6b5',
+	        '5e4631150e62fb40d0e8c2a7ca5804a39d58186a50e497139626778e25b0674d'
+	      ],
+	      [
+	        'eaa5f980c245f6f038978290afa70b6bd8855897f98b6aa485b96065d537bd99',
+	        'f65f5d3e292c2e0819a528391c994624d784869d7e6ea67fb18041024edc07dc'
+	      ],
+	      [
+	        '78c9407544ac132692ee1910a02439958ae04877151342ea96c4b6b35a49f51',
+	        'f3e0319169eb9b85d5404795539a5e68fa1fbd583c064d2462b675f194a3ddb4'
+	      ],
+	      [
+	        '494f4be219a1a77016dcd838431aea0001cdc8ae7a6fc688726578d9702857a5',
+	        '42242a969283a5f339ba7f075e36ba2af925ce30d767ed6e55f4b031880d562c'
+	      ],
+	      [
+	        'a598a8030da6d86c6bc7f2f5144ea549d28211ea58faa70ebf4c1e665c1fe9b5',
+	        '204b5d6f84822c307e4b4a7140737aec23fc63b65b35f86a10026dbd2d864e6b'
+	      ],
+	      [
+	        'c41916365abb2b5d09192f5f2dbeafec208f020f12570a184dbadc3e58595997',
+	        '4f14351d0087efa49d245b328984989d5caf9450f34bfc0ed16e96b58fa9913'
+	      ],
+	      [
+	        '841d6063a586fa475a724604da03bc5b92a2e0d2e0a36acfe4c73a5514742881',
+	        '73867f59c0659e81904f9a1c7543698e62562d6744c169ce7a36de01a8d6154'
+	      ],
+	      [
+	        '5e95bb399a6971d376026947f89bde2f282b33810928be4ded112ac4d70e20d5',
+	        '39f23f366809085beebfc71181313775a99c9aed7d8ba38b161384c746012865'
+	      ],
+	      [
+	        '36e4641a53948fd476c39f8a99fd974e5ec07564b5315d8bf99471bca0ef2f66',
+	        'd2424b1b1abe4eb8164227b085c9aa9456ea13493fd563e06fd51cf5694c78fc'
+	      ],
+	      [
+	        '336581ea7bfbbb290c191a2f507a41cf5643842170e914faeab27c2c579f726',
+	        'ead12168595fe1be99252129b6e56b3391f7ab1410cd1e0ef3dcdcabd2fda224'
+	      ],
+	      [
+	        '8ab89816dadfd6b6a1f2634fcf00ec8403781025ed6890c4849742706bd43ede',
+	        '6fdcef09f2f6d0a044e654aef624136f503d459c3e89845858a47a9129cdd24e'
+	      ],
+	      [
+	        '1e33f1a746c9c5778133344d9299fcaa20b0938e8acff2544bb40284b8c5fb94',
+	        '60660257dd11b3aa9c8ed618d24edff2306d320f1d03010e33a7d2057f3b3b6'
+	      ],
+	      [
+	        '85b7c1dcb3cec1b7ee7f30ded79dd20a0ed1f4cc18cbcfcfa410361fd8f08f31',
+	        '3d98a9cdd026dd43f39048f25a8847f4fcafad1895d7a633c6fed3c35e999511'
+	      ],
+	      [
+	        '29df9fbd8d9e46509275f4b125d6d45d7fbe9a3b878a7af872a2800661ac5f51',
+	        'b4c4fe99c775a606e2d8862179139ffda61dc861c019e55cd2876eb2a27d84b'
+	      ],
+	      [
+	        'a0b1cae06b0a847a3fea6e671aaf8adfdfe58ca2f768105c8082b2e449fce252',
+	        'ae434102edde0958ec4b19d917a6a28e6b72da1834aff0e650f049503a296cf2'
+	      ],
+	      [
+	        '4e8ceafb9b3e9a136dc7ff67e840295b499dfb3b2133e4ba113f2e4c0e121e5',
+	        'cf2174118c8b6d7a4b48f6d534ce5c79422c086a63460502b827ce62a326683c'
+	      ],
+	      [
+	        'd24a44e047e19b6f5afb81c7ca2f69080a5076689a010919f42725c2b789a33b',
+	        '6fb8d5591b466f8fc63db50f1c0f1c69013f996887b8244d2cdec417afea8fa3'
+	      ],
+	      [
+	        'ea01606a7a6c9cdd249fdfcfacb99584001edd28abbab77b5104e98e8e3b35d4',
+	        '322af4908c7312b0cfbfe369f7a7b3cdb7d4494bc2823700cfd652188a3ea98d'
+	      ],
+	      [
+	        'af8addbf2b661c8a6c6328655eb96651252007d8c5ea31be4ad196de8ce2131f',
+	        '6749e67c029b85f52a034eafd096836b2520818680e26ac8f3dfbcdb71749700'
+	      ],
+	      [
+	        'e3ae1974566ca06cc516d47e0fb165a674a3dabcfca15e722f0e3450f45889',
+	        '2aeabe7e4531510116217f07bf4d07300de97e4874f81f533420a72eeb0bd6a4'
+	      ],
+	      [
+	        '591ee355313d99721cf6993ffed1e3e301993ff3ed258802075ea8ced397e246',
+	        'b0ea558a113c30bea60fc4775460c7901ff0b053d25ca2bdeee98f1a4be5d196'
+	      ],
+	      [
+	        '11396d55fda54c49f19aa97318d8da61fa8584e47b084945077cf03255b52984',
+	        '998c74a8cd45ac01289d5833a7beb4744ff536b01b257be4c5767bea93ea57a4'
+	      ],
+	      [
+	        '3c5d2a1ba39c5a1790000738c9e0c40b8dcdfd5468754b6405540157e017aa7a',
+	        'b2284279995a34e2f9d4de7396fc18b80f9b8b9fdd270f6661f79ca4c81bd257'
+	      ],
+	      [
+	        'cc8704b8a60a0defa3a99a7299f2e9c3fbc395afb04ac078425ef8a1793cc030',
+	        'bdd46039feed17881d1e0862db347f8cf395b74fc4bcdc4e940b74e3ac1f1b13'
+	      ],
+	      [
+	        'c533e4f7ea8555aacd9777ac5cad29b97dd4defccc53ee7ea204119b2889b197',
+	        '6f0a256bc5efdf429a2fb6242f1a43a2d9b925bb4a4b3a26bb8e0f45eb596096'
+	      ],
+	      [
+	        'c14f8f2ccb27d6f109f6d08d03cc96a69ba8c34eec07bbcf566d48e33da6593',
+	        'c359d6923bb398f7fd4473e16fe1c28475b740dd098075e6c0e8649113dc3a38'
+	      ],
+	      [
+	        'a6cbc3046bc6a450bac24789fa17115a4c9739ed75f8f21ce441f72e0b90e6ef',
+	        '21ae7f4680e889bb130619e2c0f95a360ceb573c70603139862afd617fa9b9f'
+	      ],
+	      [
+	        '347d6d9a02c48927ebfb86c1359b1caf130a3c0267d11ce6344b39f99d43cc38',
+	        '60ea7f61a353524d1c987f6ecec92f086d565ab687870cb12689ff1e31c74448'
+	      ],
+	      [
+	        'da6545d2181db8d983f7dcb375ef5866d47c67b1bf31c8cf855ef7437b72656a',
+	        '49b96715ab6878a79e78f07ce5680c5d6673051b4935bd897fea824b77dc208a'
+	      ],
+	      [
+	        'c40747cc9d012cb1a13b8148309c6de7ec25d6945d657146b9d5994b8feb1111',
+	        '5ca560753be2a12fc6de6caf2cb489565db936156b9514e1bb5e83037e0fa2d4'
+	      ],
+	      [
+	        '4e42c8ec82c99798ccf3a610be870e78338c7f713348bd34c8203ef4037f3502',
+	        '7571d74ee5e0fb92a7a8b33a07783341a5492144cc54bcc40a94473693606437'
+	      ],
+	      [
+	        '3775ab7089bc6af823aba2e1af70b236d251cadb0c86743287522a1b3b0dedea',
+	        'be52d107bcfa09d8bcb9736a828cfa7fac8db17bf7a76a2c42ad961409018cf7'
+	      ],
+	      [
+	        'cee31cbf7e34ec379d94fb814d3d775ad954595d1314ba8846959e3e82f74e26',
+	        '8fd64a14c06b589c26b947ae2bcf6bfa0149ef0be14ed4d80f448a01c43b1c6d'
+	      ],
+	      [
+	        'b4f9eaea09b6917619f6ea6a4eb5464efddb58fd45b1ebefcdc1a01d08b47986',
+	        '39e5c9925b5a54b07433a4f18c61726f8bb131c012ca542eb24a8ac07200682a'
+	      ],
+	      [
+	        'd4263dfc3d2df923a0179a48966d30ce84e2515afc3dccc1b77907792ebcc60e',
+	        '62dfaf07a0f78feb30e30d6295853ce189e127760ad6cf7fae164e122a208d54'
+	      ],
+	      [
+	        '48457524820fa65a4f8d35eb6930857c0032acc0a4a2de422233eeda897612c4',
+	        '25a748ab367979d98733c38a1fa1c2e7dc6cc07db2d60a9ae7a76aaa49bd0f77'
+	      ],
+	      [
+	        'dfeeef1881101f2cb11644f3a2afdfc2045e19919152923f367a1767c11cceda',
+	        'ecfb7056cf1de042f9420bab396793c0c390bde74b4bbdff16a83ae09a9a7517'
+	      ],
+	      [
+	        '6d7ef6b17543f8373c573f44e1f389835d89bcbc6062ced36c82df83b8fae859',
+	        'cd450ec335438986dfefa10c57fea9bcc521a0959b2d80bbf74b190dca712d10'
+	      ],
+	      [
+	        'e75605d59102a5a2684500d3b991f2e3f3c88b93225547035af25af66e04541f',
+	        'f5c54754a8f71ee540b9b48728473e314f729ac5308b06938360990e2bfad125'
+	      ],
+	      [
+	        'eb98660f4c4dfaa06a2be453d5020bc99a0c2e60abe388457dd43fefb1ed620c',
+	        '6cb9a8876d9cb8520609af3add26cd20a0a7cd8a9411131ce85f44100099223e'
+	      ],
+	      [
+	        '13e87b027d8514d35939f2e6892b19922154596941888336dc3563e3b8dba942',
+	        'fef5a3c68059a6dec5d624114bf1e91aac2b9da568d6abeb2570d55646b8adf1'
+	      ],
+	      [
+	        'ee163026e9fd6fe017c38f06a5be6fc125424b371ce2708e7bf4491691e5764a',
+	        '1acb250f255dd61c43d94ccc670d0f58f49ae3fa15b96623e5430da0ad6c62b2'
+	      ],
+	      [
+	        'b268f5ef9ad51e4d78de3a750c2dc89b1e626d43505867999932e5db33af3d80',
+	        '5f310d4b3c99b9ebb19f77d41c1dee018cf0d34fd4191614003e945a1216e423'
+	      ],
+	      [
+	        'ff07f3118a9df035e9fad85eb6c7bfe42b02f01ca99ceea3bf7ffdba93c4750d',
+	        '438136d603e858a3a5c440c38eccbaddc1d2942114e2eddd4740d098ced1f0d8'
+	      ],
+	      [
+	        '8d8b9855c7c052a34146fd20ffb658bea4b9f69e0d825ebec16e8c3ce2b526a1',
+	        'cdb559eedc2d79f926baf44fb84ea4d44bcf50fee51d7ceb30e2e7f463036758'
+	      ],
+	      [
+	        '52db0b5384dfbf05bfa9d472d7ae26dfe4b851ceca91b1eba54263180da32b63',
+	        'c3b997d050ee5d423ebaf66a6db9f57b3180c902875679de924b69d84a7b375'
+	      ],
+	      [
+	        'e62f9490d3d51da6395efd24e80919cc7d0f29c3f3fa48c6fff543becbd43352',
+	        '6d89ad7ba4876b0b22c2ca280c682862f342c8591f1daf5170e07bfd9ccafa7d'
+	      ],
+	      [
+	        '7f30ea2476b399b4957509c88f77d0191afa2ff5cb7b14fd6d8e7d65aaab1193',
+	        'ca5ef7d4b231c94c3b15389a5f6311e9daff7bb67b103e9880ef4bff637acaec'
+	      ],
+	      [
+	        '5098ff1e1d9f14fb46a210fada6c903fef0fb7b4a1dd1d9ac60a0361800b7a00',
+	        '9731141d81fc8f8084d37c6e7542006b3ee1b40d60dfe5362a5b132fd17ddc0'
+	      ],
+	      [
+	        '32b78c7de9ee512a72895be6b9cbefa6e2f3c4ccce445c96b9f2c81e2778ad58',
+	        'ee1849f513df71e32efc3896ee28260c73bb80547ae2275ba497237794c8753c'
+	      ],
+	      [
+	        'e2cb74fddc8e9fbcd076eef2a7c72b0ce37d50f08269dfc074b581550547a4f7',
+	        'd3aa2ed71c9dd2247a62df062736eb0baddea9e36122d2be8641abcb005cc4a4'
+	      ],
+	      [
+	        '8438447566d4d7bedadc299496ab357426009a35f235cb141be0d99cd10ae3a8',
+	        'c4e1020916980a4da5d01ac5e6ad330734ef0d7906631c4f2390426b2edd791f'
+	      ],
+	      [
+	        '4162d488b89402039b584c6fc6c308870587d9c46f660b878ab65c82c711d67e',
+	        '67163e903236289f776f22c25fb8a3afc1732f2b84b4e95dbda47ae5a0852649'
+	      ],
+	      [
+	        '3fad3fa84caf0f34f0f89bfd2dcf54fc175d767aec3e50684f3ba4a4bf5f683d',
+	        'cd1bc7cb6cc407bb2f0ca647c718a730cf71872e7d0d2a53fa20efcdfe61826'
+	      ],
+	      [
+	        '674f2600a3007a00568c1a7ce05d0816c1fb84bf1370798f1c69532faeb1a86b',
+	        '299d21f9413f33b3edf43b257004580b70db57da0b182259e09eecc69e0d38a5'
+	      ],
+	      [
+	        'd32f4da54ade74abb81b815ad1fb3b263d82d6c692714bcff87d29bd5ee9f08f',
+	        'f9429e738b8e53b968e99016c059707782e14f4535359d582fc416910b3eea87'
+	      ],
+	      [
+	        '30e4e670435385556e593657135845d36fbb6931f72b08cb1ed954f1e3ce3ff6',
+	        '462f9bce619898638499350113bbc9b10a878d35da70740dc695a559eb88db7b'
+	      ],
+	      [
+	        'be2062003c51cc3004682904330e4dee7f3dcd10b01e580bf1971b04d4cad297',
+	        '62188bc49d61e5428573d48a74e1c655b1c61090905682a0d5558ed72dccb9bc'
+	      ],
+	      [
+	        '93144423ace3451ed29e0fb9ac2af211cb6e84a601df5993c419859fff5df04a',
+	        '7c10dfb164c3425f5c71a3f9d7992038f1065224f72bb9d1d902a6d13037b47c'
+	      ],
+	      [
+	        'b015f8044f5fcbdcf21ca26d6c34fb8197829205c7b7d2a7cb66418c157b112c',
+	        'ab8c1e086d04e813744a655b2df8d5f83b3cdc6faa3088c1d3aea1454e3a1d5f'
+	      ],
+	      [
+	        'd5e9e1da649d97d89e4868117a465a3a4f8a18de57a140d36b3f2af341a21b52',
+	        '4cb04437f391ed73111a13cc1d4dd0db1693465c2240480d8955e8592f27447a'
+	      ],
+	      [
+	        'd3ae41047dd7ca065dbf8ed77b992439983005cd72e16d6f996a5316d36966bb',
+	        'bd1aeb21ad22ebb22a10f0303417c6d964f8cdd7df0aca614b10dc14d125ac46'
+	      ],
+	      [
+	        '463e2763d885f958fc66cdd22800f0a487197d0a82e377b49f80af87c897b065',
+	        'bfefacdb0e5d0fd7df3a311a94de062b26b80c61fbc97508b79992671ef7ca7f'
+	      ],
+	      [
+	        '7985fdfd127c0567c6f53ec1bb63ec3158e597c40bfe747c83cddfc910641917',
+	        '603c12daf3d9862ef2b25fe1de289aed24ed291e0ec6708703a5bd567f32ed03'
+	      ],
+	      [
+	        '74a1ad6b5f76e39db2dd249410eac7f99e74c59cb83d2d0ed5ff1543da7703e9',
+	        'cc6157ef18c9c63cd6193d83631bbea0093e0968942e8c33d5737fd790e0db08'
+	      ],
+	      [
+	        '30682a50703375f602d416664ba19b7fc9bab42c72747463a71d0896b22f6da3',
+	        '553e04f6b018b4fa6c8f39e7f311d3176290d0e0f19ca73f17714d9977a22ff8'
+	      ],
+	      [
+	        '9e2158f0d7c0d5f26c3791efefa79597654e7a2b2464f52b1ee6c1347769ef57',
+	        '712fcdd1b9053f09003a3481fa7762e9ffd7c8ef35a38509e2fbf2629008373'
+	      ],
+	      [
+	        '176e26989a43c9cfeba4029c202538c28172e566e3c4fce7322857f3be327d66',
+	        'ed8cc9d04b29eb877d270b4878dc43c19aefd31f4eee09ee7b47834c1fa4b1c3'
+	      ],
+	      [
+	        '75d46efea3771e6e68abb89a13ad747ecf1892393dfc4f1b7004788c50374da8',
+	        '9852390a99507679fd0b86fd2b39a868d7efc22151346e1a3ca4726586a6bed8'
+	      ],
+	      [
+	        '809a20c67d64900ffb698c4c825f6d5f2310fb0451c869345b7319f645605721',
+	        '9e994980d9917e22b76b061927fa04143d096ccc54963e6a5ebfa5f3f8e286c1'
+	      ],
+	      [
+	        '1b38903a43f7f114ed4500b4eac7083fdefece1cf29c63528d563446f972c180',
+	        '4036edc931a60ae889353f77fd53de4a2708b26b6f5da72ad3394119daf408f9'
+	      ]
+	    ]
+	  }
+	};
+
+
+/***/ }),
+/* 131 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var bn = __webpack_require__(119);
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+	var assert = utils.assert;
+
+	var KeyPair = __webpack_require__(132);
+	var Signature = __webpack_require__(133);
+
+	function EC(options) {
+	  if (!(this instanceof EC))
+	    return new EC(options);
+
+	  // Shortcut `elliptic.ec(curve-name)`
+	  if (typeof options === 'string') {
+	    assert(elliptic.curves.hasOwnProperty(options), 'Unknown curve ' + options);
+
+	    options = elliptic.curves[options];
+	  }
+
+	  // Shortcut for `elliptic.ec(elliptic.curves.curveName)`
+	  if (options instanceof elliptic.curves.PresetCurve)
+	    options = { curve: options };
+
+	  this.curve = options.curve.curve;
+	  this.n = this.curve.n;
+	  this.nh = this.n.ushrn(1);
+	  this.g = this.curve.g;
+
+	  // Point on curve
+	  this.g = options.curve.g;
+	  this.g.precompute(options.curve.n.bitLength() + 1);
+
+	  // Hash for function for DRBG
+	  this.hash = options.hash || options.curve.hash;
+	}
+	module.exports = EC;
+
+	EC.prototype.keyPair = function keyPair(options) {
+	  return new KeyPair(this, options);
+	};
+
+	EC.prototype.keyFromPrivate = function keyFromPrivate(priv, enc) {
+	  return KeyPair.fromPrivate(this, priv, enc);
+	};
+
+	EC.prototype.keyFromPublic = function keyFromPublic(pub, enc) {
+	  return KeyPair.fromPublic(this, pub, enc);
+	};
+
+	EC.prototype.genKeyPair = function genKeyPair(options) {
+	  if (!options)
+	    options = {};
+
+	  // Instantiate Hmac_DRBG
+	  var drbg = new elliptic.hmacDRBG({
+	    hash: this.hash,
+	    pers: options.pers,
+	    entropy: options.entropy || elliptic.rand(this.hash.hmacStrength),
+	    nonce: this.n.toArray()
+	  });
+
+	  var bytes = this.n.byteLength();
+	  var ns2 = this.n.sub(new bn(2));
+	  do {
+	    var priv = new bn(drbg.generate(bytes));
+	    if (priv.cmp(ns2) > 0)
+	      continue;
+
+	    priv.iaddn(1);
+	    return this.keyFromPrivate(priv);
+	  } while (true);
+	};
+
+	EC.prototype._truncateToN = function truncateToN(msg, truncOnly) {
+	  var delta = msg.byteLength() * 8 - this.n.bitLength();
+	  if (delta > 0)
+	    msg = msg.ushrn(delta);
+	  if (!truncOnly && msg.cmp(this.n) >= 0)
+	    return msg.sub(this.n);
+	  else
+	    return msg;
+	};
+
+	EC.prototype.sign = function sign(msg, key, enc, options) {
+	  if (typeof enc === 'object') {
+	    options = enc;
+	    enc = null;
+	  }
+	  if (!options)
+	    options = {};
+
+	  key = this.keyFromPrivate(key, enc);
+	  msg = this._truncateToN(new bn(msg, 16));
+
+	  // Zero-extend key to provide enough entropy
+	  var bytes = this.n.byteLength();
+	  var bkey = key.getPrivate().toArray();
+	  for (var i = bkey.length; i < bytes; i++)
+	    bkey.unshift(0);
+
+	  // Zero-extend nonce to have the same byte size as N
+	  var nonce = msg.toArray();
+	  for (var i = nonce.length; i < bytes; i++)
+	    nonce.unshift(0);
+
+	  // Instantiate Hmac_DRBG
+	  var drbg = new elliptic.hmacDRBG({
+	    hash: this.hash,
+	    entropy: bkey,
+	    nonce: nonce
+	  });
+
+	  // Number of bytes to generate
+	  var ns1 = this.n.sub(new bn(1));
+	  do {
+	    var k = new bn(drbg.generate(this.n.byteLength()));
+	    k = this._truncateToN(k, true);
+	    if (k.cmpn(1) <= 0 || k.cmp(ns1) >= 0)
+	      continue;
+
+	    var kp = this.g.mul(k);
+	    if (kp.isInfinity())
+	      continue;
+
+	    var kpX = kp.getX();
+	    var r = kpX.umod(this.n);
+	    if (r.cmpn(0) === 0)
+	      continue;
+
+	    var s = k.invm(this.n).mul(r.mul(key.getPrivate()).iadd(msg));
+	    s = s.umod(this.n);
+	    if (s.cmpn(0) === 0)
+	      continue;
+
+	    // Use complement of `s`, if it is > `n / 2`
+	    if (options.canonical && s.cmp(this.nh) > 0)
+	      s = this.n.sub(s);
+
+	    var recoveryParam = (kp.getY().isOdd() ? 1 : 0) |
+	                        (kpX.cmp(r) !== 0 ? 2 : 0);
+
+	    return new Signature({ r: r, s: s, recoveryParam: recoveryParam });
+	  } while (true);
+	};
+
+	EC.prototype.verify = function verify(msg, signature, key, enc) {
+	  msg = this._truncateToN(new bn(msg, 16));
+	  key = this.keyFromPublic(key, enc);
+	  signature = new Signature(signature, 'hex');
+
+	  // Perform primitive values validation
+	  var r = signature.r;
+	  var s = signature.s;
+	  if (r.cmpn(1) < 0 || r.cmp(this.n) >= 0)
+	    return false;
+	  if (s.cmpn(1) < 0 || s.cmp(this.n) >= 0)
+	    return false;
+
+	  // Validate signature
+	  var sinv = s.invm(this.n);
+	  var u1 = sinv.mul(msg).umod(this.n);
+	  var u2 = sinv.mul(r).umod(this.n);
+
+	  var p = this.g.mulAdd(u1, key.getPublic(), u2);
+	  if (p.isInfinity())
+	    return false;
+
+	  return p.getX().umod(this.n).cmp(r) === 0;
+	};
+
+	EC.prototype.recoverPubKey = function(msg, signature, j, enc) {
+	  assert((3 & j) === j, 'The recovery param is more than two bits');
+	  signature = new Signature(signature, enc);
+
+	  var n = this.n;
+	  var e = new bn(msg);
+	  var r = signature.r;
+	  var s = signature.s;
+
+	  // A set LSB signifies that the y-coordinate is odd
+	  var isYOdd = j & 1;
+	  var isSecondKey = j >> 1;
+	  if (r.cmp(this.curve.p.umod(this.curve.n)) >= 0 && isSecondKey)
+	    throw new Error('Unable to find sencond key candinate');
+
+	  // 1.1. Let x = r + jn.
+	  r = this.curve.pointFromX(r, isYOdd);
+	  var eNeg = e.neg().umod(n);
+
+	  // 1.6.1 Compute Q = r^-1 (sR -  eG)
+	  //               Q = r^-1 (sR + -eG)
+	  var rInv = signature.r.invm(n);
+	  return r.mul(s).add(this.g.mul(eNeg)).mul(rInv);
+	};
+
+	EC.prototype.getKeyRecoveryParam = function(e, signature, Q, enc) {
+	  signature = new Signature(signature, enc);
+	  if (signature.recoveryParam !== null)
+	    return signature.recoveryParam;
+
+	  for (var i = 0; i < 4; i++) {
+	    var Qprime = this.recoverPubKey(e, signature, i);
+
+	    if (Qprime.eq(Q))
+	      return i;
+	  }
+	  throw new Error('Unable to find valid recovery factor');
+	};
+
+
+/***/ }),
+/* 132 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var bn = __webpack_require__(119);
+
+	function KeyPair(ec, options) {
+	  this.ec = ec;
+	  this.priv = null;
+	  this.pub = null;
+
+	  // KeyPair(ec, { priv: ..., pub: ... })
+	  if (options.priv)
+	    this._importPrivate(options.priv, options.privEnc);
+	  if (options.pub)
+	    this._importPublic(options.pub, options.pubEnc);
+	}
+	module.exports = KeyPair;
+
+	KeyPair.fromPublic = function fromPublic(ec, pub, enc) {
+	  if (pub instanceof KeyPair)
+	    return pub;
+
+	  return new KeyPair(ec, {
+	    pub: pub,
+	    pubEnc: enc
+	  });
+	};
+
+	KeyPair.fromPrivate = function fromPrivate(ec, priv, enc) {
+	  if (priv instanceof KeyPair)
+	    return priv;
+
+	  return new KeyPair(ec, {
+	    priv: priv,
+	    privEnc: enc
+	  });
+	};
+
+	KeyPair.prototype.validate = function validate() {
+	  var pub = this.getPublic();
+
+	  if (pub.isInfinity())
+	    return { result: false, reason: 'Invalid public key' };
+	  if (!pub.validate())
+	    return { result: false, reason: 'Public key is not a point' };
+	  if (!pub.mul(this.ec.curve.n).isInfinity())
+	    return { result: false, reason: 'Public key * N != O' };
+
+	  return { result: true, reason: null };
+	};
+
+	KeyPair.prototype.getPublic = function getPublic(compact, enc) {
+	  // compact is optional argument
+	  if (typeof compact === 'string') {
+	    enc = compact;
+	    compact = null;
+	  }
+
+	  if (!this.pub)
+	    this.pub = this.ec.g.mul(this.priv);
+
+	  if (!enc)
+	    return this.pub;
+
+	  return this.pub.encode(enc, compact);
+	};
+
+	KeyPair.prototype.getPrivate = function getPrivate(enc) {
+	  if (enc === 'hex')
+	    return this.priv.toString(16, 2);
+	  else
+	    return this.priv;
+	};
+
+	KeyPair.prototype._importPrivate = function _importPrivate(key, enc) {
+	  this.priv = new bn(key, enc || 16);
+
+	  // Ensure that the priv won't be bigger than n, otherwise we may fail
+	  // in fixed multiplication method
+	  this.priv = this.priv.umod(this.ec.curve.n);
+	};
+
+	KeyPair.prototype._importPublic = function _importPublic(key, enc) {
+	  if (key.x || key.y) {
+	    this.pub = this.ec.curve.point(key.x, key.y);
+	    return;
+	  }
+	  this.pub = this.ec.curve.decodePoint(key, enc);
+	};
+
+	// ECDH
+	KeyPair.prototype.derive = function derive(pub) {
+	  return pub.mul(this.priv).getX();
+	};
+
+	// ECDSA
+	KeyPair.prototype.sign = function sign(msg, enc, options) {
+	  return this.ec.sign(msg, this, enc, options);
+	};
+
+	KeyPair.prototype.verify = function verify(msg, signature) {
+	  return this.ec.verify(msg, signature, this);
+	};
+
+	KeyPair.prototype.inspect = function inspect() {
+	  return '<Key priv: ' + (this.priv && this.priv.toString(16, 2)) +
+	         ' pub: ' + (this.pub && this.pub.inspect()) + ' >';
+	};
+
+
+/***/ }),
+/* 133 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var bn = __webpack_require__(119);
+
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+	var assert = utils.assert;
+
+	function Signature(options, enc) {
+	  if (options instanceof Signature)
+	    return options;
+
+	  if (this._importDER(options, enc))
+	    return;
+
+	  assert(options.r && options.s, 'Signature without r or s');
+	  this.r = new bn(options.r, 16);
+	  this.s = new bn(options.s, 16);
+	  if (options.recoveryParam !== null)
+	    this.recoveryParam = options.recoveryParam;
+	  else
+	    this.recoveryParam = null;
+	}
+	module.exports = Signature;
+
+	function Position() {
+	  this.place = 0;
+	}
+
+	function getLength(buf, p) {
+	  var initial = buf[p.place++];
+	  if (!(initial & 0x80)) {
+	    return initial;
+	  }
+	  var octetLen = initial & 0xf;
+	  var val = 0;
+	  for (var i = 0, off = p.place; i < octetLen; i++, off++) {
+	    val <<= 8;
+	    val |= buf[off];
+	  }
+	  p.place = off;
+	  return val;
+	}
+
+	function rmPadding(buf) {
+	  var i = 0;
+	  var len = buf.length - 1;
+	  while (!buf[i] && !(buf[i + 1] & 0x80) && i < len) {
+	    i++;
+	  }
+	  if (i === 0) {
+	    return buf;
+	  }
+	  return buf.slice(i);
+	}
+
+	Signature.prototype._importDER = function _importDER(data, enc) {
+	  data = utils.toArray(data, enc);
+	  var p = new Position();
+	  if (data[p.place++] !== 0x30) {
+	    return false;
+	  }
+	  var len = getLength(data, p);
+	  if ((len + p.place) !== data.length) {
+	    return false;
+	  }
+	  if (data[p.place++] !== 0x02) {
+	    return false;
+	  }
+	  var rlen = getLength(data, p);
+	  var r = data.slice(p.place, rlen + p.place);
+	  p.place += rlen;
+	  if (data[p.place++] !== 0x02) {
+	    return false;
+	  }
+	  var slen = getLength(data, p);
+	  if (data.length !== slen + p.place) {
+	    return false;
+	  }
+	  var s = data.slice(p.place, slen + p.place);
+	  if (r[0] === 0 && (r[1] & 0x80)) {
+	    r = r.slice(1);
+	  }
+	  if (s[0] === 0 && (s[1] & 0x80)) {
+	    s = s.slice(1);
+	  }
+
+	  this.r = new bn(r);
+	  this.s = new bn(s);
+	  this.recoveryParam = null;
+
+	  return true;
+	};
+
+	function constructLength(arr, len) {
+	  if (len < 0x80) {
+	    arr.push(len);
+	    return;
+	  }
+	  var octets = 1 + (Math.log(len) / Math.LN2 >>> 3);
+	  arr.push(octets | 0x80);
+	  while (--octets) {
+	    arr.push((len >>> (octets << 3)) & 0xff);
+	  }
+	  arr.push(len);
+	}
+
+	Signature.prototype.toDER = function toDER(enc) {
+	  var r = this.r.toArray();
+	  var s = this.s.toArray();
+
+	  // Pad values
+	  if (r[0] & 0x80)
+	    r = [ 0 ].concat(r);
+	  // Pad values
+	  if (s[0] & 0x80)
+	    s = [ 0 ].concat(s);
+
+	  r = rmPadding(r);
+	  s = rmPadding(s);
+
+	  while (!s[0] && !(s[1] & 0x80)) {
+	    s = s.slice(1);
+	  }
+	  var arr = [ 0x02 ];
+	  constructLength(arr, r.length);
+	  arr = arr.concat(r);
+	  arr.push(0x02);
+	  constructLength(arr, s.length);
+	  var backHalf = arr.concat(s);
+	  var res = [ 0x30 ];
+	  constructLength(res, backHalf.length);
+	  res = res.concat(backHalf);
+	  return utils.encode(res, enc);
+	};
+
+
+/***/ }),
+/* 134 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var hash = __webpack_require__(31);
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+	var assert = utils.assert;
+	var parseBytes = utils.parseBytes;
+	var KeyPair = __webpack_require__(135);
+	var Signature = __webpack_require__(136);
+
+	function EDDSA(curve) {
+	  assert(curve === 'ed25519', 'only tested with ed25519 so far');
+
+	  if (!(this instanceof EDDSA))
+	    return new EDDSA(curve);
+
+	  var curve = elliptic.curves[curve].curve;
+	  this.curve = curve;
+	  this.g = curve.g;
+	  this.g.precompute(curve.n.bitLength() + 1);
+
+	  this.pointClass = curve.point().constructor;
+	  this.encodingLength = Math.ceil(curve.n.bitLength() / 8);
+	  this.hash = hash.sha512;
+	}
+
+	module.exports = EDDSA;
+
+	/**
+	* @param {Array|String} message - message bytes
+	* @param {Array|String|KeyPair} secret - secret bytes or a keypair
+	* @returns {Signature} - signature
+	*/
+	EDDSA.prototype.sign = function sign(message, secret) {
+	  message = parseBytes(message);
+	  var key = this.keyFromSecret(secret);
+	  var r = this.hashInt(key.messagePrefix(), message);
+	  var R = this.g.mul(r);
+	  var Rencoded = this.encodePoint(R);
+	  var s_ = this.hashInt(Rencoded, key.pubBytes(), message)
+	               .mul(key.priv());
+	  var S = r.add(s_).umod(this.curve.n);
+	  return this.makeSignature({ R: R, S: S, Rencoded: Rencoded });
+	};
+
+	/**
+	* @param {Array} message - message bytes
+	* @param {Array|String|Signature} sig - sig bytes
+	* @param {Array|String|Point|KeyPair} pub - public key
+	* @returns {Boolean} - true if public key matches sig of message
+	*/
+	EDDSA.prototype.verify = function verify(message, sig, pub) {
+	  message = parseBytes(message);
+	  sig = this.makeSignature(sig);
+	  var key = this.keyFromPublic(pub);
+	  var h = this.hashInt(sig.Rencoded(), key.pubBytes(), message);
+	  var SG = this.g.mul(sig.S());
+	  var RplusAh = sig.R().add(key.pub().mul(h));
+	  return RplusAh.eq(SG);
+	};
+
+	EDDSA.prototype.hashInt = function hashInt() {
+	  var hash = this.hash();
+	  for (var i = 0; i < arguments.length; i++)
+	    hash.update(arguments[i]);
+	  return utils.intFromLE(hash.digest()).umod(this.curve.n);
+	};
+
+	EDDSA.prototype.keyFromPublic = function keyFromPublic(pub) {
+	  return KeyPair.fromPublic(this, pub);
+	};
+
+	EDDSA.prototype.keyFromSecret = function keyFromSecret(secret) {
+	  return KeyPair.fromSecret(this, secret);
+	};
+
+	EDDSA.prototype.makeSignature = function makeSignature(sig) {
+	  if (sig instanceof Signature)
+	    return sig;
+	  return new Signature(this, sig);
+	};
+
+	/**
+	* * https://tools.ietf.org/html/draft-josefsson-eddsa-ed25519-03#section-5.2
+	*
+	* EDDSA defines methods for encoding and decoding points and integers. These are
+	* helper convenience methods, that pass along to utility functions implied
+	* parameters.
+	*
+	*/
+	EDDSA.prototype.encodePoint = function encodePoint(point) {
+	  var enc = point.getY().toArray('le', this.encodingLength);
+	  enc[this.encodingLength - 1] |= point.getX().isOdd() ? 0x80 : 0;
+	  return enc;
+	};
+
+	EDDSA.prototype.decodePoint = function decodePoint(bytes) {
+	  bytes = utils.parseBytes(bytes);
+
+	  var lastIx = bytes.length - 1;
+	  var normed = bytes.slice(0, lastIx).concat(bytes[lastIx] & ~0x80);
+	  var xIsOdd = (bytes[lastIx] & 0x80) !== 0;
+
+	  var y = utils.intFromLE(normed);
+	  return this.curve.pointFromY(y, xIsOdd);
+	};
+
+	EDDSA.prototype.encodeInt = function encodeInt(num) {
+	  return num.toArray('le', this.encodingLength);
+	};
+
+	EDDSA.prototype.decodeInt = function decodeInt(bytes) {
+	  return utils.intFromLE(bytes);
+	};
+
+	EDDSA.prototype.isPoint = function isPoint(val) {
+	  return val instanceof this.pointClass;
+	};
+
+
+/***/ }),
+/* 135 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+	var assert = utils.assert;
+	var parseBytes = utils.parseBytes;
+	var cachedProperty = utils.cachedProperty;
+
+	/**
+	* @param {EDDSA} eddsa - instance
+	* @param {Object} params - public/private key parameters
+	*
+	* @param {Array<Byte>} [params.secret] - secret seed bytes
+	* @param {Point} [params.pub] - public key point (aka `A` in eddsa terms)
+	* @param {Array<Byte>} [params.pub] - public key point encoded as bytes
+	*
+	*/
+	function KeyPair(eddsa, params) {
+	  this.eddsa = eddsa;
+	  this._secret = parseBytes(params.secret);
+	  if (eddsa.isPoint(params.pub))
+	    this._pub = params.pub;
+	  else
+	    this._pubBytes = parseBytes(params.pub);
+	}
+
+	KeyPair.fromPublic = function fromPublic(eddsa, pub) {
+	  if (pub instanceof KeyPair)
+	    return pub;
+	  return new KeyPair(eddsa, { pub: pub });
+	};
+
+	KeyPair.fromSecret = function fromSecret(eddsa, secret) {
+	  if (secret instanceof KeyPair)
+	    return secret;
+	  return new KeyPair(eddsa, { secret: secret });
+	};
+
+	KeyPair.prototype.secret = function secret() {
+	  return this._secret;
+	};
+
+	cachedProperty(KeyPair, function pubBytes() {
+	  return this.eddsa.encodePoint(this.pub());
+	});
+
+	cachedProperty(KeyPair, function pub() {
+	  if (this._pubBytes)
+	    return this.eddsa.decodePoint(this._pubBytes);
+	  return this.eddsa.g.mul(this.priv());
+	});
+
+	cachedProperty(KeyPair, function privBytes() {
+	  var eddsa = this.eddsa;
+	  var hash = this.hash();
+	  var lastIx = eddsa.encodingLength - 1;
+
+	  var a = hash.slice(0, eddsa.encodingLength);
+	  a[0] &= 248;
+	  a[lastIx] &= 127;
+	  a[lastIx] |= 64;
+
+	  return a;
+	});
+
+	cachedProperty(KeyPair, function priv() {
+	  return this.eddsa.decodeInt(this.privBytes());
+	});
+
+	cachedProperty(KeyPair, function hash() {
+	  return this.eddsa.hash().update(this.secret()).digest();
+	});
+
+	cachedProperty(KeyPair, function messagePrefix() {
+	  return this.hash().slice(this.eddsa.encodingLength);
+	});
+
+	KeyPair.prototype.sign = function sign(message) {
+	  assert(this._secret, 'KeyPair can only verify');
+	  return this.eddsa.sign(message, this);
+	};
+
+	KeyPair.prototype.verify = function verify(message, sig) {
+	  return this.eddsa.verify(message, sig, this);
+	};
+
+	KeyPair.prototype.getSecret = function getSecret(enc) {
+	  assert(this._secret, 'KeyPair is public only');
+	  return utils.encode(this.secret(), enc);
+	};
+
+	KeyPair.prototype.getPublic = function getPublic(enc) {
+	  return utils.encode(this.pubBytes(), enc);
+	};
+
+	module.exports = KeyPair;
+
+
+/***/ }),
+/* 136 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var bn = __webpack_require__(119);
+	var elliptic = __webpack_require__(120);
+	var utils = elliptic.utils;
+	var assert = utils.assert;
+	var cachedProperty = utils.cachedProperty;
+	var parseBytes = utils.parseBytes;
+
+	/**
+	* @param {EDDSA} eddsa - eddsa instance
+	* @param {Array<Bytes>|Object} sig -
+	* @param {Array<Bytes>|Point} [sig.R] - R point as Point or bytes
+	* @param {Array<Bytes>|bn} [sig.S] - S scalar as bn or bytes
+	* @param {Array<Bytes>} [sig.Rencoded] - R point encoded
+	* @param {Array<Bytes>} [sig.Sencoded] - S scalar encoded
+	*/
+	function Signature(eddsa, sig) {
+	  this.eddsa = eddsa;
+
+	  if (typeof sig !== 'object')
+	    sig = parseBytes(sig);
+
+	  if (Array.isArray(sig)) {
+	    sig = {
+	      R: sig.slice(0, eddsa.encodingLength),
+	      S: sig.slice(eddsa.encodingLength)
+	    };
+	  }
+
+	  assert(sig.R && sig.S, 'Signature without R or S');
+
+	  if (eddsa.isPoint(sig.R))
+	    this._R = sig.R;
+	  if (sig.S instanceof bn)
+	    this._S = sig.S;
+
+	  this._Rencoded = Array.isArray(sig.R) ? sig.R : sig.Rencoded;
+	  this._Sencoded = Array.isArray(sig.S) ? sig.S : sig.Sencoded;
+	}
+
+	cachedProperty(Signature, function S() {
+	  return this.eddsa.decodeInt(this.Sencoded());
+	});
+
+	cachedProperty(Signature, function R() {
+	  return this.eddsa.decodePoint(this.Rencoded());
+	});
+
+	cachedProperty(Signature, function Rencoded() {
+	  return this.eddsa.encodePoint(this.R());
+	});
+
+	cachedProperty(Signature, function Sencoded() {
+	  return this.eddsa.encodeInt(this.S());
+	});
+
+	Signature.prototype.toBytes = function toBytes() {
+	  return this.Rencoded().concat(this.Sencoded());
+	};
+
+	Signature.prototype.toHex = function toHex() {
+	  return utils.encode(this.toBytes(), 'hex').toUpperCase();
+	};
+
+	module.exports = Signature;
+
+
+/***/ }),
+/* 137 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _toDate = __webpack_require__(138);
+
+	var _toDate2 = _interopRequireDefault(_toDate);
+
+	var _toFloat = __webpack_require__(140);
+
+	var _toFloat2 = _interopRequireDefault(_toFloat);
+
+	var _toInt = __webpack_require__(141);
+
+	var _toInt2 = _interopRequireDefault(_toInt);
+
+	var _toBoolean = __webpack_require__(142);
+
+	var _toBoolean2 = _interopRequireDefault(_toBoolean);
+
+	var _equals = __webpack_require__(143);
+
+	var _equals2 = _interopRequireDefault(_equals);
+
+	var _contains = __webpack_require__(144);
+
+	var _contains2 = _interopRequireDefault(_contains);
+
+	var _matches = __webpack_require__(146);
+
+	var _matches2 = _interopRequireDefault(_matches);
+
+	var _isEmail = __webpack_require__(147);
+
+	var _isEmail2 = _interopRequireDefault(_isEmail);
+
+	var _isURL = __webpack_require__(151);
+
+	var _isURL2 = _interopRequireDefault(_isURL);
+
+	var _isMACAddress = __webpack_require__(153);
+
+	var _isMACAddress2 = _interopRequireDefault(_isMACAddress);
+
+	var _isIP = __webpack_require__(152);
+
+	var _isIP2 = _interopRequireDefault(_isIP);
+
+	var _isFQDN = __webpack_require__(150);
+
+	var _isFQDN2 = _interopRequireDefault(_isFQDN);
+
+	var _isBoolean = __webpack_require__(154);
+
+	var _isBoolean2 = _interopRequireDefault(_isBoolean);
+
+	var _isAlpha = __webpack_require__(155);
+
+	var _isAlpha2 = _interopRequireDefault(_isAlpha);
+
+	var _isAlphanumeric = __webpack_require__(157);
+
+	var _isAlphanumeric2 = _interopRequireDefault(_isAlphanumeric);
+
+	var _isNumeric = __webpack_require__(158);
+
+	var _isNumeric2 = _interopRequireDefault(_isNumeric);
+
+	var _isLowercase = __webpack_require__(159);
+
+	var _isLowercase2 = _interopRequireDefault(_isLowercase);
+
+	var _isUppercase = __webpack_require__(160);
+
+	var _isUppercase2 = _interopRequireDefault(_isUppercase);
+
+	var _isAscii = __webpack_require__(161);
+
+	var _isAscii2 = _interopRequireDefault(_isAscii);
+
+	var _isFullWidth = __webpack_require__(162);
+
+	var _isFullWidth2 = _interopRequireDefault(_isFullWidth);
+
+	var _isHalfWidth = __webpack_require__(163);
+
+	var _isHalfWidth2 = _interopRequireDefault(_isHalfWidth);
+
+	var _isVariableWidth = __webpack_require__(164);
+
+	var _isVariableWidth2 = _interopRequireDefault(_isVariableWidth);
+
+	var _isMultibyte = __webpack_require__(165);
+
+	var _isMultibyte2 = _interopRequireDefault(_isMultibyte);
+
+	var _isSurrogatePair = __webpack_require__(166);
+
+	var _isSurrogatePair2 = _interopRequireDefault(_isSurrogatePair);
+
+	var _isInt = __webpack_require__(167);
+
+	var _isInt2 = _interopRequireDefault(_isInt);
+
+	var _isFloat = __webpack_require__(168);
+
+	var _isFloat2 = _interopRequireDefault(_isFloat);
+
+	var _isDecimal = __webpack_require__(169);
+
+	var _isDecimal2 = _interopRequireDefault(_isDecimal);
+
+	var _isHexadecimal = __webpack_require__(170);
+
+	var _isHexadecimal2 = _interopRequireDefault(_isHexadecimal);
+
+	var _isDivisibleBy = __webpack_require__(171);
+
+	var _isDivisibleBy2 = _interopRequireDefault(_isDivisibleBy);
+
+	var _isHexColor = __webpack_require__(172);
+
+	var _isHexColor2 = _interopRequireDefault(_isHexColor);
+
+	var _isISRC = __webpack_require__(173);
+
+	var _isISRC2 = _interopRequireDefault(_isISRC);
+
+	var _isMD = __webpack_require__(174);
+
+	var _isMD2 = _interopRequireDefault(_isMD);
+
+	var _isJSON = __webpack_require__(175);
+
+	var _isJSON2 = _interopRequireDefault(_isJSON);
+
+	var _isEmpty = __webpack_require__(176);
+
+	var _isEmpty2 = _interopRequireDefault(_isEmpty);
+
+	var _isLength = __webpack_require__(177);
+
+	var _isLength2 = _interopRequireDefault(_isLength);
+
+	var _isByteLength = __webpack_require__(149);
+
+	var _isByteLength2 = _interopRequireDefault(_isByteLength);
+
+	var _isUUID = __webpack_require__(178);
+
+	var _isUUID2 = _interopRequireDefault(_isUUID);
+
+	var _isMongoId = __webpack_require__(179);
+
+	var _isMongoId2 = _interopRequireDefault(_isMongoId);
+
+	var _isAfter = __webpack_require__(180);
+
+	var _isAfter2 = _interopRequireDefault(_isAfter);
+
+	var _isBefore = __webpack_require__(181);
+
+	var _isBefore2 = _interopRequireDefault(_isBefore);
+
+	var _isIn = __webpack_require__(182);
+
+	var _isIn2 = _interopRequireDefault(_isIn);
+
+	var _isCreditCard = __webpack_require__(183);
+
+	var _isCreditCard2 = _interopRequireDefault(_isCreditCard);
+
+	var _isISIN = __webpack_require__(184);
+
+	var _isISIN2 = _interopRequireDefault(_isISIN);
+
+	var _isISBN = __webpack_require__(185);
+
+	var _isISBN2 = _interopRequireDefault(_isISBN);
+
+	var _isISSN = __webpack_require__(186);
+
+	var _isISSN2 = _interopRequireDefault(_isISSN);
+
+	var _isMobilePhone = __webpack_require__(187);
+
+	var _isMobilePhone2 = _interopRequireDefault(_isMobilePhone);
+
+	var _isCurrency = __webpack_require__(188);
+
+	var _isCurrency2 = _interopRequireDefault(_isCurrency);
+
+	var _isISO = __webpack_require__(189);
+
+	var _isISO2 = _interopRequireDefault(_isISO);
+
+	var _isBase = __webpack_require__(190);
+
+	var _isBase2 = _interopRequireDefault(_isBase);
+
+	var _isDataURI = __webpack_require__(191);
+
+	var _isDataURI2 = _interopRequireDefault(_isDataURI);
+
+	var _ltrim = __webpack_require__(192);
+
+	var _ltrim2 = _interopRequireDefault(_ltrim);
+
+	var _rtrim = __webpack_require__(193);
+
+	var _rtrim2 = _interopRequireDefault(_rtrim);
+
+	var _trim = __webpack_require__(194);
+
+	var _trim2 = _interopRequireDefault(_trim);
+
+	var _escape = __webpack_require__(195);
+
+	var _escape2 = _interopRequireDefault(_escape);
+
+	var _unescape = __webpack_require__(196);
+
+	var _unescape2 = _interopRequireDefault(_unescape);
+
+	var _stripLow = __webpack_require__(197);
+
+	var _stripLow2 = _interopRequireDefault(_stripLow);
+
+	var _whitelist = __webpack_require__(199);
+
+	var _whitelist2 = _interopRequireDefault(_whitelist);
+
+	var _blacklist = __webpack_require__(198);
+
+	var _blacklist2 = _interopRequireDefault(_blacklist);
+
+	var _isWhitelisted = __webpack_require__(200);
+
+	var _isWhitelisted2 = _interopRequireDefault(_isWhitelisted);
+
+	var _normalizeEmail = __webpack_require__(201);
+
+	var _normalizeEmail2 = _interopRequireDefault(_normalizeEmail);
+
+	var _toString = __webpack_require__(145);
+
+	var _toString2 = _interopRequireDefault(_toString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var version = '7.2.0';
+
+	var validator = {
+	  version: version,
+	  toDate: _toDate2.default,
+	  toFloat: _toFloat2.default,
+	  toInt: _toInt2.default,
+	  toBoolean: _toBoolean2.default,
+	  equals: _equals2.default,
+	  contains: _contains2.default,
+	  matches: _matches2.default,
+	  isEmail: _isEmail2.default,
+	  isURL: _isURL2.default,
+	  isMACAddress: _isMACAddress2.default,
+	  isIP: _isIP2.default,
+	  isFQDN: _isFQDN2.default,
+	  isBoolean: _isBoolean2.default,
+	  isAlpha: _isAlpha2.default,
+	  isAlphanumeric: _isAlphanumeric2.default,
+	  isNumeric: _isNumeric2.default,
+	  isLowercase: _isLowercase2.default,
+	  isUppercase: _isUppercase2.default,
+	  isAscii: _isAscii2.default,
+	  isFullWidth: _isFullWidth2.default,
+	  isHalfWidth: _isHalfWidth2.default,
+	  isVariableWidth: _isVariableWidth2.default,
+	  isMultibyte: _isMultibyte2.default,
+	  isSurrogatePair: _isSurrogatePair2.default,
+	  isInt: _isInt2.default,
+	  isFloat: _isFloat2.default,
+	  isDecimal: _isDecimal2.default,
+	  isHexadecimal: _isHexadecimal2.default,
+	  isDivisibleBy: _isDivisibleBy2.default,
+	  isHexColor: _isHexColor2.default,
+	  isISRC: _isISRC2.default,
+	  isMD5: _isMD2.default,
+	  isJSON: _isJSON2.default,
+	  isEmpty: _isEmpty2.default,
+	  isLength: _isLength2.default,
+	  isByteLength: _isByteLength2.default,
+	  isUUID: _isUUID2.default,
+	  isMongoId: _isMongoId2.default,
+	  isAfter: _isAfter2.default,
+	  isBefore: _isBefore2.default,
+	  isIn: _isIn2.default,
+	  isCreditCard: _isCreditCard2.default,
+	  isISIN: _isISIN2.default,
+	  isISBN: _isISBN2.default,
+	  isISSN: _isISSN2.default,
+	  isMobilePhone: _isMobilePhone2.default,
+	  isCurrency: _isCurrency2.default,
+	  isISO8601: _isISO2.default,
+	  isBase64: _isBase2.default,
+	  isDataURI: _isDataURI2.default,
+	  ltrim: _ltrim2.default,
+	  rtrim: _rtrim2.default,
+	  trim: _trim2.default,
+	  escape: _escape2.default,
+	  unescape: _unescape2.default,
+	  stripLow: _stripLow2.default,
+	  whitelist: _whitelist2.default,
+	  blacklist: _blacklist2.default,
+	  isWhitelisted: _isWhitelisted2.default,
+	  normalizeEmail: _normalizeEmail2.default,
+	  toString: _toString2.default
+	};
+
+	exports.default = validator;
+	module.exports = exports['default'];
+
+/***/ }),
+/* 138 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = toDate;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function toDate(date) {
+	  (0, _assertString2.default)(date);
+	  date = Date.parse(date);
+	  return !isNaN(date) ? new Date(date) : null;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 139 */
+/***/ (function(module, exports) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = assertString;
+	function assertString(input) {
+	  var isString = typeof input === 'string' || input instanceof String;
+
+	  if (!isString) {
+	    throw new TypeError('This library (validator.js) validates strings only');
+	  }
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 140 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = toFloat;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function toFloat(str) {
+	  (0, _assertString2.default)(str);
+	  return parseFloat(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 141 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = toInt;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function toInt(str, radix) {
+	  (0, _assertString2.default)(str);
+	  return parseInt(str, radix || 10);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 142 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = toBoolean;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function toBoolean(str, strict) {
+	  (0, _assertString2.default)(str);
+	  if (strict) {
+	    return str === '1' || str === 'true';
+	  }
+	  return str !== '0' && str !== 'false' && str !== '';
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 143 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = equals;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function equals(str, comparison) {
+	  (0, _assertString2.default)(str);
+	  return str === comparison;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 144 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = contains;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _toString = __webpack_require__(145);
+
+	var _toString2 = _interopRequireDefault(_toString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function contains(str, elem) {
+	  (0, _assertString2.default)(str);
+	  return str.indexOf((0, _toString2.default)(elem)) >= 0;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 145 */
+/***/ (function(module, exports) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+	exports.default = toString;
+	function toString(input) {
+	  if ((typeof input === 'undefined' ? 'undefined' : _typeof(input)) === 'object' && input !== null) {
+	    if (typeof input.toString === 'function') {
+	      input = input.toString();
+	    } else {
+	      input = '[object Object]';
+	    }
+	  } else if (input === null || typeof input === 'undefined' || isNaN(input) && !input.length) {
+	    input = '';
+	  }
+	  return String(input);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 146 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = matches;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function matches(str, pattern, modifiers) {
+	  (0, _assertString2.default)(str);
+	  if (Object.prototype.toString.call(pattern) !== '[object RegExp]') {
+	    pattern = new RegExp(pattern, modifiers);
+	  }
+	  return pattern.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 147 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isEmail;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _merge = __webpack_require__(148);
+
+	var _merge2 = _interopRequireDefault(_merge);
+
+	var _isByteLength = __webpack_require__(149);
+
+	var _isByteLength2 = _interopRequireDefault(_isByteLength);
+
+	var _isFQDN = __webpack_require__(150);
+
+	var _isFQDN2 = _interopRequireDefault(_isFQDN);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var default_email_options = {
+	  allow_display_name: false,
+	  require_display_name: false,
+	  allow_utf8_local_part: true,
+	  require_tld: true
+	};
+
+	/* eslint-disable max-len */
+	/* eslint-disable no-control-regex */
+	var displayName = /^[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~\.\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~\.\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF\s]*<(.+)>$/i;
+	var emailUserPart = /^[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~]+$/i;
+	var quotedEmailUser = /^([\s\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e]|(\\[\x01-\x09\x0b\x0c\x0d-\x7f]))*$/i;
+	var emailUserUtf8Part = /^[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+$/i;
+	var quotedEmailUserUtf8 = /^([\s\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|(\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*$/i;
+	/* eslint-enable max-len */
+	/* eslint-enable no-control-regex */
+
+	function isEmail(str, options) {
+	  (0, _assertString2.default)(str);
+	  options = (0, _merge2.default)(options, default_email_options);
+
+	  if (options.require_display_name || options.allow_display_name) {
+	    var display_email = str.match(displayName);
+	    if (display_email) {
+	      str = display_email[1];
+	    } else if (options.require_display_name) {
+	      return false;
+	    }
+	  }
+
+	  var parts = str.split('@');
+	  var domain = parts.pop();
+	  var user = parts.join('@');
+
+	  var lower_domain = domain.toLowerCase();
+	  if (lower_domain === 'gmail.com' || lower_domain === 'googlemail.com') {
+	    user = user.replace(/\./g, '').toLowerCase();
+	  }
+
+	  if (!(0, _isByteLength2.default)(user, { max: 64 }) || !(0, _isByteLength2.default)(domain, { max: 254 })) {
+	    return false;
+	  }
+
+	  if (!(0, _isFQDN2.default)(domain, { require_tld: options.require_tld })) {
+	    return false;
+	  }
+
+	  if (user[0] === '"') {
+	    user = user.slice(1, user.length - 1);
+	    return options.allow_utf8_local_part ? quotedEmailUserUtf8.test(user) : quotedEmailUser.test(user);
+	  }
+
+	  var pattern = options.allow_utf8_local_part ? emailUserUtf8Part : emailUserPart;
+
+	  var user_parts = user.split('.');
+	  for (var i = 0; i < user_parts.length; i++) {
+	    if (!pattern.test(user_parts[i])) {
+	      return false;
+	    }
+	  }
+
+	  return true;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 148 */
+/***/ (function(module, exports) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = merge;
+	function merge() {
+	  var obj = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+	  var defaults = arguments[1];
+
+	  for (var key in defaults) {
+	    if (typeof obj[key] === 'undefined') {
+	      obj[key] = defaults[key];
+	    }
+	  }
+	  return obj;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 149 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+	exports.default = isByteLength;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/* eslint-disable prefer-rest-params */
+	function isByteLength(str, options) {
+	  (0, _assertString2.default)(str);
+	  var min = void 0;
+	  var max = void 0;
+	  if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) === 'object') {
+	    min = options.min || 0;
+	    max = options.max;
+	  } else {
+	    // backwards compatibility: isByteLength(str, min [, max])
+	    min = arguments[1];
+	    max = arguments[2];
+	  }
+	  var len = encodeURI(str).split(/%..|./).length - 1;
+	  return len >= min && (typeof max === 'undefined' || len <= max);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 150 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isFDQN;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _merge = __webpack_require__(148);
+
+	var _merge2 = _interopRequireDefault(_merge);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var default_fqdn_options = {
+	  require_tld: true,
+	  allow_underscores: false,
+	  allow_trailing_dot: false
+	};
+
+	function isFDQN(str, options) {
+	  (0, _assertString2.default)(str);
+	  options = (0, _merge2.default)(options, default_fqdn_options);
+
+	  /* Remove the optional trailing dot before checking validity */
+	  if (options.allow_trailing_dot && str[str.length - 1] === '.') {
+	    str = str.substring(0, str.length - 1);
+	  }
+	  var parts = str.split('.');
+	  if (options.require_tld) {
+	    var tld = parts.pop();
+	    if (!parts.length || !/^([a-z\u00a1-\uffff]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
+	      return false;
+	    }
+	    // disallow spaces
+	    if (/[\s\u2002-\u200B\u202F\u205F\u3000\uFEFF\uDB40\uDC20]/.test(tld)) {
+	      return false;
+	    }
+	  }
+	  for (var part, i = 0; i < parts.length; i++) {
+	    part = parts[i];
+	    if (options.allow_underscores) {
+	      part = part.replace(/_/g, '');
+	    }
+	    if (!/^[a-z\u00a1-\uffff0-9-]+$/i.test(part)) {
+	      return false;
+	    }
+	    // disallow full-width chars
+	    if (/[\uff01-\uff5e]/.test(part)) {
+	      return false;
+	    }
+	    if (part[0] === '-' || part[part.length - 1] === '-') {
+	      return false;
+	    }
+	  }
+	  return true;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 151 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isURL;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _isFQDN = __webpack_require__(150);
+
+	var _isFQDN2 = _interopRequireDefault(_isFQDN);
+
+	var _isIP = __webpack_require__(152);
+
+	var _isIP2 = _interopRequireDefault(_isIP);
+
+	var _merge = __webpack_require__(148);
+
+	var _merge2 = _interopRequireDefault(_merge);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var default_url_options = {
+	  protocols: ['http', 'https', 'ftp'],
+	  require_tld: true,
+	  require_protocol: false,
+	  require_host: true,
+	  require_valid_protocol: true,
+	  allow_underscores: false,
+	  allow_trailing_dot: false,
+	  allow_protocol_relative_urls: false
+	};
+
+	var wrapped_ipv6 = /^\[([^\]]+)\](?::([0-9]+))?$/;
+
+	function isRegExp(obj) {
+	  return Object.prototype.toString.call(obj) === '[object RegExp]';
+	}
+
+	function checkHost(host, matches) {
+	  for (var i = 0; i < matches.length; i++) {
+	    var match = matches[i];
+	    if (host === match || isRegExp(match) && match.test(host)) {
+	      return true;
+	    }
+	  }
+	  return false;
+	}
+
+	function isURL(url, options) {
+	  (0, _assertString2.default)(url);
+	  if (!url || url.length >= 2083 || /[\s<>]/.test(url)) {
+	    return false;
+	  }
+	  if (url.indexOf('mailto:') === 0) {
+	    return false;
+	  }
+	  options = (0, _merge2.default)(options, default_url_options);
+	  var protocol = void 0,
+	      auth = void 0,
+	      host = void 0,
+	      hostname = void 0,
+	      port = void 0,
+	      port_str = void 0,
+	      split = void 0,
+	      ipv6 = void 0;
+
+	  split = url.split('#');
+	  url = split.shift();
+
+	  split = url.split('?');
+	  url = split.shift();
+
+	  split = url.split('://');
+	  if (split.length > 1) {
+	    protocol = split.shift();
+	    if (options.require_valid_protocol && options.protocols.indexOf(protocol) === -1) {
+	      return false;
+	    }
+	  } else if (options.require_protocol) {
+	    return false;
+	  } else if (options.allow_protocol_relative_urls && url.substr(0, 2) === '//') {
+	    split[0] = url.substr(2);
+	  }
+	  url = split.join('://');
+
+	  split = url.split('/');
+	  url = split.shift();
+
+	  if (url === '' && !options.require_host) {
+	    return true;
+	  }
+
+	  split = url.split('@');
+	  if (split.length > 1) {
+	    auth = split.shift();
+	    if (auth.indexOf(':') >= 0 && auth.split(':').length > 2) {
+	      return false;
+	    }
+	  }
+	  hostname = split.join('@');
+
+	  port_str = null;
+	  ipv6 = null;
+	  var ipv6_match = hostname.match(wrapped_ipv6);
+	  if (ipv6_match) {
+	    host = '';
+	    ipv6 = ipv6_match[1];
+	    port_str = ipv6_match[2] || null;
+	  } else {
+	    split = hostname.split(':');
+	    host = split.shift();
+	    if (split.length) {
+	      port_str = split.join(':');
+	    }
+	  }
+
+	  if (port_str !== null) {
+	    port = parseInt(port_str, 10);
+	    if (!/^[0-9]+$/.test(port_str) || port <= 0 || port > 65535) {
+	      return false;
+	    }
+	  }
+
+	  if (!(0, _isIP2.default)(host) && !(0, _isFQDN2.default)(host, options) && (!ipv6 || !(0, _isIP2.default)(ipv6, 6)) && host !== 'localhost') {
+	    return false;
+	  }
+
+	  host = host || ipv6;
+
+	  if (options.host_whitelist && !checkHost(host, options.host_whitelist)) {
+	    return false;
+	  }
+	  if (options.host_blacklist && checkHost(host, options.host_blacklist)) {
+	    return false;
+	  }
+
+	  return true;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 152 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isIP;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var ipv4Maybe = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+	var ipv6Block = /^[0-9A-F]{1,4}$/i;
+
+	function isIP(str) {
+	  var version = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
+
+	  (0, _assertString2.default)(str);
+	  version = String(version);
+	  if (!version) {
+	    return isIP(str, 4) || isIP(str, 6);
+	  } else if (version === '4') {
+	    if (!ipv4Maybe.test(str)) {
+	      return false;
+	    }
+	    var parts = str.split('.').sort(function (a, b) {
+	      return a - b;
+	    });
+	    return parts[3] <= 255;
+	  } else if (version === '6') {
+	    var blocks = str.split(':');
+	    var foundOmissionBlock = false; // marker to indicate ::
+
+	    // At least some OS accept the last 32 bits of an IPv6 address
+	    // (i.e. 2 of the blocks) in IPv4 notation, and RFC 3493 says
+	    // that '::ffff:a.b.c.d' is valid for IPv4-mapped IPv6 addresses,
+	    // and '::a.b.c.d' is deprecated, but also valid.
+	    var foundIPv4TransitionBlock = isIP(blocks[blocks.length - 1], 4);
+	    var expectedNumberOfBlocks = foundIPv4TransitionBlock ? 7 : 8;
+
+	    if (blocks.length > expectedNumberOfBlocks) {
+	      return false;
+	    }
+	    // initial or final ::
+	    if (str === '::') {
+	      return true;
+	    } else if (str.substr(0, 2) === '::') {
+	      blocks.shift();
+	      blocks.shift();
+	      foundOmissionBlock = true;
+	    } else if (str.substr(str.length - 2) === '::') {
+	      blocks.pop();
+	      blocks.pop();
+	      foundOmissionBlock = true;
+	    }
+
+	    for (var i = 0; i < blocks.length; ++i) {
+	      // test for a :: which can not be at the string start/end
+	      // since those cases have been handled above
+	      if (blocks[i] === '' && i > 0 && i < blocks.length - 1) {
+	        if (foundOmissionBlock) {
+	          return false; // multiple :: in address
+	        }
+	        foundOmissionBlock = true;
+	      } else if (foundIPv4TransitionBlock && i === blocks.length - 1) {
+	        // it has been checked before that the last
+	        // block is a valid IPv4 address
+	      } else if (!ipv6Block.test(blocks[i])) {
+	        return false;
+	      }
+	    }
+	    if (foundOmissionBlock) {
+	      return blocks.length >= 1;
+	    }
+	    return blocks.length === expectedNumberOfBlocks;
+	  }
+	  return false;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 153 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isMACAddress;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var macAddress = /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/;
+
+	function isMACAddress(str) {
+	  (0, _assertString2.default)(str);
+	  return macAddress.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 154 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isBoolean;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isBoolean(str) {
+	  (0, _assertString2.default)(str);
+	  return ['true', 'false', '1', '0'].indexOf(str) >= 0;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 155 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isAlpha;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _alpha = __webpack_require__(156);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isAlpha(str) {
+	  var locale = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'en-US';
+
+	  (0, _assertString2.default)(str);
+	  if (locale in _alpha.alpha) {
+	    return _alpha.alpha[locale].test(str);
+	  }
+	  throw new Error('Invalid locale \'' + locale + '\'');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 156 */
+/***/ (function(module, exports) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	var alpha = exports.alpha = {
+	  'en-US': /^[A-Z]+$/i,
+	  'cs-CZ': /^[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]+$/i,
+	  'da-DK': /^[A-ZÆØÅ]+$/i,
+	  'de-DE': /^[A-ZÄÖÜß]+$/i,
+	  'es-ES': /^[A-ZÁÉÍÑÓÚÜ]+$/i,
+	  'fr-FR': /^[A-ZÀÂÆÇÉÈÊËÏÎÔŒÙÛÜŸ]+$/i,
+	  'nl-NL': /^[A-ZÉËÏÓÖÜ]+$/i,
+	  'hu-HU': /^[A-ZÁÉÍÓÖŐÚÜŰ]+$/i,
+	  'pl-PL': /^[A-ZĄĆĘŚŁŃÓŻŹ]+$/i,
+	  'pt-PT': /^[A-ZÃÁÀÂÇÉÊÍÕÓÔÚÜ]+$/i,
+	  'ru-RU': /^[А-ЯЁ]+$/i,
+	  'sr-RS@latin': /^[A-ZČĆŽŠĐ]+$/i,
+	  'sr-RS': /^[А-ЯЂЈЉЊЋЏ]+$/i,
+	  'tr-TR': /^[A-ZÇĞİıÖŞÜ]+$/i,
+	  'uk-UA': /^[А-ЩЬЮЯЄIЇҐ]+$/i,
+	  ar: /^[ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوىيًٌٍَُِّْٰ]+$/
+	};
+
+	var alphanumeric = exports.alphanumeric = {
+	  'en-US': /^[0-9A-Z]+$/i,
+	  'cs-CZ': /^[0-9A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]+$/i,
+	  'da-DK': /^[0-9A-ZÆØÅ]$/i,
+	  'de-DE': /^[0-9A-ZÄÖÜß]+$/i,
+	  'es-ES': /^[0-9A-ZÁÉÍÑÓÚÜ]+$/i,
+	  'fr-FR': /^[0-9A-ZÀÂÆÇÉÈÊËÏÎÔŒÙÛÜŸ]+$/i,
+	  'hu-HU': /^[0-9A-ZÁÉÍÓÖŐÚÜŰ]+$/i,
+	  'nl-NL': /^[0-9A-ZÉËÏÓÖÜ]+$/i,
+	  'pl-PL': /^[0-9A-ZĄĆĘŚŁŃÓŻŹ]+$/i,
+	  'pt-PT': /^[0-9A-ZÃÁÀÂÇÉÊÍÕÓÔÚÜ]+$/i,
+	  'ru-RU': /^[0-9А-ЯЁ]+$/i,
+	  'sr-RS@latin': /^[0-9A-ZČĆŽŠĐ]+$/i,
+	  'sr-RS': /^[0-9А-ЯЂЈЉЊЋЏ]+$/i,
+	  'tr-TR': /^[0-9A-ZÇĞİıÖŞÜ]+$/i,
+	  'uk-UA': /^[0-9А-ЩЬЮЯЄIЇҐ]+$/i,
+	  ar: /^[٠١٢٣٤٥٦٧٨٩0-9ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوىيًٌٍَُِّْٰ]+$/
+	};
+
+	var englishLocales = exports.englishLocales = ['AU', 'GB', 'HK', 'IN', 'NZ', 'ZA', 'ZM'];
+
+	for (var locale, i = 0; i < englishLocales.length; i++) {
+	  locale = 'en-' + englishLocales[i];
+	  alpha[locale] = alpha['en-US'];
+	  alphanumeric[locale] = alphanumeric['en-US'];
+	}
+
+	alpha['pt-BR'] = alpha['pt-PT'];
+	alphanumeric['pt-BR'] = alphanumeric['pt-PT'];
+
+	// Source: http://www.localeplanet.com/java/
+	var arabicLocales = exports.arabicLocales = ['AE', 'BH', 'DZ', 'EG', 'IQ', 'JO', 'KW', 'LB', 'LY', 'MA', 'QM', 'QA', 'SA', 'SD', 'SY', 'TN', 'YE'];
+
+	for (var _locale, _i = 0; _i < arabicLocales.length; _i++) {
+	  _locale = 'ar-' + arabicLocales[_i];
+	  alpha[_locale] = alpha.ar;
+	  alphanumeric[_locale] = alphanumeric.ar;
+	}
+
+/***/ }),
+/* 157 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isAlphanumeric;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _alpha = __webpack_require__(156);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isAlphanumeric(str) {
+	  var locale = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'en-US';
+
+	  (0, _assertString2.default)(str);
+	  if (locale in _alpha.alphanumeric) {
+	    return _alpha.alphanumeric[locale].test(str);
+	  }
+	  throw new Error('Invalid locale \'' + locale + '\'');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 158 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isNumeric;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var numeric = /^[-+]?[0-9]+$/;
+
+	function isNumeric(str) {
+	  (0, _assertString2.default)(str);
+	  return numeric.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 159 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isLowercase;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isLowercase(str) {
+	  (0, _assertString2.default)(str);
+	  return str === str.toLowerCase();
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 160 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isUppercase;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isUppercase(str) {
+	  (0, _assertString2.default)(str);
+	  return str === str.toUpperCase();
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 161 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isAscii;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/* eslint-disable no-control-regex */
+	var ascii = /^[\x00-\x7F]+$/;
+	/* eslint-enable no-control-regex */
+
+	function isAscii(str) {
+	  (0, _assertString2.default)(str);
+	  return ascii.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 162 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.fullWidth = undefined;
+	exports.default = isFullWidth;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var fullWidth = exports.fullWidth = /[^\u0020-\u007E\uFF61-\uFF9F\uFFA0-\uFFDC\uFFE8-\uFFEE0-9a-zA-Z]/;
+
+	function isFullWidth(str) {
+	  (0, _assertString2.default)(str);
+	  return fullWidth.test(str);
+	}
+
+/***/ }),
+/* 163 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.halfWidth = undefined;
+	exports.default = isHalfWidth;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var halfWidth = exports.halfWidth = /[\u0020-\u007E\uFF61-\uFF9F\uFFA0-\uFFDC\uFFE8-\uFFEE0-9a-zA-Z]/;
+
+	function isHalfWidth(str) {
+	  (0, _assertString2.default)(str);
+	  return halfWidth.test(str);
+	}
+
+/***/ }),
+/* 164 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isVariableWidth;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _isFullWidth = __webpack_require__(162);
+
+	var _isHalfWidth = __webpack_require__(163);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isVariableWidth(str) {
+	  (0, _assertString2.default)(str);
+	  return _isFullWidth.fullWidth.test(str) && _isHalfWidth.halfWidth.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 165 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isMultibyte;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/* eslint-disable no-control-regex */
+	var multibyte = /[^\x00-\x7F]/;
+	/* eslint-enable no-control-regex */
+
+	function isMultibyte(str) {
+	  (0, _assertString2.default)(str);
+	  return multibyte.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 166 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isSurrogatePair;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var surrogatePair = /[\uD800-\uDBFF][\uDC00-\uDFFF]/;
+
+	function isSurrogatePair(str) {
+	  (0, _assertString2.default)(str);
+	  return surrogatePair.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 167 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isInt;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var int = /^(?:[-+]?(?:0|[1-9][0-9]*))$/;
+	var intLeadingZeroes = /^[-+]?[0-9]+$/;
+
+	function isInt(str, options) {
+	  (0, _assertString2.default)(str);
+	  options = options || {};
+
+	  // Get the regex to use for testing, based on whether
+	  // leading zeroes are allowed or not.
+	  var regex = options.hasOwnProperty('allow_leading_zeroes') && !options.allow_leading_zeroes ? int : intLeadingZeroes;
+
+	  // Check min/max/lt/gt
+	  var minCheckPassed = !options.hasOwnProperty('min') || str >= options.min;
+	  var maxCheckPassed = !options.hasOwnProperty('max') || str <= options.max;
+	  var ltCheckPassed = !options.hasOwnProperty('lt') || str < options.lt;
+	  var gtCheckPassed = !options.hasOwnProperty('gt') || str > options.gt;
+
+	  return regex.test(str) && minCheckPassed && maxCheckPassed && ltCheckPassed && gtCheckPassed;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 168 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isFloat;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var float = /^(?:[-+])?(?:[0-9]+)?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/;
+
+	function isFloat(str, options) {
+	  (0, _assertString2.default)(str);
+	  options = options || {};
+	  if (str === '' || str === '.') {
+	    return false;
+	  }
+	  return float.test(str) && (!options.hasOwnProperty('min') || str >= options.min) && (!options.hasOwnProperty('max') || str <= options.max) && (!options.hasOwnProperty('lt') || str < options.lt) && (!options.hasOwnProperty('gt') || str > options.gt);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 169 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isDecimal;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var decimal = /^[-+]?([0-9]+|\.[0-9]+|[0-9]+\.[0-9]+)$/;
+
+	function isDecimal(str) {
+	  (0, _assertString2.default)(str);
+	  return str !== '' && decimal.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 170 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isHexadecimal;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var hexadecimal = /^[0-9A-F]+$/i;
+
+	function isHexadecimal(str) {
+	  (0, _assertString2.default)(str);
+	  return hexadecimal.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 171 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isDivisibleBy;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _toFloat = __webpack_require__(140);
+
+	var _toFloat2 = _interopRequireDefault(_toFloat);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isDivisibleBy(str, num) {
+	  (0, _assertString2.default)(str);
+	  return (0, _toFloat2.default)(str) % parseInt(num, 10) === 0;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 172 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isHexColor;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var hexcolor = /^#?([0-9A-F]{3}|[0-9A-F]{6})$/i;
+
+	function isHexColor(str) {
+	  (0, _assertString2.default)(str);
+	  return hexcolor.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 173 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isISRC;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	// see http://isrc.ifpi.org/en/isrc-standard/code-syntax
+	var isrc = /^[A-Z]{2}[0-9A-Z]{3}\d{2}\d{5}$/;
+
+	function isISRC(str) {
+	  (0, _assertString2.default)(str);
+	  return isrc.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 174 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isMD5;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var md5 = /^[a-f0-9]{32}$/;
+
+	function isMD5(str) {
+	  (0, _assertString2.default)(str);
+	  return md5.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 175 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+	exports.default = isJSON;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isJSON(str) {
+	  (0, _assertString2.default)(str);
+	  try {
+	    var obj = JSON.parse(str);
+	    return !!obj && (typeof obj === 'undefined' ? 'undefined' : _typeof(obj)) === 'object';
+	  } catch (e) {/* ignore */}
+	  return false;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 176 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isEmpty;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isEmpty(str) {
+	  (0, _assertString2.default)(str);
+	  return str.length === 0;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 177 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+	exports.default = isLength;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/* eslint-disable prefer-rest-params */
+	function isLength(str, options) {
+	  (0, _assertString2.default)(str);
+	  var min = void 0;
+	  var max = void 0;
+	  if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) === 'object') {
+	    min = options.min || 0;
+	    max = options.max;
+	  } else {
+	    // backwards compatibility: isLength(str, min [, max])
+	    min = arguments[1];
+	    max = arguments[2];
+	  }
+	  var surrogatePairs = str.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || [];
+	  var len = str.length - surrogatePairs.length;
+	  return len >= min && (typeof max === 'undefined' || len <= max);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 178 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isUUID;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var uuid = {
+	  3: /^[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i,
+	  4: /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+	  5: /^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+	  all: /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i
+	};
+
+	function isUUID(str) {
+	  var version = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'all';
+
+	  (0, _assertString2.default)(str);
+	  var pattern = uuid[version];
+	  return pattern && pattern.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 179 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isMongoId;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _isHexadecimal = __webpack_require__(170);
+
+	var _isHexadecimal2 = _interopRequireDefault(_isHexadecimal);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isMongoId(str) {
+	  (0, _assertString2.default)(str);
+	  return (0, _isHexadecimal2.default)(str) && str.length === 24;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 180 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isAfter;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _toDate = __webpack_require__(138);
+
+	var _toDate2 = _interopRequireDefault(_toDate);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isAfter(str) {
+	  var date = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : String(new Date());
+
+	  (0, _assertString2.default)(str);
+	  var comparison = (0, _toDate2.default)(date);
+	  var original = (0, _toDate2.default)(str);
+	  return !!(original && comparison && original > comparison);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 181 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isBefore;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _toDate = __webpack_require__(138);
+
+	var _toDate2 = _interopRequireDefault(_toDate);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isBefore(str) {
+	  var date = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : String(new Date());
+
+	  (0, _assertString2.default)(str);
+	  var comparison = (0, _toDate2.default)(date);
+	  var original = (0, _toDate2.default)(str);
+	  return !!(original && comparison && original < comparison);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 182 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+	exports.default = isIn;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _toString = __webpack_require__(145);
+
+	var _toString2 = _interopRequireDefault(_toString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isIn(str, options) {
+	  (0, _assertString2.default)(str);
+	  var i = void 0;
+	  if (Object.prototype.toString.call(options) === '[object Array]') {
+	    var array = [];
+	    for (i in options) {
+	      if ({}.hasOwnProperty.call(options, i)) {
+	        array[i] = (0, _toString2.default)(options[i]);
+	      }
+	    }
+	    return array.indexOf(str) >= 0;
+	  } else if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) === 'object') {
+	    return options.hasOwnProperty(str);
+	  } else if (options && typeof options.indexOf === 'function') {
+	    return options.indexOf(str) >= 0;
+	  }
+	  return false;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 183 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isCreditCard;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/* eslint-disable max-len */
+	var creditCard = /^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|(222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11}|62[0-9]{14})$/;
+	/* eslint-enable max-len */
+
+	function isCreditCard(str) {
+	  (0, _assertString2.default)(str);
+	  var sanitized = str.replace(/[- ]+/g, '');
+	  if (!creditCard.test(sanitized)) {
+	    return false;
+	  }
+	  var sum = 0;
+	  var digit = void 0;
+	  var tmpNum = void 0;
+	  var shouldDouble = void 0;
+	  for (var i = sanitized.length - 1; i >= 0; i--) {
+	    digit = sanitized.substring(i, i + 1);
+	    tmpNum = parseInt(digit, 10);
+	    if (shouldDouble) {
+	      tmpNum *= 2;
+	      if (tmpNum >= 10) {
+	        sum += tmpNum % 10 + 1;
+	      } else {
+	        sum += tmpNum;
+	      }
+	    } else {
+	      sum += tmpNum;
+	    }
+	    shouldDouble = !shouldDouble;
+	  }
+	  return !!(sum % 10 === 0 ? sanitized : false);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 184 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isISIN;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var isin = /^[A-Z]{2}[0-9A-Z]{9}[0-9]$/;
+
+	function isISIN(str) {
+	  (0, _assertString2.default)(str);
+	  if (!isin.test(str)) {
+	    return false;
+	  }
+
+	  var checksumStr = str.replace(/[A-Z]/g, function (character) {
+	    return parseInt(character, 36);
+	  });
+
+	  var sum = 0;
+	  var digit = void 0;
+	  var tmpNum = void 0;
+	  var shouldDouble = true;
+	  for (var i = checksumStr.length - 2; i >= 0; i--) {
+	    digit = checksumStr.substring(i, i + 1);
+	    tmpNum = parseInt(digit, 10);
+	    if (shouldDouble) {
+	      tmpNum *= 2;
+	      if (tmpNum >= 10) {
+	        sum += tmpNum + 1;
+	      } else {
+	        sum += tmpNum;
+	      }
+	    } else {
+	      sum += tmpNum;
+	    }
+	    shouldDouble = !shouldDouble;
+	  }
+
+	  return parseInt(str.substr(str.length - 1), 10) === (10000 - sum) % 10;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 185 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isISBN;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var isbn10Maybe = /^(?:[0-9]{9}X|[0-9]{10})$/;
+	var isbn13Maybe = /^(?:[0-9]{13})$/;
+	var factor = [1, 3];
+
+	function isISBN(str) {
+	  var version = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
+
+	  (0, _assertString2.default)(str);
+	  version = String(version);
+	  if (!version) {
+	    return isISBN(str, 10) || isISBN(str, 13);
+	  }
+	  var sanitized = str.replace(/[\s-]+/g, '');
+	  var checksum = 0;
+	  var i = void 0;
+	  if (version === '10') {
+	    if (!isbn10Maybe.test(sanitized)) {
+	      return false;
+	    }
+	    for (i = 0; i < 9; i++) {
+	      checksum += (i + 1) * sanitized.charAt(i);
+	    }
+	    if (sanitized.charAt(9) === 'X') {
+	      checksum += 10 * 10;
+	    } else {
+	      checksum += 10 * sanitized.charAt(9);
+	    }
+	    if (checksum % 11 === 0) {
+	      return !!sanitized;
+	    }
+	  } else if (version === '13') {
+	    if (!isbn13Maybe.test(sanitized)) {
+	      return false;
+	    }
+	    for (i = 0; i < 12; i++) {
+	      checksum += factor[i % 2] * sanitized.charAt(i);
+	    }
+	    if (sanitized.charAt(12) - (10 - checksum % 10) % 10 === 0) {
+	      return !!sanitized;
+	    }
+	  }
+	  return false;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 186 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isISSN;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var issn = '^\\d{4}-?\\d{3}[\\dX]$';
+
+	function isISSN(str) {
+	  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+	  (0, _assertString2.default)(str);
+	  var testIssn = issn;
+	  testIssn = options.require_hyphen ? testIssn.replace('?', '') : testIssn;
+	  testIssn = options.case_sensitive ? new RegExp(testIssn) : new RegExp(testIssn, 'i');
+	  if (!testIssn.test(str)) {
+	    return false;
+	  }
+	  var issnDigits = str.replace('-', '');
+	  var position = 8;
+	  var checksum = 0;
+	  var _iteratorNormalCompletion = true;
+	  var _didIteratorError = false;
+	  var _iteratorError = undefined;
+
+	  try {
+	    for (var _iterator = issnDigits[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+	      var digit = _step.value;
+
+	      var digitValue = digit.toUpperCase() === 'X' ? 10 : +digit;
+	      checksum += digitValue * position;
+	      --position;
+	    }
+	  } catch (err) {
+	    _didIteratorError = true;
+	    _iteratorError = err;
+	  } finally {
+	    try {
+	      if (!_iteratorNormalCompletion && _iterator.return) {
+	        _iterator.return();
+	      }
+	    } finally {
+	      if (_didIteratorError) {
+	        throw _iteratorError;
+	      }
+	    }
+	  }
+
+	  return checksum % 11 === 0;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 187 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isMobilePhone;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/* eslint-disable max-len */
+	var phones = {
+	  'ar-DZ': /^(\+?213|0)(5|6|7)\d{8}$/,
+	  'ar-SY': /^(!?(\+?963)|0)?9\d{8}$/,
+	  'ar-SA': /^(!?(\+?966)|0)?5\d{8}$/,
+	  'en-US': /^(\+?1)?[2-9]\d{2}[2-9](?!11)\d{6}$/,
+	  'cs-CZ': /^(\+?420)? ?[1-9][0-9]{2} ?[0-9]{3} ?[0-9]{3}$/,
+	  'de-DE': /^(\+?49[ \.\-])?([\(]{1}[0-9]{1,6}[\)])?([0-9 \.\-\/]{3,20})((x|ext|extension)[ ]?[0-9]{1,4})?$/,
+	  'da-DK': /^(\+?45)?(\d{8})$/,
+	  'el-GR': /^(\+?30)?(69\d{8})$/,
+	  'en-AU': /^(\+?61|0)4\d{8}$/,
+	  'en-GB': /^(\+?44|0)7\d{9}$/,
+	  'en-HK': /^(\+?852\-?)?[569]\d{3}\-?\d{4}$/,
+	  'en-IN': /^(\+?91|0)?[789]\d{9}$/,
+	  'en-KE': /^(\+?254|0)?[7]\d{8}$/,
+	  'en-NG': /^(\+?234|0)?[789]\d{9}$/,
+	  'en-NZ': /^(\+?64|0)2\d{7,9}$/,
+	  'en-UG': /^(\+?256|0)?[7]\d{8}$/,
+	  'en-RW': /^(\+?250|0)?[7]\d{8}$/,
+	  'en-TZ': /^(\+?255|0)?[67]\d{8}$/,
+	  'en-ZA': /^(\+?27|0)\d{9}$/,
+	  'en-ZM': /^(\+?26)?09[567]\d{7}$/,
+	  'es-ES': /^(\+?34)?(6\d{1}|7[1234])\d{7}$/,
+	  'fi-FI': /^(\+?358|0)\s?(4(0|1|2|4|5|6)?|50)\s?(\d\s?){4,8}\d$/,
+	  'fa-IR': /^(\+?98[\-\s]?|0)9[0-39]\d[\-\s]?\d{3}[\-\s]?\d{4}$/,
+	  'fr-FR': /^(\+?33|0)[67]\d{8}$/,
+	  'he-IL': /^(\+972|0)([23489]|5[0248]|77)[1-9]\d{6}/,
+	  'hu-HU': /^(\+?36)(20|30|70)\d{7}$/,
+	  'lt-LT': /^(\+370|8)\d{8}$/,
+	  'id-ID': /^(\+?62|0[1-9])[\s|\d]+$/,
+	  'it-IT': /^(\+?39)?\s?3\d{2} ?\d{6,7}$/,
+	  'ko-KR': /^((\+?82)[ \-]?)?0?1([0|1|6|7|8|9]{1})[ \-]?\d{3,4}[ \-]?\d{4}$/,
+	  'ja-JP': /^(\+?81|0)\d{1,4}[ \-]?\d{1,4}[ \-]?\d{4}$/,
+	  'ms-MY': /^(\+?6?01){1}(([145]{1}(\-|\s)?\d{7,8})|([236789]{1}(\s|\-)?\d{7}))$/,
+	  'nb-NO': /^(\+?47)?[49]\d{7}$/,
+	  'nl-BE': /^(\+?32|0)4?\d{8}$/,
+	  'nn-NO': /^(\+?47)?[49]\d{7}$/,
+	  'pl-PL': /^(\+?48)? ?[5-8]\d ?\d{3} ?\d{2} ?\d{2}$/,
+	  'pt-BR': /^(\+?55|0)\-?[1-9]{2}\-?[2-9]{1}\d{3,4}\-?\d{4}$/,
+	  'pt-PT': /^(\+?351)?9[1236]\d{7}$/,
+	  'ro-RO': /^(\+?4?0)\s?7\d{2}(\/|\s|\.|\-)?\d{3}(\s|\.|\-)?\d{3}$/,
+	  'en-PK': /^((\+92)|(0092))-{0,1}\d{3}-{0,1}\d{7}$|^\d{11}$|^\d{4}-\d{7}$/,
+	  'ru-RU': /^(\+?7|8)?9\d{9}$/,
+	  'sr-RS': /^(\+3816|06)[- \d]{5,9}$/,
+	  'tr-TR': /^(\+?90|0)?5\d{9}$/,
+	  'vi-VN': /^(\+?84|0)?((1(2([0-9])|6([2-9])|88|99))|(9((?!5)[0-9])))([0-9]{7})$/,
+	  'zh-CN': /^(\+?0?86\-?)?1[345789]\d{9}$/,
+	  'zh-TW': /^(\+?886\-?|0)?9\d{8}$/
+	};
+	/* eslint-enable max-len */
+
+	// aliases
+	phones['en-CA'] = phones['en-US'];
+	phones['fr-BE'] = phones['nl-BE'];
+	phones['zh-HK'] = phones['en-HK'];
+
+	function isMobilePhone(str, locale) {
+	  (0, _assertString2.default)(str);
+	  if (locale in phones) {
+	    return phones[locale].test(str);
+	  } else if (locale === 'any') {
+	    return !!Object.values(phones).find(function (phone) {
+	      return phone.test(str);
+	    });
+	  }
+	  return false;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 188 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isCurrency;
+
+	var _merge = __webpack_require__(148);
+
+	var _merge2 = _interopRequireDefault(_merge);
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function currencyRegex(options) {
+	  var symbol = '(\\' + options.symbol.replace(/\./g, '\\.') + ')' + (options.require_symbol ? '' : '?'),
+	      negative = '-?',
+	      whole_dollar_amount_without_sep = '[1-9]\\d*',
+	      whole_dollar_amount_with_sep = '[1-9]\\d{0,2}(\\' + options.thousands_separator + '\\d{3})*',
+	      valid_whole_dollar_amounts = ['0', whole_dollar_amount_without_sep, whole_dollar_amount_with_sep],
+	      whole_dollar_amount = '(' + valid_whole_dollar_amounts.join('|') + ')?',
+	      decimal_amount = '(\\' + options.decimal_separator + '\\d{2})?';
+	  var pattern = whole_dollar_amount + decimal_amount;
+
+	  // default is negative sign before symbol, but there are two other options (besides parens)
+	  if (options.allow_negatives && !options.parens_for_negatives) {
+	    if (options.negative_sign_after_digits) {
+	      pattern += negative;
+	    } else if (options.negative_sign_before_digits) {
+	      pattern = negative + pattern;
+	    }
+	  }
+
+	  // South African Rand, for example, uses R 123 (space) and R-123 (no space)
+	  if (options.allow_negative_sign_placeholder) {
+	    pattern = '( (?!\\-))?' + pattern;
+	  } else if (options.allow_space_after_symbol) {
+	    pattern = ' ?' + pattern;
+	  } else if (options.allow_space_after_digits) {
+	    pattern += '( (?!$))?';
+	  }
+
+	  if (options.symbol_after_digits) {
+	    pattern += symbol;
+	  } else {
+	    pattern = symbol + pattern;
+	  }
+
+	  if (options.allow_negatives) {
+	    if (options.parens_for_negatives) {
+	      pattern = '(\\(' + pattern + '\\)|' + pattern + ')';
+	    } else if (!(options.negative_sign_before_digits || options.negative_sign_after_digits)) {
+	      pattern = negative + pattern;
+	    }
+	  }
+
+	  // ensure there's a dollar and/or decimal amount, and that
+	  // it doesn't start with a space or a negative sign followed by a space
+	  return new RegExp('^(?!-? )(?=.*\\d)' + pattern + '$');
+	}
+
+	var default_currency_options = {
+	  symbol: '$',
+	  require_symbol: false,
+	  allow_space_after_symbol: false,
+	  symbol_after_digits: false,
+	  allow_negatives: true,
+	  parens_for_negatives: false,
+	  negative_sign_before_digits: false,
+	  negative_sign_after_digits: false,
+	  allow_negative_sign_placeholder: false,
+	  thousands_separator: ',',
+	  decimal_separator: '.',
+	  allow_space_after_digits: false
+	};
+
+	function isCurrency(str, options) {
+	  (0, _assertString2.default)(str);
+	  options = (0, _merge2.default)(options, default_currency_options);
+	  return currencyRegex(options).test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 189 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.iso8601 = undefined;
+
+	exports.default = function (str) {
+	  (0, _assertString2.default)(str);
+	  return iso8601.test(str);
+	};
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/* eslint-disable max-len */
+	// from http://goo.gl/0ejHHW
+	var iso8601 = exports.iso8601 = /^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/;
+	/* eslint-enable max-len */
+
+/***/ }),
+/* 190 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isBase64;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var notBase64 = /[^A-Z0-9+\/=]/i;
+
+	function isBase64(str) {
+	  (0, _assertString2.default)(str);
+	  var len = str.length;
+	  if (!len || len % 4 !== 0 || notBase64.test(str)) {
+	    return false;
+	  }
+	  var firstPaddingChar = str.indexOf('=');
+	  return firstPaddingChar === -1 || firstPaddingChar === len - 1 || firstPaddingChar === len - 2 && str[len - 1] === '=';
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 191 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isDataURI;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var dataURI = /^\s*data:([a-z]+\/[a-z0-9\-\+]+(;[a-z\-]+=[a-z0-9\-]+)?)?(;base64)?,[a-z0-9!\$&',\(\)\*\+,;=\-\._~:@\/\?%\s]*\s*$/i; // eslint-disable-line max-len
+
+	function isDataURI(str) {
+	  (0, _assertString2.default)(str);
+	  return dataURI.test(str);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 192 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = ltrim;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function ltrim(str, chars) {
+	  (0, _assertString2.default)(str);
+	  var pattern = chars ? new RegExp('^[' + chars + ']+', 'g') : /^\s+/g;
+	  return str.replace(pattern, '');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 193 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = rtrim;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function rtrim(str, chars) {
+	  (0, _assertString2.default)(str);
+	  var pattern = chars ? new RegExp('[' + chars + ']') : /\s/;
+
+	  var idx = str.length - 1;
+	  while (idx >= 0 && pattern.test(str[idx])) {
+	    idx--;
+	  }
+
+	  return idx < str.length ? str.substr(0, idx + 1) : str;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 194 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = trim;
+
+	var _rtrim = __webpack_require__(193);
+
+	var _rtrim2 = _interopRequireDefault(_rtrim);
+
+	var _ltrim = __webpack_require__(192);
+
+	var _ltrim2 = _interopRequireDefault(_ltrim);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function trim(str, chars) {
+	  return (0, _rtrim2.default)((0, _ltrim2.default)(str, chars), chars);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 195 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = escape;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function escape(str) {
+	  (0, _assertString2.default)(str);
+	  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#x27;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\//g, '&#x2F;').replace(/\\/g, '&#x5C;').replace(/`/g, '&#96;');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 196 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = unescape;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function unescape(str) {
+	  (0, _assertString2.default)(str);
+	  return str.replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#x27;/g, "'").replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&#x2F;/g, '/').replace(/&#96;/g, '`');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 197 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = stripLow;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	var _blacklist = __webpack_require__(198);
+
+	var _blacklist2 = _interopRequireDefault(_blacklist);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function stripLow(str, keep_new_lines) {
+	  (0, _assertString2.default)(str);
+	  var chars = keep_new_lines ? '\\x00-\\x09\\x0B\\x0C\\x0E-\\x1F\\x7F' : '\\x00-\\x1F\\x7F';
+	  return (0, _blacklist2.default)(str, chars);
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 198 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = blacklist;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function blacklist(str, chars) {
+	  (0, _assertString2.default)(str);
+	  return str.replace(new RegExp('[' + chars + ']+', 'g'), '');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 199 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = whitelist;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function whitelist(str, chars) {
+	  (0, _assertString2.default)(str);
+	  return str.replace(new RegExp('[^' + chars + ']+', 'g'), '');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 200 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = isWhitelisted;
+
+	var _assertString = __webpack_require__(139);
+
+	var _assertString2 = _interopRequireDefault(_assertString);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function isWhitelisted(str, chars) {
+	  (0, _assertString2.default)(str);
+	  for (var i = str.length - 1; i >= 0; i--) {
+	    if (chars.indexOf(str[i]) === -1) {
+	      return false;
+	    }
+	  }
+	  return true;
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 201 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = normalizeEmail;
+
+	var _isEmail = __webpack_require__(147);
+
+	var _isEmail2 = _interopRequireDefault(_isEmail);
+
+	var _merge = __webpack_require__(148);
+
+	var _merge2 = _interopRequireDefault(_merge);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var default_normalize_email_options = {
+	  // The following options apply to all email addresses
+	  // Lowercases the local part of the email address.
+	  // Please note this may violate RFC 5321 as per http://stackoverflow.com/a/9808332/192024).
+	  // The domain is always lowercased, as per RFC 1035
+	  all_lowercase: true,
+
+	  // The following conversions are specific to GMail
+	  // Lowercases the local part of the GMail address (known to be case-insensitive)
+	  gmail_lowercase: true,
+	  // Removes dots from the local part of the email address, as that's ignored by GMail
+	  gmail_remove_dots: true,
+	  // Removes the subaddress (e.g. "+foo") from the email address
+	  gmail_remove_subaddress: true,
+	  // Conversts the googlemail.com domain to gmail.com
+	  gmail_convert_googlemaildotcom: true,
+
+	  // The following conversions are specific to Outlook.com / Windows Live / Hotmail
+	  // Lowercases the local part of the Outlook.com address (known to be case-insensitive)
+	  outlookdotcom_lowercase: true,
+	  // Removes the subaddress (e.g. "+foo") from the email address
+	  outlookdotcom_remove_subaddress: true,
+
+	  // The following conversions are specific to Yahoo
+	  // Lowercases the local part of the Yahoo address (known to be case-insensitive)
+	  yahoo_lowercase: true,
+	  // Removes the subaddress (e.g. "-foo") from the email address
+	  yahoo_remove_subaddress: true,
+
+	  // The following conversions are specific to iCloud
+	  // Lowercases the local part of the iCloud address (known to be case-insensitive)
+	  icloud_lowercase: true,
+	  // Removes the subaddress (e.g. "+foo") from the email address
+	  icloud_remove_subaddress: true
+	};
+
+	// List of domains used by iCloud
+	var icloud_domains = ['icloud.com', 'me.com'];
+
+	// List of domains used by Outlook.com and its predecessors
+	// This list is likely incomplete.
+	// Partial reference:
+	// https://blogs.office.com/2013/04/17/outlook-com-gets-two-step-verification-sign-in-by-alias-and-new-international-domains/
+	var outlookdotcom_domains = ['hotmail.at', 'hotmail.be', 'hotmail.ca', 'hotmail.cl', 'hotmail.co.il', 'hotmail.co.nz', 'hotmail.co.th', 'hotmail.co.uk', 'hotmail.com', 'hotmail.com.ar', 'hotmail.com.au', 'hotmail.com.br', 'hotmail.com.gr', 'hotmail.com.mx', 'hotmail.com.pe', 'hotmail.com.tr', 'hotmail.com.vn', 'hotmail.cz', 'hotmail.de', 'hotmail.dk', 'hotmail.es', 'hotmail.fr', 'hotmail.hu', 'hotmail.id', 'hotmail.ie', 'hotmail.in', 'hotmail.it', 'hotmail.jp', 'hotmail.kr', 'hotmail.lv', 'hotmail.my', 'hotmail.ph', 'hotmail.pt', 'hotmail.sa', 'hotmail.sg', 'hotmail.sk', 'live.be', 'live.co.uk', 'live.com', 'live.com.ar', 'live.com.mx', 'live.de', 'live.es', 'live.eu', 'live.fr', 'live.it', 'live.nl', 'msn.com', 'outlook.at', 'outlook.be', 'outlook.cl', 'outlook.co.il', 'outlook.co.nz', 'outlook.co.th', 'outlook.com', 'outlook.com.ar', 'outlook.com.au', 'outlook.com.br', 'outlook.com.gr', 'outlook.com.pe', 'outlook.com.tr', 'outlook.com.vn', 'outlook.cz', 'outlook.de', 'outlook.dk', 'outlook.es', 'outlook.fr', 'outlook.hu', 'outlook.id', 'outlook.ie', 'outlook.in', 'outlook.it', 'outlook.jp', 'outlook.kr', 'outlook.lv', 'outlook.my', 'outlook.ph', 'outlook.pt', 'outlook.sa', 'outlook.sg', 'outlook.sk', 'passport.com'];
+
+	// List of domains used by Yahoo Mail
+	// This list is likely incomplete
+	var yahoo_domains = ['rocketmail.com', 'yahoo.ca', 'yahoo.co.uk', 'yahoo.com', 'yahoo.de', 'yahoo.fr', 'yahoo.in', 'yahoo.it', 'ymail.com'];
+
+	function normalizeEmail(email, options) {
+	  options = (0, _merge2.default)(options, default_normalize_email_options);
+
+	  if (!(0, _isEmail2.default)(email)) {
+	    return false;
+	  }
+
+	  var raw_parts = email.split('@');
+	  var domain = raw_parts.pop();
+	  var user = raw_parts.join('@');
+	  var parts = [user, domain];
+
+	  // The domain is always lowercased, as it's case-insensitive per RFC 1035
+	  parts[1] = parts[1].toLowerCase();
+
+	  if (parts[1] === 'gmail.com' || parts[1] === 'googlemail.com') {
+	    // Address is GMail
+	    if (options.gmail_remove_subaddress) {
+	      parts[0] = parts[0].split('+')[0];
+	    }
+	    if (options.gmail_remove_dots) {
+	      parts[0] = parts[0].replace(/\./g, '');
+	    }
+	    if (!parts[0].length) {
+	      return false;
+	    }
+	    if (options.all_lowercase || options.gmail_lowercase) {
+	      parts[0] = parts[0].toLowerCase();
+	    }
+	    parts[1] = options.gmail_convert_googlemaildotcom ? 'gmail.com' : parts[1];
+	  } else if (~icloud_domains.indexOf(parts[1])) {
+	    // Address is iCloud
+	    if (options.icloud_remove_subaddress) {
+	      parts[0] = parts[0].split('+')[0];
+	    }
+	    if (!parts[0].length) {
+	      return false;
+	    }
+	    if (options.all_lowercase || options.icloud_lowercase) {
+	      parts[0] = parts[0].toLowerCase();
+	    }
+	  } else if (~outlookdotcom_domains.indexOf(parts[1])) {
+	    // Address is Outlook.com
+	    if (options.outlookdotcom_remove_subaddress) {
+	      parts[0] = parts[0].split('+')[0];
+	    }
+	    if (!parts[0].length) {
+	      return false;
+	    }
+	    if (options.all_lowercase || options.outlookdotcom_lowercase) {
+	      parts[0] = parts[0].toLowerCase();
+	    }
+	  } else if (~yahoo_domains.indexOf(parts[1])) {
+	    // Address is Yahoo
+	    if (options.yahoo_remove_subaddress) {
+	      var components = parts[0].split('-');
+	      parts[0] = components.length > 1 ? components.slice(0, -1).join('-') : components[0];
+	    }
+	    if (!parts[0].length) {
+	      return false;
+	    }
+	    if (options.all_lowercase || options.yahoo_lowercase) {
+	      parts[0] = parts[0].toLowerCase();
+	    }
+	  } else if (options.all_lowercase) {
+	    // Any other address
+	    parts[0] = parts[0].toLowerCase();
+	  }
+	  return parts.join('@');
+	}
+	module.exports = exports['default'];
+
+/***/ }),
+/* 202 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(Buffer) {'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	    value: true
+	});
+	exports.derToJose = derToJose;
+	exports.joseToDer = joseToDer;
+	var asn1 = __webpack_require__(203);
+
+	function base64UrlEscape(str) {
+	    return str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+	}
+
+	var ECDSASigValue = asn1.define('ECDSASigValue', function () {
+	    this.seq().obj(this.key('r').int(), this.key('s').int());
+	});
+
+	var seq = 0x10,
+	    int = 0x02;
+
+	function getParamSize(keySize) {
+	    var result = (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
+	    return result;
+	}
+
+	var paramBytesForAlg = {
+	    ES256: getParamSize(256),
+	    ES384: getParamSize(384),
+	    ES512: getParamSize(521)
+	};
+
+	function getParamBytesForAlg(alg) {
+	    var paramBytes = paramBytesForAlg[alg];
+	    if (paramBytes) {
+	        return paramBytes;
+	    }
+
+	    throw new Error('Unknown algorithm "' + alg + '"');
+	}
+
+	function bignumToBuf(bn, numBytes) {
+	    var buf = new Buffer(bn.toString('hex', numBytes), 'hex');
+	    return buf;
+	}
+
+	function signatureAsBuffer(signature) {
+	    if (Buffer.isBuffer(signature)) {
+	        return new Buffer(signature);
+	    } else if ('string' === typeof signature) {
+	        return new Buffer(signature, 'base64');
+	    }
+
+	    throw new TypeError('ECDSA signature must be a Base64 string or a Buffer');
+	}
+
+	function reduceBuffer(buf) {
+	    var padding = 0;
+	    for (var n = buf.length; padding < n && buf[padding] === 0;) {
+	        ++padding;
+	    }
+
+	    var needsSign = buf[padding] >= 0x80;
+	    if (needsSign) {
+	        --padding;
+
+	        if (padding < 0) {
+	            var old = buf;
+	            buf = new Buffer(1 + buf.length);
+	            buf[0] = 0;
+	            old.copy(buf, 1);
+
+	            return buf;
+	        }
+	    }
+
+	    if (padding === 0) {
+	        return buf;
+	    }
+
+	    buf = buf.slice(padding);
+	    return buf;
+	}
+
+	function derToJose(signature, alg) {
+	    signature = signatureAsBuffer(signature);
+	    var paramBytes = getParamBytesForAlg(alg);
+
+	    signature = ECDSASigValue.decode(signature, 'der');
+
+	    var r = bignumToBuf(signature.r, paramBytes);
+	    var s = bignumToBuf(signature.s, paramBytes);
+
+	    signature = Buffer.concat([r, s], r.length + s.length);
+	    signature = signature.toString('base64');
+	    signature = base64UrlEscape(signature);
+
+	    return signature;
+	}
+
+	function joseToDer(signature, alg) {
+	    signature = signatureAsBuffer(signature);
+	    var paramBytes = getParamBytesForAlg(alg);
+
+	    var signatureBytes = signature.length;
+	    if (signatureBytes !== paramBytes * 2) {
+	        throw new TypeError('"' + alg + '" signatures must be "' + paramBytes * 2 + '" bytes, saw "' + signatureBytes + '"');
+	    }
+
+	    var r = reduceBuffer(signature.slice(0, paramBytes));
+	    var s = reduceBuffer(signature.slice(paramBytes));
+
+	    var rsBytes = 1 + 1 + r.length + 1 + 1 + s.length;
+
+	    var oneByteLength = rsBytes < 0x80;
+
+	    signature = new Buffer((oneByteLength ? 2 : 3) + rsBytes);
+
+	    var offset = 0;
+	    signature[offset++] = seq | 0x20 | 0 << 6;
+	    if (oneByteLength) {
+	        signature[offset++] = rsBytes;
+	    } else {
+	        signature[offset++] = 0x80 | 1;
+	        signature[offset++] = rsBytes & 0xff;
+	    }
+	    signature[offset++] = int | 0 << 6;
+	    signature[offset++] = r.length;
+	    r.copy(signature, offset);
+	    offset += r.length;
+	    signature[offset++] = int | 0 << 6;
+	    signature[offset++] = s.length;
+	    s.copy(signature, offset);
+
+	    return signature;
+	}
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
+
+/***/ }),
+/* 203 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var asn1 = exports;
+
+	asn1.bignum = __webpack_require__(204);
+
+	asn1.define = __webpack_require__(206).define;
+	asn1.base = __webpack_require__(207);
+	asn1.constants = __webpack_require__(211);
+	asn1.decoders = __webpack_require__(213);
+	asn1.encoders = __webpack_require__(216);
+
+
+/***/ }),
+/* 204 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(module) {(function (module, exports) {
+	  'use strict';
+
+	  // Utils
+	  function assert (val, msg) {
+	    if (!val) throw new Error(msg || 'Assertion failed');
+	  }
+
+	  // Could use `inherits` module, but don't want to move from single file
+	  // architecture yet.
+	  function inherits (ctor, superCtor) {
+	    ctor.super_ = superCtor;
+	    var TempCtor = function () {};
+	    TempCtor.prototype = superCtor.prototype;
+	    ctor.prototype = new TempCtor();
+	    ctor.prototype.constructor = ctor;
+	  }
+
+	  // BN
+
+	  function BN (number, base, endian) {
+	    if (BN.isBN(number)) {
+	      return number;
+	    }
+
+	    this.negative = 0;
+	    this.words = null;
+	    this.length = 0;
+
+	    // Reduction context
+	    this.red = null;
+
+	    if (number !== null) {
+	      if (base === 'le' || base === 'be') {
+	        endian = base;
+	        base = 10;
+	      }
+
+	      this._init(number || 0, base || 10, endian || 'be');
+	    }
+	  }
+	  if (typeof module === 'object') {
+	    module.exports = BN;
+	  } else {
+	    exports.BN = BN;
+	  }
+
+	  BN.BN = BN;
+	  BN.wordSize = 26;
+
+	  var Buffer;
+	  try {
+	    Buffer = __webpack_require__(205).Buffer;
+	  } catch (e) {
+	  }
+
+	  BN.isBN = function isBN (num) {
+	    if (num instanceof BN) {
+	      return true;
+	    }
+
+	    return num !== null && typeof num === 'object' &&
+	      num.constructor.wordSize === BN.wordSize && Array.isArray(num.words);
+	  };
+
+	  BN.max = function max (left, right) {
+	    if (left.cmp(right) > 0) return left;
+	    return right;
+	  };
+
+	  BN.min = function min (left, right) {
+	    if (left.cmp(right) < 0) return left;
+	    return right;
+	  };
+
+	  BN.prototype._init = function init (number, base, endian) {
+	    if (typeof number === 'number') {
+	      return this._initNumber(number, base, endian);
+	    }
+
+	    if (typeof number === 'object') {
+	      return this._initArray(number, base, endian);
+	    }
+
+	    if (base === 'hex') {
+	      base = 16;
+	    }
+	    assert(base === (base | 0) && base >= 2 && base <= 36);
+
+	    number = number.toString().replace(/\s+/g, '');
+	    var start = 0;
+	    if (number[0] === '-') {
+	      start++;
+	    }
+
+	    if (base === 16) {
+	      this._parseHex(number, start);
+	    } else {
+	      this._parseBase(number, base, start);
+	    }
+
+	    if (number[0] === '-') {
+	      this.negative = 1;
+	    }
+
+	    this.strip();
+
+	    if (endian !== 'le') return;
+
+	    this._initArray(this.toArray(), base, endian);
+	  };
+
+	  BN.prototype._initNumber = function _initNumber (number, base, endian) {
+	    if (number < 0) {
+	      this.negative = 1;
+	      number = -number;
+	    }
+	    if (number < 0x4000000) {
+	      this.words = [ number & 0x3ffffff ];
+	      this.length = 1;
+	    } else if (number < 0x10000000000000) {
+	      this.words = [
+	        number & 0x3ffffff,
+	        (number / 0x4000000) & 0x3ffffff
+	      ];
+	      this.length = 2;
+	    } else {
+	      assert(number < 0x20000000000000); // 2 ^ 53 (unsafe)
+	      this.words = [
+	        number & 0x3ffffff,
+	        (number / 0x4000000) & 0x3ffffff,
+	        1
+	      ];
+	      this.length = 3;
+	    }
+
+	    if (endian !== 'le') return;
+
+	    // Reverse the bytes
+	    this._initArray(this.toArray(), base, endian);
+	  };
+
+	  BN.prototype._initArray = function _initArray (number, base, endian) {
+	    // Perhaps a Uint8Array
+	    assert(typeof number.length === 'number');
+	    if (number.length <= 0) {
+	      this.words = [ 0 ];
+	      this.length = 1;
+	      return this;
+	    }
+
+	    this.length = Math.ceil(number.length / 3);
+	    this.words = new Array(this.length);
+	    for (var i = 0; i < this.length; i++) {
+	      this.words[i] = 0;
+	    }
+
+	    var j, w;
+	    var off = 0;
+	    if (endian === 'be') {
+	      for (i = number.length - 1, j = 0; i >= 0; i -= 3) {
+	        w = number[i] | (number[i - 1] << 8) | (number[i - 2] << 16);
+	        this.words[j] |= (w << off) & 0x3ffffff;
+	        this.words[j + 1] = (w >>> (26 - off)) & 0x3ffffff;
+	        off += 24;
+	        if (off >= 26) {
+	          off -= 26;
+	          j++;
+	        }
+	      }
+	    } else if (endian === 'le') {
+	      for (i = 0, j = 0; i < number.length; i += 3) {
+	        w = number[i] | (number[i + 1] << 8) | (number[i + 2] << 16);
+	        this.words[j] |= (w << off) & 0x3ffffff;
+	        this.words[j + 1] = (w >>> (26 - off)) & 0x3ffffff;
+	        off += 24;
+	        if (off >= 26) {
+	          off -= 26;
+	          j++;
+	        }
+	      }
+	    }
+	    return this.strip();
+	  };
+
+	  function parseHex (str, start, end) {
+	    var r = 0;
+	    var len = Math.min(str.length, end);
+	    for (var i = start; i < len; i++) {
+	      var c = str.charCodeAt(i) - 48;
+
+	      r <<= 4;
+
+	      // 'a' - 'f'
+	      if (c >= 49 && c <= 54) {
+	        r |= c - 49 + 0xa;
+
+	      // 'A' - 'F'
+	      } else if (c >= 17 && c <= 22) {
+	        r |= c - 17 + 0xa;
+
+	      // '0' - '9'
+	      } else {
+	        r |= c & 0xf;
+	      }
+	    }
+	    return r;
+	  }
+
+	  BN.prototype._parseHex = function _parseHex (number, start) {
+	    // Create possibly bigger array to ensure that it fits the number
+	    this.length = Math.ceil((number.length - start) / 6);
+	    this.words = new Array(this.length);
+	    for (var i = 0; i < this.length; i++) {
+	      this.words[i] = 0;
+	    }
+
+	    var j, w;
+	    // Scan 24-bit chunks and add them to the number
+	    var off = 0;
+	    for (i = number.length - 6, j = 0; i >= start; i -= 6) {
+	      w = parseHex(number, i, i + 6);
+	      this.words[j] |= (w << off) & 0x3ffffff;
+	      // NOTE: `0x3fffff` is intentional here, 26bits max shift + 24bit hex limb
+	      this.words[j + 1] |= w >>> (26 - off) & 0x3fffff;
+	      off += 24;
+	      if (off >= 26) {
+	        off -= 26;
+	        j++;
+	      }
+	    }
+	    if (i + 6 !== start) {
+	      w = parseHex(number, start, i + 6);
+	      this.words[j] |= (w << off) & 0x3ffffff;
+	      this.words[j + 1] |= w >>> (26 - off) & 0x3fffff;
+	    }
+	    this.strip();
+	  };
+
+	  function parseBase (str, start, end, mul) {
+	    var r = 0;
+	    var len = Math.min(str.length, end);
+	    for (var i = start; i < len; i++) {
+	      var c = str.charCodeAt(i) - 48;
+
+	      r *= mul;
+
+	      // 'a'
+	      if (c >= 49) {
+	        r += c - 49 + 0xa;
+
+	      // 'A'
+	      } else if (c >= 17) {
+	        r += c - 17 + 0xa;
+
+	      // '0' - '9'
+	      } else {
+	        r += c;
+	      }
+	    }
+	    return r;
+	  }
+
+	  BN.prototype._parseBase = function _parseBase (number, base, start) {
+	    // Initialize as zero
+	    this.words = [ 0 ];
+	    this.length = 1;
+
+	    // Find length of limb in base
+	    for (var limbLen = 0, limbPow = 1; limbPow <= 0x3ffffff; limbPow *= base) {
+	      limbLen++;
+	    }
+	    limbLen--;
+	    limbPow = (limbPow / base) | 0;
+
+	    var total = number.length - start;
+	    var mod = total % limbLen;
+	    var end = Math.min(total, total - mod) + start;
+
+	    var word = 0;
+	    for (var i = start; i < end; i += limbLen) {
+	      word = parseBase(number, i, i + limbLen, base);
+
+	      this.imuln(limbPow);
+	      if (this.words[0] + word < 0x4000000) {
+	        this.words[0] += word;
+	      } else {
+	        this._iaddn(word);
+	      }
+	    }
+
+	    if (mod !== 0) {
+	      var pow = 1;
+	      word = parseBase(number, i, number.length, base);
+
+	      for (i = 0; i < mod; i++) {
+	        pow *= base;
+	      }
+
+	      this.imuln(pow);
+	      if (this.words[0] + word < 0x4000000) {
+	        this.words[0] += word;
+	      } else {
+	        this._iaddn(word);
+	      }
+	    }
+	  };
+
+	  BN.prototype.copy = function copy (dest) {
+	    dest.words = new Array(this.length);
+	    for (var i = 0; i < this.length; i++) {
+	      dest.words[i] = this.words[i];
+	    }
+	    dest.length = this.length;
+	    dest.negative = this.negative;
+	    dest.red = this.red;
+	  };
+
+	  BN.prototype.clone = function clone () {
+	    var r = new BN(null);
+	    this.copy(r);
+	    return r;
+	  };
+
+	  BN.prototype._expand = function _expand (size) {
+	    while (this.length < size) {
+	      this.words[this.length++] = 0;
+	    }
+	    return this;
+	  };
+
+	  // Remove leading `0` from `this`
+	  BN.prototype.strip = function strip () {
+	    while (this.length > 1 && this.words[this.length - 1] === 0) {
+	      this.length--;
+	    }
+	    return this._normSign();
+	  };
+
+	  BN.prototype._normSign = function _normSign () {
+	    // -0 = 0
+	    if (this.length === 1 && this.words[0] === 0) {
+	      this.negative = 0;
+	    }
+	    return this;
+	  };
+
+	  BN.prototype.inspect = function inspect () {
+	    return (this.red ? '<BN-R: ' : '<BN: ') + this.toString(16) + '>';
+	  };
+
+	  /*
+
+	  var zeros = [];
+	  var groupSizes = [];
+	  var groupBases = [];
+
+	  var s = '';
+	  var i = -1;
+	  while (++i < BN.wordSize) {
+	    zeros[i] = s;
+	    s += '0';
+	  }
+	  groupSizes[0] = 0;
+	  groupSizes[1] = 0;
+	  groupBases[0] = 0;
+	  groupBases[1] = 0;
+	  var base = 2 - 1;
+	  while (++base < 36 + 1) {
+	    var groupSize = 0;
+	    var groupBase = 1;
+	    while (groupBase < (1 << BN.wordSize) / base) {
+	      groupBase *= base;
+	      groupSize += 1;
+	    }
+	    groupSizes[base] = groupSize;
+	    groupBases[base] = groupBase;
+	  }
+
+	  */
+
+	  var zeros = [
+	    '',
+	    '0',
+	    '00',
+	    '000',
+	    '0000',
+	    '00000',
+	    '000000',
+	    '0000000',
+	    '00000000',
+	    '000000000',
+	    '0000000000',
+	    '00000000000',
+	    '000000000000',
+	    '0000000000000',
+	    '00000000000000',
+	    '000000000000000',
+	    '0000000000000000',
+	    '00000000000000000',
+	    '000000000000000000',
+	    '0000000000000000000',
+	    '00000000000000000000',
+	    '000000000000000000000',
+	    '0000000000000000000000',
+	    '00000000000000000000000',
+	    '000000000000000000000000',
+	    '0000000000000000000000000'
+	  ];
+
+	  var groupSizes = [
+	    0, 0,
+	    25, 16, 12, 11, 10, 9, 8,
+	    8, 7, 7, 7, 7, 6, 6,
+	    6, 6, 6, 6, 6, 5, 5,
+	    5, 5, 5, 5, 5, 5, 5,
+	    5, 5, 5, 5, 5, 5, 5
+	  ];
+
+	  var groupBases = [
+	    0, 0,
+	    33554432, 43046721, 16777216, 48828125, 60466176, 40353607, 16777216,
+	    43046721, 10000000, 19487171, 35831808, 62748517, 7529536, 11390625,
+	    16777216, 24137569, 34012224, 47045881, 64000000, 4084101, 5153632,
+	    6436343, 7962624, 9765625, 11881376, 14348907, 17210368, 20511149,
+	    24300000, 28629151, 33554432, 39135393, 45435424, 52521875, 60466176
+	  ];
+
+	  BN.prototype.toString = function toString (base, padding) {
+	    base = base || 10;
+	    padding = padding | 0 || 1;
+
+	    var out;
+	    if (base === 16 || base === 'hex') {
+	      out = '';
+	      var off = 0;
+	      var carry = 0;
+	      for (var i = 0; i < this.length; i++) {
+	        var w = this.words[i];
+	        var word = (((w << off) | carry) & 0xffffff).toString(16);
+	        carry = (w >>> (24 - off)) & 0xffffff;
+	        if (carry !== 0 || i !== this.length - 1) {
+	          out = zeros[6 - word.length] + word + out;
+	        } else {
+	          out = word + out;
+	        }
+	        off += 2;
+	        if (off >= 26) {
+	          off -= 26;
+	          i--;
+	        }
+	      }
+	      if (carry !== 0) {
+	        out = carry.toString(16) + out;
+	      }
+	      while (out.length % padding !== 0) {
+	        out = '0' + out;
+	      }
+	      if (this.negative !== 0) {
+	        out = '-' + out;
+	      }
+	      return out;
+	    }
+
+	    if (base === (base | 0) && base >= 2 && base <= 36) {
+	      // var groupSize = Math.floor(BN.wordSize * Math.LN2 / Math.log(base));
+	      var groupSize = groupSizes[base];
+	      // var groupBase = Math.pow(base, groupSize);
+	      var groupBase = groupBases[base];
+	      out = '';
+	      var c = this.clone();
+	      c.negative = 0;
+	      while (!c.isZero()) {
+	        var r = c.modn(groupBase).toString(base);
+	        c = c.idivn(groupBase);
+
+	        if (!c.isZero()) {
+	          out = zeros[groupSize - r.length] + r + out;
+	        } else {
+	          out = r + out;
+	        }
+	      }
+	      if (this.isZero()) {
+	        out = '0' + out;
+	      }
+	      while (out.length % padding !== 0) {
+	        out = '0' + out;
+	      }
+	      if (this.negative !== 0) {
+	        out = '-' + out;
+	      }
+	      return out;
+	    }
+
+	    assert(false, 'Base should be between 2 and 36');
+	  };
+
+	  BN.prototype.toNumber = function toNumber () {
+	    var ret = this.words[0];
+	    if (this.length === 2) {
+	      ret += this.words[1] * 0x4000000;
+	    } else if (this.length === 3 && this.words[2] === 0x01) {
+	      // NOTE: at this stage it is known that the top bit is set
+	      ret += 0x10000000000000 + (this.words[1] * 0x4000000);
+	    } else if (this.length > 2) {
+	      assert(false, 'Number can only safely store up to 53 bits');
+	    }
+	    return (this.negative !== 0) ? -ret : ret;
+	  };
+
+	  BN.prototype.toJSON = function toJSON () {
+	    return this.toString(16);
+	  };
+
+	  BN.prototype.toBuffer = function toBuffer (endian, length) {
+	    assert(typeof Buffer !== 'undefined');
+	    return this.toArrayLike(Buffer, endian, length);
+	  };
+
+	  BN.prototype.toArray = function toArray (endian, length) {
+	    return this.toArrayLike(Array, endian, length);
+	  };
+
+	  BN.prototype.toArrayLike = function toArrayLike (ArrayType, endian, length) {
+	    var byteLength = this.byteLength();
+	    var reqLength = length || Math.max(1, byteLength);
+	    assert(byteLength <= reqLength, 'byte array longer than desired length');
+	    assert(reqLength > 0, 'Requested array length <= 0');
+
+	    this.strip();
+	    var littleEndian = endian === 'le';
+	    var res = new ArrayType(reqLength);
+
+	    var b, i;
+	    var q = this.clone();
+	    if (!littleEndian) {
+	      // Assume big-endian
+	      for (i = 0; i < reqLength - byteLength; i++) {
+	        res[i] = 0;
+	      }
+
+	      for (i = 0; !q.isZero(); i++) {
+	        b = q.andln(0xff);
+	        q.iushrn(8);
+
+	        res[reqLength - i - 1] = b;
+	      }
+	    } else {
+	      for (i = 0; !q.isZero(); i++) {
+	        b = q.andln(0xff);
+	        q.iushrn(8);
+
+	        res[i] = b;
+	      }
+
+	      for (; i < reqLength; i++) {
+	        res[i] = 0;
+	      }
+	    }
+
+	    return res;
+	  };
+
+	  if (Math.clz32) {
+	    BN.prototype._countBits = function _countBits (w) {
+	      return 32 - Math.clz32(w);
+	    };
+	  } else {
+	    BN.prototype._countBits = function _countBits (w) {
+	      var t = w;
+	      var r = 0;
+	      if (t >= 0x1000) {
+	        r += 13;
+	        t >>>= 13;
+	      }
+	      if (t >= 0x40) {
+	        r += 7;
+	        t >>>= 7;
+	      }
+	      if (t >= 0x8) {
+	        r += 4;
+	        t >>>= 4;
+	      }
+	      if (t >= 0x02) {
+	        r += 2;
+	        t >>>= 2;
+	      }
+	      return r + t;
+	    };
+	  }
+
+	  BN.prototype._zeroBits = function _zeroBits (w) {
+	    // Short-cut
+	    if (w === 0) return 26;
+
+	    var t = w;
+	    var r = 0;
+	    if ((t & 0x1fff) === 0) {
+	      r += 13;
+	      t >>>= 13;
+	    }
+	    if ((t & 0x7f) === 0) {
+	      r += 7;
+	      t >>>= 7;
+	    }
+	    if ((t & 0xf) === 0) {
+	      r += 4;
+	      t >>>= 4;
+	    }
+	    if ((t & 0x3) === 0) {
+	      r += 2;
+	      t >>>= 2;
+	    }
+	    if ((t & 0x1) === 0) {
+	      r++;
+	    }
+	    return r;
+	  };
+
+	  // Return number of used bits in a BN
+	  BN.prototype.bitLength = function bitLength () {
+	    var w = this.words[this.length - 1];
+	    var hi = this._countBits(w);
+	    return (this.length - 1) * 26 + hi;
+	  };
+
+	  function toBitArray (num) {
+	    var w = new Array(num.bitLength());
+
+	    for (var bit = 0; bit < w.length; bit++) {
+	      var off = (bit / 26) | 0;
+	      var wbit = bit % 26;
+
+	      w[bit] = (num.words[off] & (1 << wbit)) >>> wbit;
+	    }
+
+	    return w;
+	  }
+
+	  // Number of trailing zero bits
+	  BN.prototype.zeroBits = function zeroBits () {
+	    if (this.isZero()) return 0;
+
+	    var r = 0;
+	    for (var i = 0; i < this.length; i++) {
+	      var b = this._zeroBits(this.words[i]);
+	      r += b;
+	      if (b !== 26) break;
+	    }
+	    return r;
+	  };
+
+	  BN.prototype.byteLength = function byteLength () {
+	    return Math.ceil(this.bitLength() / 8);
+	  };
+
+	  BN.prototype.toTwos = function toTwos (width) {
+	    if (this.negative !== 0) {
+	      return this.abs().inotn(width).iaddn(1);
+	    }
+	    return this.clone();
+	  };
+
+	  BN.prototype.fromTwos = function fromTwos (width) {
+	    if (this.testn(width - 1)) {
+	      return this.notn(width).iaddn(1).ineg();
+	    }
+	    return this.clone();
+	  };
+
+	  BN.prototype.isNeg = function isNeg () {
+	    return this.negative !== 0;
+	  };
+
+	  // Return negative clone of `this`
+	  BN.prototype.neg = function neg () {
+	    return this.clone().ineg();
+	  };
+
+	  BN.prototype.ineg = function ineg () {
+	    if (!this.isZero()) {
+	      this.negative ^= 1;
+	    }
+
+	    return this;
+	  };
+
+	  // Or `num` with `this` in-place
+	  BN.prototype.iuor = function iuor (num) {
+	    while (this.length < num.length) {
+	      this.words[this.length++] = 0;
+	    }
+
+	    for (var i = 0; i < num.length; i++) {
+	      this.words[i] = this.words[i] | num.words[i];
+	    }
+
+	    return this.strip();
+	  };
+
+	  BN.prototype.ior = function ior (num) {
+	    assert((this.negative | num.negative) === 0);
+	    return this.iuor(num);
+	  };
+
+	  // Or `num` with `this`
+	  BN.prototype.or = function or (num) {
+	    if (this.length > num.length) return this.clone().ior(num);
+	    return num.clone().ior(this);
+	  };
+
+	  BN.prototype.uor = function uor (num) {
+	    if (this.length > num.length) return this.clone().iuor(num);
+	    return num.clone().iuor(this);
+	  };
+
+	  // And `num` with `this` in-place
+	  BN.prototype.iuand = function iuand (num) {
+	    // b = min-length(num, this)
+	    var b;
+	    if (this.length > num.length) {
+	      b = num;
+	    } else {
+	      b = this;
+	    }
+
+	    for (var i = 0; i < b.length; i++) {
+	      this.words[i] = this.words[i] & num.words[i];
+	    }
+
+	    this.length = b.length;
+
+	    return this.strip();
+	  };
+
+	  BN.prototype.iand = function iand (num) {
+	    assert((this.negative | num.negative) === 0);
+	    return this.iuand(num);
+	  };
+
+	  // And `num` with `this`
+	  BN.prototype.and = function and (num) {
+	    if (this.length > num.length) return this.clone().iand(num);
+	    return num.clone().iand(this);
+	  };
+
+	  BN.prototype.uand = function uand (num) {
+	    if (this.length > num.length) return this.clone().iuand(num);
+	    return num.clone().iuand(this);
+	  };
+
+	  // Xor `num` with `this` in-place
+	  BN.prototype.iuxor = function iuxor (num) {
+	    // a.length > b.length
+	    var a;
+	    var b;
+	    if (this.length > num.length) {
+	      a = this;
+	      b = num;
+	    } else {
+	      a = num;
+	      b = this;
+	    }
+
+	    for (var i = 0; i < b.length; i++) {
+	      this.words[i] = a.words[i] ^ b.words[i];
+	    }
+
+	    if (this !== a) {
+	      for (; i < a.length; i++) {
+	        this.words[i] = a.words[i];
+	      }
+	    }
+
+	    this.length = a.length;
+
+	    return this.strip();
+	  };
+
+	  BN.prototype.ixor = function ixor (num) {
+	    assert((this.negative | num.negative) === 0);
+	    return this.iuxor(num);
+	  };
+
+	  // Xor `num` with `this`
+	  BN.prototype.xor = function xor (num) {
+	    if (this.length > num.length) return this.clone().ixor(num);
+	    return num.clone().ixor(this);
+	  };
+
+	  BN.prototype.uxor = function uxor (num) {
+	    if (this.length > num.length) return this.clone().iuxor(num);
+	    return num.clone().iuxor(this);
+	  };
+
+	  // Not ``this`` with ``width`` bitwidth
+	  BN.prototype.inotn = function inotn (width) {
+	    assert(typeof width === 'number' && width >= 0);
+
+	    var bytesNeeded = Math.ceil(width / 26) | 0;
+	    var bitsLeft = width % 26;
+
+	    // Extend the buffer with leading zeroes
+	    this._expand(bytesNeeded);
+
+	    if (bitsLeft > 0) {
+	      bytesNeeded--;
+	    }
+
+	    // Handle complete words
+	    for (var i = 0; i < bytesNeeded; i++) {
+	      this.words[i] = ~this.words[i] & 0x3ffffff;
+	    }
+
+	    // Handle the residue
+	    if (bitsLeft > 0) {
+	      this.words[i] = ~this.words[i] & (0x3ffffff >> (26 - bitsLeft));
+	    }
+
+	    // And remove leading zeroes
+	    return this.strip();
+	  };
+
+	  BN.prototype.notn = function notn (width) {
+	    return this.clone().inotn(width);
+	  };
+
+	  // Set `bit` of `this`
+	  BN.prototype.setn = function setn (bit, val) {
+	    assert(typeof bit === 'number' && bit >= 0);
+
+	    var off = (bit / 26) | 0;
+	    var wbit = bit % 26;
+
+	    this._expand(off + 1);
+
+	    if (val) {
+	      this.words[off] = this.words[off] | (1 << wbit);
+	    } else {
+	      this.words[off] = this.words[off] & ~(1 << wbit);
+	    }
+
+	    return this.strip();
+	  };
+
+	  // Add `num` to `this` in-place
+	  BN.prototype.iadd = function iadd (num) {
+	    var r;
+
+	    // negative + positive
+	    if (this.negative !== 0 && num.negative === 0) {
+	      this.negative = 0;
+	      r = this.isub(num);
+	      this.negative ^= 1;
+	      return this._normSign();
+
+	    // positive + negative
+	    } else if (this.negative === 0 && num.negative !== 0) {
+	      num.negative = 0;
+	      r = this.isub(num);
+	      num.negative = 1;
+	      return r._normSign();
+	    }
+
+	    // a.length > b.length
+	    var a, b;
+	    if (this.length > num.length) {
+	      a = this;
+	      b = num;
+	    } else {
+	      a = num;
+	      b = this;
+	    }
+
+	    var carry = 0;
+	    for (var i = 0; i < b.length; i++) {
+	      r = (a.words[i] | 0) + (b.words[i] | 0) + carry;
+	      this.words[i] = r & 0x3ffffff;
+	      carry = r >>> 26;
+	    }
+	    for (; carry !== 0 && i < a.length; i++) {
+	      r = (a.words[i] | 0) + carry;
+	      this.words[i] = r & 0x3ffffff;
+	      carry = r >>> 26;
+	    }
+
+	    this.length = a.length;
+	    if (carry !== 0) {
+	      this.words[this.length] = carry;
+	      this.length++;
+	    // Copy the rest of the words
+	    } else if (a !== this) {
+	      for (; i < a.length; i++) {
+	        this.words[i] = a.words[i];
+	      }
+	    }
+
+	    return this;
+	  };
+
+	  // Add `num` to `this`
+	  BN.prototype.add = function add (num) {
+	    var res;
+	    if (num.negative !== 0 && this.negative === 0) {
+	      num.negative = 0;
+	      res = this.sub(num);
+	      num.negative ^= 1;
+	      return res;
+	    } else if (num.negative === 0 && this.negative !== 0) {
+	      this.negative = 0;
+	      res = num.sub(this);
+	      this.negative = 1;
+	      return res;
+	    }
+
+	    if (this.length > num.length) return this.clone().iadd(num);
+
+	    return num.clone().iadd(this);
+	  };
+
+	  // Subtract `num` from `this` in-place
+	  BN.prototype.isub = function isub (num) {
+	    // this - (-num) = this + num
+	    if (num.negative !== 0) {
+	      num.negative = 0;
+	      var r = this.iadd(num);
+	      num.negative = 1;
+	      return r._normSign();
+
+	    // -this - num = -(this + num)
+	    } else if (this.negative !== 0) {
+	      this.negative = 0;
+	      this.iadd(num);
+	      this.negative = 1;
+	      return this._normSign();
+	    }
+
+	    // At this point both numbers are positive
+	    var cmp = this.cmp(num);
+
+	    // Optimization - zeroify
+	    if (cmp === 0) {
+	      this.negative = 0;
+	      this.length = 1;
+	      this.words[0] = 0;
+	      return this;
+	    }
+
+	    // a > b
+	    var a, b;
+	    if (cmp > 0) {
+	      a = this;
+	      b = num;
+	    } else {
+	      a = num;
+	      b = this;
+	    }
+
+	    var carry = 0;
+	    for (var i = 0; i < b.length; i++) {
+	      r = (a.words[i] | 0) - (b.words[i] | 0) + carry;
+	      carry = r >> 26;
+	      this.words[i] = r & 0x3ffffff;
+	    }
+	    for (; carry !== 0 && i < a.length; i++) {
+	      r = (a.words[i] | 0) + carry;
+	      carry = r >> 26;
+	      this.words[i] = r & 0x3ffffff;
+	    }
+
+	    // Copy rest of the words
+	    if (carry === 0 && i < a.length && a !== this) {
+	      for (; i < a.length; i++) {
+	        this.words[i] = a.words[i];
+	      }
+	    }
+
+	    this.length = Math.max(this.length, i);
+
+	    if (a !== this) {
+	      this.negative = 1;
+	    }
+
+	    return this.strip();
+	  };
+
+	  // Subtract `num` from `this`
+	  BN.prototype.sub = function sub (num) {
+	    return this.clone().isub(num);
+	  };
+
+	  function smallMulTo (self, num, out) {
+	    out.negative = num.negative ^ self.negative;
+	    var len = (self.length + num.length) | 0;
+	    out.length = len;
+	    len = (len - 1) | 0;
+
+	    // Peel one iteration (compiler can't do it, because of code complexity)
+	    var a = self.words[0] | 0;
+	    var b = num.words[0] | 0;
+	    var r = a * b;
+
+	    var lo = r & 0x3ffffff;
+	    var carry = (r / 0x4000000) | 0;
+	    out.words[0] = lo;
+
+	    for (var k = 1; k < len; k++) {
+	      // Sum all words with the same `i + j = k` and accumulate `ncarry`,
+	      // note that ncarry could be >= 0x3ffffff
+	      var ncarry = carry >>> 26;
+	      var rword = carry & 0x3ffffff;
+	      var maxJ = Math.min(k, num.length - 1);
+	      for (var j = Math.max(0, k - self.length + 1); j <= maxJ; j++) {
+	        var i = (k - j) | 0;
+	        a = self.words[i] | 0;
+	        b = num.words[j] | 0;
+	        r = a * b + rword;
+	        ncarry += (r / 0x4000000) | 0;
+	        rword = r & 0x3ffffff;
+	      }
+	      out.words[k] = rword | 0;
+	      carry = ncarry | 0;
+	    }
+	    if (carry !== 0) {
+	      out.words[k] = carry | 0;
+	    } else {
+	      out.length--;
+	    }
+
+	    return out.strip();
+	  }
+
+	  // TODO(indutny): it may be reasonable to omit it for users who don't need
+	  // to work with 256-bit numbers, otherwise it gives 20% improvement for 256-bit
+	  // multiplication (like elliptic secp256k1).
+	  var comb10MulTo = function comb10MulTo (self, num, out) {
+	    var a = self.words;
+	    var b = num.words;
+	    var o = out.words;
+	    var c = 0;
+	    var lo;
+	    var mid;
+	    var hi;
+	    var a0 = a[0] | 0;
+	    var al0 = a0 & 0x1fff;
+	    var ah0 = a0 >>> 13;
+	    var a1 = a[1] | 0;
+	    var al1 = a1 & 0x1fff;
+	    var ah1 = a1 >>> 13;
+	    var a2 = a[2] | 0;
+	    var al2 = a2 & 0x1fff;
+	    var ah2 = a2 >>> 13;
+	    var a3 = a[3] | 0;
+	    var al3 = a3 & 0x1fff;
+	    var ah3 = a3 >>> 13;
+	    var a4 = a[4] | 0;
+	    var al4 = a4 & 0x1fff;
+	    var ah4 = a4 >>> 13;
+	    var a5 = a[5] | 0;
+	    var al5 = a5 & 0x1fff;
+	    var ah5 = a5 >>> 13;
+	    var a6 = a[6] | 0;
+	    var al6 = a6 & 0x1fff;
+	    var ah6 = a6 >>> 13;
+	    var a7 = a[7] | 0;
+	    var al7 = a7 & 0x1fff;
+	    var ah7 = a7 >>> 13;
+	    var a8 = a[8] | 0;
+	    var al8 = a8 & 0x1fff;
+	    var ah8 = a8 >>> 13;
+	    var a9 = a[9] | 0;
+	    var al9 = a9 & 0x1fff;
+	    var ah9 = a9 >>> 13;
+	    var b0 = b[0] | 0;
+	    var bl0 = b0 & 0x1fff;
+	    var bh0 = b0 >>> 13;
+	    var b1 = b[1] | 0;
+	    var bl1 = b1 & 0x1fff;
+	    var bh1 = b1 >>> 13;
+	    var b2 = b[2] | 0;
+	    var bl2 = b2 & 0x1fff;
+	    var bh2 = b2 >>> 13;
+	    var b3 = b[3] | 0;
+	    var bl3 = b3 & 0x1fff;
+	    var bh3 = b3 >>> 13;
+	    var b4 = b[4] | 0;
+	    var bl4 = b4 & 0x1fff;
+	    var bh4 = b4 >>> 13;
+	    var b5 = b[5] | 0;
+	    var bl5 = b5 & 0x1fff;
+	    var bh5 = b5 >>> 13;
+	    var b6 = b[6] | 0;
+	    var bl6 = b6 & 0x1fff;
+	    var bh6 = b6 >>> 13;
+	    var b7 = b[7] | 0;
+	    var bl7 = b7 & 0x1fff;
+	    var bh7 = b7 >>> 13;
+	    var b8 = b[8] | 0;
+	    var bl8 = b8 & 0x1fff;
+	    var bh8 = b8 >>> 13;
+	    var b9 = b[9] | 0;
+	    var bl9 = b9 & 0x1fff;
+	    var bh9 = b9 >>> 13;
+
+	    out.negative = self.negative ^ num.negative;
+	    out.length = 19;
+	    /* k = 0 */
+	    lo = Math.imul(al0, bl0);
+	    mid = Math.imul(al0, bh0);
+	    mid = (mid + Math.imul(ah0, bl0)) | 0;
+	    hi = Math.imul(ah0, bh0);
+	    var w0 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w0 >>> 26)) | 0;
+	    w0 &= 0x3ffffff;
+	    /* k = 1 */
+	    lo = Math.imul(al1, bl0);
+	    mid = Math.imul(al1, bh0);
+	    mid = (mid + Math.imul(ah1, bl0)) | 0;
+	    hi = Math.imul(ah1, bh0);
+	    lo = (lo + Math.imul(al0, bl1)) | 0;
+	    mid = (mid + Math.imul(al0, bh1)) | 0;
+	    mid = (mid + Math.imul(ah0, bl1)) | 0;
+	    hi = (hi + Math.imul(ah0, bh1)) | 0;
+	    var w1 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w1 >>> 26)) | 0;
+	    w1 &= 0x3ffffff;
+	    /* k = 2 */
+	    lo = Math.imul(al2, bl0);
+	    mid = Math.imul(al2, bh0);
+	    mid = (mid + Math.imul(ah2, bl0)) | 0;
+	    hi = Math.imul(ah2, bh0);
+	    lo = (lo + Math.imul(al1, bl1)) | 0;
+	    mid = (mid + Math.imul(al1, bh1)) | 0;
+	    mid = (mid + Math.imul(ah1, bl1)) | 0;
+	    hi = (hi + Math.imul(ah1, bh1)) | 0;
+	    lo = (lo + Math.imul(al0, bl2)) | 0;
+	    mid = (mid + Math.imul(al0, bh2)) | 0;
+	    mid = (mid + Math.imul(ah0, bl2)) | 0;
+	    hi = (hi + Math.imul(ah0, bh2)) | 0;
+	    var w2 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w2 >>> 26)) | 0;
+	    w2 &= 0x3ffffff;
+	    /* k = 3 */
+	    lo = Math.imul(al3, bl0);
+	    mid = Math.imul(al3, bh0);
+	    mid = (mid + Math.imul(ah3, bl0)) | 0;
+	    hi = Math.imul(ah3, bh0);
+	    lo = (lo + Math.imul(al2, bl1)) | 0;
+	    mid = (mid + Math.imul(al2, bh1)) | 0;
+	    mid = (mid + Math.imul(ah2, bl1)) | 0;
+	    hi = (hi + Math.imul(ah2, bh1)) | 0;
+	    lo = (lo + Math.imul(al1, bl2)) | 0;
+	    mid = (mid + Math.imul(al1, bh2)) | 0;
+	    mid = (mid + Math.imul(ah1, bl2)) | 0;
+	    hi = (hi + Math.imul(ah1, bh2)) | 0;
+	    lo = (lo + Math.imul(al0, bl3)) | 0;
+	    mid = (mid + Math.imul(al0, bh3)) | 0;
+	    mid = (mid + Math.imul(ah0, bl3)) | 0;
+	    hi = (hi + Math.imul(ah0, bh3)) | 0;
+	    var w3 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w3 >>> 26)) | 0;
+	    w3 &= 0x3ffffff;
+	    /* k = 4 */
+	    lo = Math.imul(al4, bl0);
+	    mid = Math.imul(al4, bh0);
+	    mid = (mid + Math.imul(ah4, bl0)) | 0;
+	    hi = Math.imul(ah4, bh0);
+	    lo = (lo + Math.imul(al3, bl1)) | 0;
+	    mid = (mid + Math.imul(al3, bh1)) | 0;
+	    mid = (mid + Math.imul(ah3, bl1)) | 0;
+	    hi = (hi + Math.imul(ah3, bh1)) | 0;
+	    lo = (lo + Math.imul(al2, bl2)) | 0;
+	    mid = (mid + Math.imul(al2, bh2)) | 0;
+	    mid = (mid + Math.imul(ah2, bl2)) | 0;
+	    hi = (hi + Math.imul(ah2, bh2)) | 0;
+	    lo = (lo + Math.imul(al1, bl3)) | 0;
+	    mid = (mid + Math.imul(al1, bh3)) | 0;
+	    mid = (mid + Math.imul(ah1, bl3)) | 0;
+	    hi = (hi + Math.imul(ah1, bh3)) | 0;
+	    lo = (lo + Math.imul(al0, bl4)) | 0;
+	    mid = (mid + Math.imul(al0, bh4)) | 0;
+	    mid = (mid + Math.imul(ah0, bl4)) | 0;
+	    hi = (hi + Math.imul(ah0, bh4)) | 0;
+	    var w4 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w4 >>> 26)) | 0;
+	    w4 &= 0x3ffffff;
+	    /* k = 5 */
+	    lo = Math.imul(al5, bl0);
+	    mid = Math.imul(al5, bh0);
+	    mid = (mid + Math.imul(ah5, bl0)) | 0;
+	    hi = Math.imul(ah5, bh0);
+	    lo = (lo + Math.imul(al4, bl1)) | 0;
+	    mid = (mid + Math.imul(al4, bh1)) | 0;
+	    mid = (mid + Math.imul(ah4, bl1)) | 0;
+	    hi = (hi + Math.imul(ah4, bh1)) | 0;
+	    lo = (lo + Math.imul(al3, bl2)) | 0;
+	    mid = (mid + Math.imul(al3, bh2)) | 0;
+	    mid = (mid + Math.imul(ah3, bl2)) | 0;
+	    hi = (hi + Math.imul(ah3, bh2)) | 0;
+	    lo = (lo + Math.imul(al2, bl3)) | 0;
+	    mid = (mid + Math.imul(al2, bh3)) | 0;
+	    mid = (mid + Math.imul(ah2, bl3)) | 0;
+	    hi = (hi + Math.imul(ah2, bh3)) | 0;
+	    lo = (lo + Math.imul(al1, bl4)) | 0;
+	    mid = (mid + Math.imul(al1, bh4)) | 0;
+	    mid = (mid + Math.imul(ah1, bl4)) | 0;
+	    hi = (hi + Math.imul(ah1, bh4)) | 0;
+	    lo = (lo + Math.imul(al0, bl5)) | 0;
+	    mid = (mid + Math.imul(al0, bh5)) | 0;
+	    mid = (mid + Math.imul(ah0, bl5)) | 0;
+	    hi = (hi + Math.imul(ah0, bh5)) | 0;
+	    var w5 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w5 >>> 26)) | 0;
+	    w5 &= 0x3ffffff;
+	    /* k = 6 */
+	    lo = Math.imul(al6, bl0);
+	    mid = Math.imul(al6, bh0);
+	    mid = (mid + Math.imul(ah6, bl0)) | 0;
+	    hi = Math.imul(ah6, bh0);
+	    lo = (lo + Math.imul(al5, bl1)) | 0;
+	    mid = (mid + Math.imul(al5, bh1)) | 0;
+	    mid = (mid + Math.imul(ah5, bl1)) | 0;
+	    hi = (hi + Math.imul(ah5, bh1)) | 0;
+	    lo = (lo + Math.imul(al4, bl2)) | 0;
+	    mid = (mid + Math.imul(al4, bh2)) | 0;
+	    mid = (mid + Math.imul(ah4, bl2)) | 0;
+	    hi = (hi + Math.imul(ah4, bh2)) | 0;
+	    lo = (lo + Math.imul(al3, bl3)) | 0;
+	    mid = (mid + Math.imul(al3, bh3)) | 0;
+	    mid = (mid + Math.imul(ah3, bl3)) | 0;
+	    hi = (hi + Math.imul(ah3, bh3)) | 0;
+	    lo = (lo + Math.imul(al2, bl4)) | 0;
+	    mid = (mid + Math.imul(al2, bh4)) | 0;
+	    mid = (mid + Math.imul(ah2, bl4)) | 0;
+	    hi = (hi + Math.imul(ah2, bh4)) | 0;
+	    lo = (lo + Math.imul(al1, bl5)) | 0;
+	    mid = (mid + Math.imul(al1, bh5)) | 0;
+	    mid = (mid + Math.imul(ah1, bl5)) | 0;
+	    hi = (hi + Math.imul(ah1, bh5)) | 0;
+	    lo = (lo + Math.imul(al0, bl6)) | 0;
+	    mid = (mid + Math.imul(al0, bh6)) | 0;
+	    mid = (mid + Math.imul(ah0, bl6)) | 0;
+	    hi = (hi + Math.imul(ah0, bh6)) | 0;
+	    var w6 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w6 >>> 26)) | 0;
+	    w6 &= 0x3ffffff;
+	    /* k = 7 */
+	    lo = Math.imul(al7, bl0);
+	    mid = Math.imul(al7, bh0);
+	    mid = (mid + Math.imul(ah7, bl0)) | 0;
+	    hi = Math.imul(ah7, bh0);
+	    lo = (lo + Math.imul(al6, bl1)) | 0;
+	    mid = (mid + Math.imul(al6, bh1)) | 0;
+	    mid = (mid + Math.imul(ah6, bl1)) | 0;
+	    hi = (hi + Math.imul(ah6, bh1)) | 0;
+	    lo = (lo + Math.imul(al5, bl2)) | 0;
+	    mid = (mid + Math.imul(al5, bh2)) | 0;
+	    mid = (mid + Math.imul(ah5, bl2)) | 0;
+	    hi = (hi + Math.imul(ah5, bh2)) | 0;
+	    lo = (lo + Math.imul(al4, bl3)) | 0;
+	    mid = (mid + Math.imul(al4, bh3)) | 0;
+	    mid = (mid + Math.imul(ah4, bl3)) | 0;
+	    hi = (hi + Math.imul(ah4, bh3)) | 0;
+	    lo = (lo + Math.imul(al3, bl4)) | 0;
+	    mid = (mid + Math.imul(al3, bh4)) | 0;
+	    mid = (mid + Math.imul(ah3, bl4)) | 0;
+	    hi = (hi + Math.imul(ah3, bh4)) | 0;
+	    lo = (lo + Math.imul(al2, bl5)) | 0;
+	    mid = (mid + Math.imul(al2, bh5)) | 0;
+	    mid = (mid + Math.imul(ah2, bl5)) | 0;
+	    hi = (hi + Math.imul(ah2, bh5)) | 0;
+	    lo = (lo + Math.imul(al1, bl6)) | 0;
+	    mid = (mid + Math.imul(al1, bh6)) | 0;
+	    mid = (mid + Math.imul(ah1, bl6)) | 0;
+	    hi = (hi + Math.imul(ah1, bh6)) | 0;
+	    lo = (lo + Math.imul(al0, bl7)) | 0;
+	    mid = (mid + Math.imul(al0, bh7)) | 0;
+	    mid = (mid + Math.imul(ah0, bl7)) | 0;
+	    hi = (hi + Math.imul(ah0, bh7)) | 0;
+	    var w7 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w7 >>> 26)) | 0;
+	    w7 &= 0x3ffffff;
+	    /* k = 8 */
+	    lo = Math.imul(al8, bl0);
+	    mid = Math.imul(al8, bh0);
+	    mid = (mid + Math.imul(ah8, bl0)) | 0;
+	    hi = Math.imul(ah8, bh0);
+	    lo = (lo + Math.imul(al7, bl1)) | 0;
+	    mid = (mid + Math.imul(al7, bh1)) | 0;
+	    mid = (mid + Math.imul(ah7, bl1)) | 0;
+	    hi = (hi + Math.imul(ah7, bh1)) | 0;
+	    lo = (lo + Math.imul(al6, bl2)) | 0;
+	    mid = (mid + Math.imul(al6, bh2)) | 0;
+	    mid = (mid + Math.imul(ah6, bl2)) | 0;
+	    hi = (hi + Math.imul(ah6, bh2)) | 0;
+	    lo = (lo + Math.imul(al5, bl3)) | 0;
+	    mid = (mid + Math.imul(al5, bh3)) | 0;
+	    mid = (mid + Math.imul(ah5, bl3)) | 0;
+	    hi = (hi + Math.imul(ah5, bh3)) | 0;
+	    lo = (lo + Math.imul(al4, bl4)) | 0;
+	    mid = (mid + Math.imul(al4, bh4)) | 0;
+	    mid = (mid + Math.imul(ah4, bl4)) | 0;
+	    hi = (hi + Math.imul(ah4, bh4)) | 0;
+	    lo = (lo + Math.imul(al3, bl5)) | 0;
+	    mid = (mid + Math.imul(al3, bh5)) | 0;
+	    mid = (mid + Math.imul(ah3, bl5)) | 0;
+	    hi = (hi + Math.imul(ah3, bh5)) | 0;
+	    lo = (lo + Math.imul(al2, bl6)) | 0;
+	    mid = (mid + Math.imul(al2, bh6)) | 0;
+	    mid = (mid + Math.imul(ah2, bl6)) | 0;
+	    hi = (hi + Math.imul(ah2, bh6)) | 0;
+	    lo = (lo + Math.imul(al1, bl7)) | 0;
+	    mid = (mid + Math.imul(al1, bh7)) | 0;
+	    mid = (mid + Math.imul(ah1, bl7)) | 0;
+	    hi = (hi + Math.imul(ah1, bh7)) | 0;
+	    lo = (lo + Math.imul(al0, bl8)) | 0;
+	    mid = (mid + Math.imul(al0, bh8)) | 0;
+	    mid = (mid + Math.imul(ah0, bl8)) | 0;
+	    hi = (hi + Math.imul(ah0, bh8)) | 0;
+	    var w8 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w8 >>> 26)) | 0;
+	    w8 &= 0x3ffffff;
+	    /* k = 9 */
+	    lo = Math.imul(al9, bl0);
+	    mid = Math.imul(al9, bh0);
+	    mid = (mid + Math.imul(ah9, bl0)) | 0;
+	    hi = Math.imul(ah9, bh0);
+	    lo = (lo + Math.imul(al8, bl1)) | 0;
+	    mid = (mid + Math.imul(al8, bh1)) | 0;
+	    mid = (mid + Math.imul(ah8, bl1)) | 0;
+	    hi = (hi + Math.imul(ah8, bh1)) | 0;
+	    lo = (lo + Math.imul(al7, bl2)) | 0;
+	    mid = (mid + Math.imul(al7, bh2)) | 0;
+	    mid = (mid + Math.imul(ah7, bl2)) | 0;
+	    hi = (hi + Math.imul(ah7, bh2)) | 0;
+	    lo = (lo + Math.imul(al6, bl3)) | 0;
+	    mid = (mid + Math.imul(al6, bh3)) | 0;
+	    mid = (mid + Math.imul(ah6, bl3)) | 0;
+	    hi = (hi + Math.imul(ah6, bh3)) | 0;
+	    lo = (lo + Math.imul(al5, bl4)) | 0;
+	    mid = (mid + Math.imul(al5, bh4)) | 0;
+	    mid = (mid + Math.imul(ah5, bl4)) | 0;
+	    hi = (hi + Math.imul(ah5, bh4)) | 0;
+	    lo = (lo + Math.imul(al4, bl5)) | 0;
+	    mid = (mid + Math.imul(al4, bh5)) | 0;
+	    mid = (mid + Math.imul(ah4, bl5)) | 0;
+	    hi = (hi + Math.imul(ah4, bh5)) | 0;
+	    lo = (lo + Math.imul(al3, bl6)) | 0;
+	    mid = (mid + Math.imul(al3, bh6)) | 0;
+	    mid = (mid + Math.imul(ah3, bl6)) | 0;
+	    hi = (hi + Math.imul(ah3, bh6)) | 0;
+	    lo = (lo + Math.imul(al2, bl7)) | 0;
+	    mid = (mid + Math.imul(al2, bh7)) | 0;
+	    mid = (mid + Math.imul(ah2, bl7)) | 0;
+	    hi = (hi + Math.imul(ah2, bh7)) | 0;
+	    lo = (lo + Math.imul(al1, bl8)) | 0;
+	    mid = (mid + Math.imul(al1, bh8)) | 0;
+	    mid = (mid + Math.imul(ah1, bl8)) | 0;
+	    hi = (hi + Math.imul(ah1, bh8)) | 0;
+	    lo = (lo + Math.imul(al0, bl9)) | 0;
+	    mid = (mid + Math.imul(al0, bh9)) | 0;
+	    mid = (mid + Math.imul(ah0, bl9)) | 0;
+	    hi = (hi + Math.imul(ah0, bh9)) | 0;
+	    var w9 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w9 >>> 26)) | 0;
+	    w9 &= 0x3ffffff;
+	    /* k = 10 */
+	    lo = Math.imul(al9, bl1);
+	    mid = Math.imul(al9, bh1);
+	    mid = (mid + Math.imul(ah9, bl1)) | 0;
+	    hi = Math.imul(ah9, bh1);
+	    lo = (lo + Math.imul(al8, bl2)) | 0;
+	    mid = (mid + Math.imul(al8, bh2)) | 0;
+	    mid = (mid + Math.imul(ah8, bl2)) | 0;
+	    hi = (hi + Math.imul(ah8, bh2)) | 0;
+	    lo = (lo + Math.imul(al7, bl3)) | 0;
+	    mid = (mid + Math.imul(al7, bh3)) | 0;
+	    mid = (mid + Math.imul(ah7, bl3)) | 0;
+	    hi = (hi + Math.imul(ah7, bh3)) | 0;
+	    lo = (lo + Math.imul(al6, bl4)) | 0;
+	    mid = (mid + Math.imul(al6, bh4)) | 0;
+	    mid = (mid + Math.imul(ah6, bl4)) | 0;
+	    hi = (hi + Math.imul(ah6, bh4)) | 0;
+	    lo = (lo + Math.imul(al5, bl5)) | 0;
+	    mid = (mid + Math.imul(al5, bh5)) | 0;
+	    mid = (mid + Math.imul(ah5, bl5)) | 0;
+	    hi = (hi + Math.imul(ah5, bh5)) | 0;
+	    lo = (lo + Math.imul(al4, bl6)) | 0;
+	    mid = (mid + Math.imul(al4, bh6)) | 0;
+	    mid = (mid + Math.imul(ah4, bl6)) | 0;
+	    hi = (hi + Math.imul(ah4, bh6)) | 0;
+	    lo = (lo + Math.imul(al3, bl7)) | 0;
+	    mid = (mid + Math.imul(al3, bh7)) | 0;
+	    mid = (mid + Math.imul(ah3, bl7)) | 0;
+	    hi = (hi + Math.imul(ah3, bh7)) | 0;
+	    lo = (lo + Math.imul(al2, bl8)) | 0;
+	    mid = (mid + Math.imul(al2, bh8)) | 0;
+	    mid = (mid + Math.imul(ah2, bl8)) | 0;
+	    hi = (hi + Math.imul(ah2, bh8)) | 0;
+	    lo = (lo + Math.imul(al1, bl9)) | 0;
+	    mid = (mid + Math.imul(al1, bh9)) | 0;
+	    mid = (mid + Math.imul(ah1, bl9)) | 0;
+	    hi = (hi + Math.imul(ah1, bh9)) | 0;
+	    var w10 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w10 >>> 26)) | 0;
+	    w10 &= 0x3ffffff;
+	    /* k = 11 */
+	    lo = Math.imul(al9, bl2);
+	    mid = Math.imul(al9, bh2);
+	    mid = (mid + Math.imul(ah9, bl2)) | 0;
+	    hi = Math.imul(ah9, bh2);
+	    lo = (lo + Math.imul(al8, bl3)) | 0;
+	    mid = (mid + Math.imul(al8, bh3)) | 0;
+	    mid = (mid + Math.imul(ah8, bl3)) | 0;
+	    hi = (hi + Math.imul(ah8, bh3)) | 0;
+	    lo = (lo + Math.imul(al7, bl4)) | 0;
+	    mid = (mid + Math.imul(al7, bh4)) | 0;
+	    mid = (mid + Math.imul(ah7, bl4)) | 0;
+	    hi = (hi + Math.imul(ah7, bh4)) | 0;
+	    lo = (lo + Math.imul(al6, bl5)) | 0;
+	    mid = (mid + Math.imul(al6, bh5)) | 0;
+	    mid = (mid + Math.imul(ah6, bl5)) | 0;
+	    hi = (hi + Math.imul(ah6, bh5)) | 0;
+	    lo = (lo + Math.imul(al5, bl6)) | 0;
+	    mid = (mid + Math.imul(al5, bh6)) | 0;
+	    mid = (mid + Math.imul(ah5, bl6)) | 0;
+	    hi = (hi + Math.imul(ah5, bh6)) | 0;
+	    lo = (lo + Math.imul(al4, bl7)) | 0;
+	    mid = (mid + Math.imul(al4, bh7)) | 0;
+	    mid = (mid + Math.imul(ah4, bl7)) | 0;
+	    hi = (hi + Math.imul(ah4, bh7)) | 0;
+	    lo = (lo + Math.imul(al3, bl8)) | 0;
+	    mid = (mid + Math.imul(al3, bh8)) | 0;
+	    mid = (mid + Math.imul(ah3, bl8)) | 0;
+	    hi = (hi + Math.imul(ah3, bh8)) | 0;
+	    lo = (lo + Math.imul(al2, bl9)) | 0;
+	    mid = (mid + Math.imul(al2, bh9)) | 0;
+	    mid = (mid + Math.imul(ah2, bl9)) | 0;
+	    hi = (hi + Math.imul(ah2, bh9)) | 0;
+	    var w11 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w11 >>> 26)) | 0;
+	    w11 &= 0x3ffffff;
+	    /* k = 12 */
+	    lo = Math.imul(al9, bl3);
+	    mid = Math.imul(al9, bh3);
+	    mid = (mid + Math.imul(ah9, bl3)) | 0;
+	    hi = Math.imul(ah9, bh3);
+	    lo = (lo + Math.imul(al8, bl4)) | 0;
+	    mid = (mid + Math.imul(al8, bh4)) | 0;
+	    mid = (mid + Math.imul(ah8, bl4)) | 0;
+	    hi = (hi + Math.imul(ah8, bh4)) | 0;
+	    lo = (lo + Math.imul(al7, bl5)) | 0;
+	    mid = (mid + Math.imul(al7, bh5)) | 0;
+	    mid = (mid + Math.imul(ah7, bl5)) | 0;
+	    hi = (hi + Math.imul(ah7, bh5)) | 0;
+	    lo = (lo + Math.imul(al6, bl6)) | 0;
+	    mid = (mid + Math.imul(al6, bh6)) | 0;
+	    mid = (mid + Math.imul(ah6, bl6)) | 0;
+	    hi = (hi + Math.imul(ah6, bh6)) | 0;
+	    lo = (lo + Math.imul(al5, bl7)) | 0;
+	    mid = (mid + Math.imul(al5, bh7)) | 0;
+	    mid = (mid + Math.imul(ah5, bl7)) | 0;
+	    hi = (hi + Math.imul(ah5, bh7)) | 0;
+	    lo = (lo + Math.imul(al4, bl8)) | 0;
+	    mid = (mid + Math.imul(al4, bh8)) | 0;
+	    mid = (mid + Math.imul(ah4, bl8)) | 0;
+	    hi = (hi + Math.imul(ah4, bh8)) | 0;
+	    lo = (lo + Math.imul(al3, bl9)) | 0;
+	    mid = (mid + Math.imul(al3, bh9)) | 0;
+	    mid = (mid + Math.imul(ah3, bl9)) | 0;
+	    hi = (hi + Math.imul(ah3, bh9)) | 0;
+	    var w12 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w12 >>> 26)) | 0;
+	    w12 &= 0x3ffffff;
+	    /* k = 13 */
+	    lo = Math.imul(al9, bl4);
+	    mid = Math.imul(al9, bh4);
+	    mid = (mid + Math.imul(ah9, bl4)) | 0;
+	    hi = Math.imul(ah9, bh4);
+	    lo = (lo + Math.imul(al8, bl5)) | 0;
+	    mid = (mid + Math.imul(al8, bh5)) | 0;
+	    mid = (mid + Math.imul(ah8, bl5)) | 0;
+	    hi = (hi + Math.imul(ah8, bh5)) | 0;
+	    lo = (lo + Math.imul(al7, bl6)) | 0;
+	    mid = (mid + Math.imul(al7, bh6)) | 0;
+	    mid = (mid + Math.imul(ah7, bl6)) | 0;
+	    hi = (hi + Math.imul(ah7, bh6)) | 0;
+	    lo = (lo + Math.imul(al6, bl7)) | 0;
+	    mid = (mid + Math.imul(al6, bh7)) | 0;
+	    mid = (mid + Math.imul(ah6, bl7)) | 0;
+	    hi = (hi + Math.imul(ah6, bh7)) | 0;
+	    lo = (lo + Math.imul(al5, bl8)) | 0;
+	    mid = (mid + Math.imul(al5, bh8)) | 0;
+	    mid = (mid + Math.imul(ah5, bl8)) | 0;
+	    hi = (hi + Math.imul(ah5, bh8)) | 0;
+	    lo = (lo + Math.imul(al4, bl9)) | 0;
+	    mid = (mid + Math.imul(al4, bh9)) | 0;
+	    mid = (mid + Math.imul(ah4, bl9)) | 0;
+	    hi = (hi + Math.imul(ah4, bh9)) | 0;
+	    var w13 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w13 >>> 26)) | 0;
+	    w13 &= 0x3ffffff;
+	    /* k = 14 */
+	    lo = Math.imul(al9, bl5);
+	    mid = Math.imul(al9, bh5);
+	    mid = (mid + Math.imul(ah9, bl5)) | 0;
+	    hi = Math.imul(ah9, bh5);
+	    lo = (lo + Math.imul(al8, bl6)) | 0;
+	    mid = (mid + Math.imul(al8, bh6)) | 0;
+	    mid = (mid + Math.imul(ah8, bl6)) | 0;
+	    hi = (hi + Math.imul(ah8, bh6)) | 0;
+	    lo = (lo + Math.imul(al7, bl7)) | 0;
+	    mid = (mid + Math.imul(al7, bh7)) | 0;
+	    mid = (mid + Math.imul(ah7, bl7)) | 0;
+	    hi = (hi + Math.imul(ah7, bh7)) | 0;
+	    lo = (lo + Math.imul(al6, bl8)) | 0;
+	    mid = (mid + Math.imul(al6, bh8)) | 0;
+	    mid = (mid + Math.imul(ah6, bl8)) | 0;
+	    hi = (hi + Math.imul(ah6, bh8)) | 0;
+	    lo = (lo + Math.imul(al5, bl9)) | 0;
+	    mid = (mid + Math.imul(al5, bh9)) | 0;
+	    mid = (mid + Math.imul(ah5, bl9)) | 0;
+	    hi = (hi + Math.imul(ah5, bh9)) | 0;
+	    var w14 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w14 >>> 26)) | 0;
+	    w14 &= 0x3ffffff;
+	    /* k = 15 */
+	    lo = Math.imul(al9, bl6);
+	    mid = Math.imul(al9, bh6);
+	    mid = (mid + Math.imul(ah9, bl6)) | 0;
+	    hi = Math.imul(ah9, bh6);
+	    lo = (lo + Math.imul(al8, bl7)) | 0;
+	    mid = (mid + Math.imul(al8, bh7)) | 0;
+	    mid = (mid + Math.imul(ah8, bl7)) | 0;
+	    hi = (hi + Math.imul(ah8, bh7)) | 0;
+	    lo = (lo + Math.imul(al7, bl8)) | 0;
+	    mid = (mid + Math.imul(al7, bh8)) | 0;
+	    mid = (mid + Math.imul(ah7, bl8)) | 0;
+	    hi = (hi + Math.imul(ah7, bh8)) | 0;
+	    lo = (lo + Math.imul(al6, bl9)) | 0;
+	    mid = (mid + Math.imul(al6, bh9)) | 0;
+	    mid = (mid + Math.imul(ah6, bl9)) | 0;
+	    hi = (hi + Math.imul(ah6, bh9)) | 0;
+	    var w15 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w15 >>> 26)) | 0;
+	    w15 &= 0x3ffffff;
+	    /* k = 16 */
+	    lo = Math.imul(al9, bl7);
+	    mid = Math.imul(al9, bh7);
+	    mid = (mid + Math.imul(ah9, bl7)) | 0;
+	    hi = Math.imul(ah9, bh7);
+	    lo = (lo + Math.imul(al8, bl8)) | 0;
+	    mid = (mid + Math.imul(al8, bh8)) | 0;
+	    mid = (mid + Math.imul(ah8, bl8)) | 0;
+	    hi = (hi + Math.imul(ah8, bh8)) | 0;
+	    lo = (lo + Math.imul(al7, bl9)) | 0;
+	    mid = (mid + Math.imul(al7, bh9)) | 0;
+	    mid = (mid + Math.imul(ah7, bl9)) | 0;
+	    hi = (hi + Math.imul(ah7, bh9)) | 0;
+	    var w16 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w16 >>> 26)) | 0;
+	    w16 &= 0x3ffffff;
+	    /* k = 17 */
+	    lo = Math.imul(al9, bl8);
+	    mid = Math.imul(al9, bh8);
+	    mid = (mid + Math.imul(ah9, bl8)) | 0;
+	    hi = Math.imul(ah9, bh8);
+	    lo = (lo + Math.imul(al8, bl9)) | 0;
+	    mid = (mid + Math.imul(al8, bh9)) | 0;
+	    mid = (mid + Math.imul(ah8, bl9)) | 0;
+	    hi = (hi + Math.imul(ah8, bh9)) | 0;
+	    var w17 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w17 >>> 26)) | 0;
+	    w17 &= 0x3ffffff;
+	    /* k = 18 */
+	    lo = Math.imul(al9, bl9);
+	    mid = Math.imul(al9, bh9);
+	    mid = (mid + Math.imul(ah9, bl9)) | 0;
+	    hi = Math.imul(ah9, bh9);
+	    var w18 = (((c + lo) | 0) + ((mid & 0x1fff) << 13)) | 0;
+	    c = (((hi + (mid >>> 13)) | 0) + (w18 >>> 26)) | 0;
+	    w18 &= 0x3ffffff;
+	    o[0] = w0;
+	    o[1] = w1;
+	    o[2] = w2;
+	    o[3] = w3;
+	    o[4] = w4;
+	    o[5] = w5;
+	    o[6] = w6;
+	    o[7] = w7;
+	    o[8] = w8;
+	    o[9] = w9;
+	    o[10] = w10;
+	    o[11] = w11;
+	    o[12] = w12;
+	    o[13] = w13;
+	    o[14] = w14;
+	    o[15] = w15;
+	    o[16] = w16;
+	    o[17] = w17;
+	    o[18] = w18;
+	    if (c !== 0) {
+	      o[19] = c;
+	      out.length++;
+	    }
+	    return out;
+	  };
+
+	  // Polyfill comb
+	  if (!Math.imul) {
+	    comb10MulTo = smallMulTo;
+	  }
+
+	  function bigMulTo (self, num, out) {
+	    out.negative = num.negative ^ self.negative;
+	    out.length = self.length + num.length;
+
+	    var carry = 0;
+	    var hncarry = 0;
+	    for (var k = 0; k < out.length - 1; k++) {
+	      // Sum all words with the same `i + j = k` and accumulate `ncarry`,
+	      // note that ncarry could be >= 0x3ffffff
+	      var ncarry = hncarry;
+	      hncarry = 0;
+	      var rword = carry & 0x3ffffff;
+	      var maxJ = Math.min(k, num.length - 1);
+	      for (var j = Math.max(0, k - self.length + 1); j <= maxJ; j++) {
+	        var i = k - j;
+	        var a = self.words[i] | 0;
+	        var b = num.words[j] | 0;
+	        var r = a * b;
+
+	        var lo = r & 0x3ffffff;
+	        ncarry = (ncarry + ((r / 0x4000000) | 0)) | 0;
+	        lo = (lo + rword) | 0;
+	        rword = lo & 0x3ffffff;
+	        ncarry = (ncarry + (lo >>> 26)) | 0;
+
+	        hncarry += ncarry >>> 26;
+	        ncarry &= 0x3ffffff;
+	      }
+	      out.words[k] = rword;
+	      carry = ncarry;
+	      ncarry = hncarry;
+	    }
+	    if (carry !== 0) {
+	      out.words[k] = carry;
+	    } else {
+	      out.length--;
+	    }
+
+	    return out.strip();
+	  }
+
+	  function jumboMulTo (self, num, out) {
+	    var fftm = new FFTM();
+	    return fftm.mulp(self, num, out);
+	  }
+
+	  BN.prototype.mulTo = function mulTo (num, out) {
+	    var res;
+	    var len = this.length + num.length;
+	    if (this.length === 10 && num.length === 10) {
+	      res = comb10MulTo(this, num, out);
+	    } else if (len < 63) {
+	      res = smallMulTo(this, num, out);
+	    } else if (len < 1024) {
+	      res = bigMulTo(this, num, out);
+	    } else {
+	      res = jumboMulTo(this, num, out);
+	    }
+
+	    return res;
+	  };
+
+	  // Cooley-Tukey algorithm for FFT
+	  // slightly revisited to rely on looping instead of recursion
+
+	  function FFTM (x, y) {
+	    this.x = x;
+	    this.y = y;
+	  }
+
+	  FFTM.prototype.makeRBT = function makeRBT (N) {
+	    var t = new Array(N);
+	    var l = BN.prototype._countBits(N) - 1;
+	    for (var i = 0; i < N; i++) {
+	      t[i] = this.revBin(i, l, N);
+	    }
+
+	    return t;
+	  };
+
+	  // Returns binary-reversed representation of `x`
+	  FFTM.prototype.revBin = function revBin (x, l, N) {
+	    if (x === 0 || x === N - 1) return x;
+
+	    var rb = 0;
+	    for (var i = 0; i < l; i++) {
+	      rb |= (x & 1) << (l - i - 1);
+	      x >>= 1;
+	    }
+
+	    return rb;
+	  };
+
+	  // Performs "tweedling" phase, therefore 'emulating'
+	  // behaviour of the recursive algorithm
+	  FFTM.prototype.permute = function permute (rbt, rws, iws, rtws, itws, N) {
+	    for (var i = 0; i < N; i++) {
+	      rtws[i] = rws[rbt[i]];
+	      itws[i] = iws[rbt[i]];
+	    }
+	  };
+
+	  FFTM.prototype.transform = function transform (rws, iws, rtws, itws, N, rbt) {
+	    this.permute(rbt, rws, iws, rtws, itws, N);
+
+	    for (var s = 1; s < N; s <<= 1) {
+	      var l = s << 1;
+
+	      var rtwdf = Math.cos(2 * Math.PI / l);
+	      var itwdf = Math.sin(2 * Math.PI / l);
+
+	      for (var p = 0; p < N; p += l) {
+	        var rtwdf_ = rtwdf;
+	        var itwdf_ = itwdf;
+
+	        for (var j = 0; j < s; j++) {
+	          var re = rtws[p + j];
+	          var ie = itws[p + j];
+
+	          var ro = rtws[p + j + s];
+	          var io = itws[p + j + s];
+
+	          var rx = rtwdf_ * ro - itwdf_ * io;
+
+	          io = rtwdf_ * io + itwdf_ * ro;
+	          ro = rx;
+
+	          rtws[p + j] = re + ro;
+	          itws[p + j] = ie + io;
+
+	          rtws[p + j + s] = re - ro;
+	          itws[p + j + s] = ie - io;
+
+	          /* jshint maxdepth : false */
+	          if (j !== l) {
+	            rx = rtwdf * rtwdf_ - itwdf * itwdf_;
+
+	            itwdf_ = rtwdf * itwdf_ + itwdf * rtwdf_;
+	            rtwdf_ = rx;
+	          }
+	        }
+	      }
+	    }
+	  };
+
+	  FFTM.prototype.guessLen13b = function guessLen13b (n, m) {
+	    var N = Math.max(m, n) | 1;
+	    var odd = N & 1;
+	    var i = 0;
+	    for (N = N / 2 | 0; N; N = N >>> 1) {
+	      i++;
+	    }
+
+	    return 1 << i + 1 + odd;
+	  };
+
+	  FFTM.prototype.conjugate = function conjugate (rws, iws, N) {
+	    if (N <= 1) return;
+
+	    for (var i = 0; i < N / 2; i++) {
+	      var t = rws[i];
+
+	      rws[i] = rws[N - i - 1];
+	      rws[N - i - 1] = t;
+
+	      t = iws[i];
+
+	      iws[i] = -iws[N - i - 1];
+	      iws[N - i - 1] = -t;
+	    }
+	  };
+
+	  FFTM.prototype.normalize13b = function normalize13b (ws, N) {
+	    var carry = 0;
+	    for (var i = 0; i < N / 2; i++) {
+	      var w = Math.round(ws[2 * i + 1] / N) * 0x2000 +
+	        Math.round(ws[2 * i] / N) +
+	        carry;
+
+	      ws[i] = w & 0x3ffffff;
+
+	      if (w < 0x4000000) {
+	        carry = 0;
+	      } else {
+	        carry = w / 0x4000000 | 0;
+	      }
+	    }
+
+	    return ws;
+	  };
+
+	  FFTM.prototype.convert13b = function convert13b (ws, len, rws, N) {
+	    var carry = 0;
+	    for (var i = 0; i < len; i++) {
+	      carry = carry + (ws[i] | 0);
+
+	      rws[2 * i] = carry & 0x1fff; carry = carry >>> 13;
+	      rws[2 * i + 1] = carry & 0x1fff; carry = carry >>> 13;
+	    }
+
+	    // Pad with zeroes
+	    for (i = 2 * len; i < N; ++i) {
+	      rws[i] = 0;
+	    }
+
+	    assert(carry === 0);
+	    assert((carry & ~0x1fff) === 0);
+	  };
+
+	  FFTM.prototype.stub = function stub (N) {
+	    var ph = new Array(N);
+	    for (var i = 0; i < N; i++) {
+	      ph[i] = 0;
+	    }
+
+	    return ph;
+	  };
+
+	  FFTM.prototype.mulp = function mulp (x, y, out) {
+	    var N = 2 * this.guessLen13b(x.length, y.length);
+
+	    var rbt = this.makeRBT(N);
+
+	    var _ = this.stub(N);
+
+	    var rws = new Array(N);
+	    var rwst = new Array(N);
+	    var iwst = new Array(N);
+
+	    var nrws = new Array(N);
+	    var nrwst = new Array(N);
+	    var niwst = new Array(N);
+
+	    var rmws = out.words;
+	    rmws.length = N;
+
+	    this.convert13b(x.words, x.length, rws, N);
+	    this.convert13b(y.words, y.length, nrws, N);
+
+	    this.transform(rws, _, rwst, iwst, N, rbt);
+	    this.transform(nrws, _, nrwst, niwst, N, rbt);
+
+	    for (var i = 0; i < N; i++) {
+	      var rx = rwst[i] * nrwst[i] - iwst[i] * niwst[i];
+	      iwst[i] = rwst[i] * niwst[i] + iwst[i] * nrwst[i];
+	      rwst[i] = rx;
+	    }
+
+	    this.conjugate(rwst, iwst, N);
+	    this.transform(rwst, iwst, rmws, _, N, rbt);
+	    this.conjugate(rmws, _, N);
+	    this.normalize13b(rmws, N);
+
+	    out.negative = x.negative ^ y.negative;
+	    out.length = x.length + y.length;
+	    return out.strip();
+	  };
+
+	  // Multiply `this` by `num`
+	  BN.prototype.mul = function mul (num) {
+	    var out = new BN(null);
+	    out.words = new Array(this.length + num.length);
+	    return this.mulTo(num, out);
+	  };
+
+	  // Multiply employing FFT
+	  BN.prototype.mulf = function mulf (num) {
+	    var out = new BN(null);
+	    out.words = new Array(this.length + num.length);
+	    return jumboMulTo(this, num, out);
+	  };
+
+	  // In-place Multiplication
+	  BN.prototype.imul = function imul (num) {
+	    return this.clone().mulTo(num, this);
+	  };
+
+	  BN.prototype.imuln = function imuln (num) {
+	    assert(typeof num === 'number');
+	    assert(num < 0x4000000);
+
+	    // Carry
+	    var carry = 0;
+	    for (var i = 0; i < this.length; i++) {
+	      var w = (this.words[i] | 0) * num;
+	      var lo = (w & 0x3ffffff) + (carry & 0x3ffffff);
+	      carry >>= 26;
+	      carry += (w / 0x4000000) | 0;
+	      // NOTE: lo is 27bit maximum
+	      carry += lo >>> 26;
+	      this.words[i] = lo & 0x3ffffff;
+	    }
+
+	    if (carry !== 0) {
+	      this.words[i] = carry;
+	      this.length++;
+	    }
+
+	    return this;
+	  };
+
+	  BN.prototype.muln = function muln (num) {
+	    return this.clone().imuln(num);
+	  };
+
+	  // `this` * `this`
+	  BN.prototype.sqr = function sqr () {
+	    return this.mul(this);
+	  };
+
+	  // `this` * `this` in-place
+	  BN.prototype.isqr = function isqr () {
+	    return this.imul(this.clone());
+	  };
+
+	  // Math.pow(`this`, `num`)
+	  BN.prototype.pow = function pow (num) {
+	    var w = toBitArray(num);
+	    if (w.length === 0) return new BN(1);
+
+	    // Skip leading zeroes
+	    var res = this;
+	    for (var i = 0; i < w.length; i++, res = res.sqr()) {
+	      if (w[i] !== 0) break;
+	    }
+
+	    if (++i < w.length) {
+	      for (var q = res.sqr(); i < w.length; i++, q = q.sqr()) {
+	        if (w[i] === 0) continue;
+
+	        res = res.mul(q);
+	      }
+	    }
+
+	    return res;
+	  };
+
+	  // Shift-left in-place
+	  BN.prototype.iushln = function iushln (bits) {
+	    assert(typeof bits === 'number' && bits >= 0);
+	    var r = bits % 26;
+	    var s = (bits - r) / 26;
+	    var carryMask = (0x3ffffff >>> (26 - r)) << (26 - r);
+	    var i;
+
+	    if (r !== 0) {
+	      var carry = 0;
+
+	      for (i = 0; i < this.length; i++) {
+	        var newCarry = this.words[i] & carryMask;
+	        var c = ((this.words[i] | 0) - newCarry) << r;
+	        this.words[i] = c | carry;
+	        carry = newCarry >>> (26 - r);
+	      }
+
+	      if (carry) {
+	        this.words[i] = carry;
+	        this.length++;
+	      }
+	    }
+
+	    if (s !== 0) {
+	      for (i = this.length - 1; i >= 0; i--) {
+	        this.words[i + s] = this.words[i];
+	      }
+
+	      for (i = 0; i < s; i++) {
+	        this.words[i] = 0;
+	      }
+
+	      this.length += s;
+	    }
+
+	    return this.strip();
+	  };
+
+	  BN.prototype.ishln = function ishln (bits) {
+	    // TODO(indutny): implement me
+	    assert(this.negative === 0);
+	    return this.iushln(bits);
+	  };
+
+	  // Shift-right in-place
+	  // NOTE: `hint` is a lowest bit before trailing zeroes
+	  // NOTE: if `extended` is present - it will be filled with destroyed bits
+	  BN.prototype.iushrn = function iushrn (bits, hint, extended) {
+	    assert(typeof bits === 'number' && bits >= 0);
+	    var h;
+	    if (hint) {
+	      h = (hint - (hint % 26)) / 26;
+	    } else {
+	      h = 0;
+	    }
+
+	    var r = bits % 26;
+	    var s = Math.min((bits - r) / 26, this.length);
+	    var mask = 0x3ffffff ^ ((0x3ffffff >>> r) << r);
+	    var maskedWords = extended;
+
+	    h -= s;
+	    h = Math.max(0, h);
+
+	    // Extended mode, copy masked part
+	    if (maskedWords) {
+	      for (var i = 0; i < s; i++) {
+	        maskedWords.words[i] = this.words[i];
+	      }
+	      maskedWords.length = s;
+	    }
+
+	    if (s === 0) {
+	      // No-op, we should not move anything at all
+	    } else if (this.length > s) {
+	      this.length -= s;
+	      for (i = 0; i < this.length; i++) {
+	        this.words[i] = this.words[i + s];
+	      }
+	    } else {
+	      this.words[0] = 0;
+	      this.length = 1;
+	    }
+
+	    var carry = 0;
+	    for (i = this.length - 1; i >= 0 && (carry !== 0 || i >= h); i--) {
+	      var word = this.words[i] | 0;
+	      this.words[i] = (carry << (26 - r)) | (word >>> r);
+	      carry = word & mask;
+	    }
+
+	    // Push carried bits as a mask
+	    if (maskedWords && carry !== 0) {
+	      maskedWords.words[maskedWords.length++] = carry;
+	    }
+
+	    if (this.length === 0) {
+	      this.words[0] = 0;
+	      this.length = 1;
+	    }
+
+	    return this.strip();
+	  };
+
+	  BN.prototype.ishrn = function ishrn (bits, hint, extended) {
+	    // TODO(indutny): implement me
+	    assert(this.negative === 0);
+	    return this.iushrn(bits, hint, extended);
+	  };
+
+	  // Shift-left
+	  BN.prototype.shln = function shln (bits) {
+	    return this.clone().ishln(bits);
+	  };
+
+	  BN.prototype.ushln = function ushln (bits) {
+	    return this.clone().iushln(bits);
+	  };
+
+	  // Shift-right
+	  BN.prototype.shrn = function shrn (bits) {
+	    return this.clone().ishrn(bits);
+	  };
+
+	  BN.prototype.ushrn = function ushrn (bits) {
+	    return this.clone().iushrn(bits);
+	  };
+
+	  // Test if n bit is set
+	  BN.prototype.testn = function testn (bit) {
+	    assert(typeof bit === 'number' && bit >= 0);
+	    var r = bit % 26;
+	    var s = (bit - r) / 26;
+	    var q = 1 << r;
+
+	    // Fast case: bit is much higher than all existing words
+	    if (this.length <= s) return false;
+
+	    // Check bit and return
+	    var w = this.words[s];
+
+	    return !!(w & q);
+	  };
+
+	  // Return only lowers bits of number (in-place)
+	  BN.prototype.imaskn = function imaskn (bits) {
+	    assert(typeof bits === 'number' && bits >= 0);
+	    var r = bits % 26;
+	    var s = (bits - r) / 26;
+
+	    assert(this.negative === 0, 'imaskn works only with positive numbers');
+
+	    if (this.length <= s) {
+	      return this;
+	    }
+
+	    if (r !== 0) {
+	      s++;
+	    }
+	    this.length = Math.min(s, this.length);
+
+	    if (r !== 0) {
+	      var mask = 0x3ffffff ^ ((0x3ffffff >>> r) << r);
+	      this.words[this.length - 1] &= mask;
+	    }
+
+	    return this.strip();
+	  };
+
+	  // Return only lowers bits of number
+	  BN.prototype.maskn = function maskn (bits) {
+	    return this.clone().imaskn(bits);
+	  };
+
+	  // Add plain number `num` to `this`
+	  BN.prototype.iaddn = function iaddn (num) {
+	    assert(typeof num === 'number');
+	    assert(num < 0x4000000);
+	    if (num < 0) return this.isubn(-num);
+
+	    // Possible sign change
+	    if (this.negative !== 0) {
+	      if (this.length === 1 && (this.words[0] | 0) < num) {
+	        this.words[0] = num - (this.words[0] | 0);
+	        this.negative = 0;
+	        return this;
+	      }
+
+	      this.negative = 0;
+	      this.isubn(num);
+	      this.negative = 1;
+	      return this;
+	    }
+
+	    // Add without checks
+	    return this._iaddn(num);
+	  };
+
+	  BN.prototype._iaddn = function _iaddn (num) {
+	    this.words[0] += num;
+
+	    // Carry
+	    for (var i = 0; i < this.length && this.words[i] >= 0x4000000; i++) {
+	      this.words[i] -= 0x4000000;
+	      if (i === this.length - 1) {
+	        this.words[i + 1] = 1;
+	      } else {
+	        this.words[i + 1]++;
+	      }
+	    }
+	    this.length = Math.max(this.length, i + 1);
+
+	    return this;
+	  };
+
+	  // Subtract plain number `num` from `this`
+	  BN.prototype.isubn = function isubn (num) {
+	    assert(typeof num === 'number');
+	    assert(num < 0x4000000);
+	    if (num < 0) return this.iaddn(-num);
+
+	    if (this.negative !== 0) {
+	      this.negative = 0;
+	      this.iaddn(num);
+	      this.negative = 1;
+	      return this;
+	    }
+
+	    this.words[0] -= num;
+
+	    if (this.length === 1 && this.words[0] < 0) {
+	      this.words[0] = -this.words[0];
+	      this.negative = 1;
+	    } else {
+	      // Carry
+	      for (var i = 0; i < this.length && this.words[i] < 0; i++) {
+	        this.words[i] += 0x4000000;
+	        this.words[i + 1] -= 1;
+	      }
+	    }
+
+	    return this.strip();
+	  };
+
+	  BN.prototype.addn = function addn (num) {
+	    return this.clone().iaddn(num);
+	  };
+
+	  BN.prototype.subn = function subn (num) {
+	    return this.clone().isubn(num);
+	  };
+
+	  BN.prototype.iabs = function iabs () {
+	    this.negative = 0;
+
+	    return this;
+	  };
+
+	  BN.prototype.abs = function abs () {
+	    return this.clone().iabs();
+	  };
+
+	  BN.prototype._ishlnsubmul = function _ishlnsubmul (num, mul, shift) {
+	    var len = num.length + shift;
+	    var i;
+
+	    this._expand(len);
+
+	    var w;
+	    var carry = 0;
+	    for (i = 0; i < num.length; i++) {
+	      w = (this.words[i + shift] | 0) + carry;
+	      var right = (num.words[i] | 0) * mul;
+	      w -= right & 0x3ffffff;
+	      carry = (w >> 26) - ((right / 0x4000000) | 0);
+	      this.words[i + shift] = w & 0x3ffffff;
+	    }
+	    for (; i < this.length - shift; i++) {
+	      w = (this.words[i + shift] | 0) + carry;
+	      carry = w >> 26;
+	      this.words[i + shift] = w & 0x3ffffff;
+	    }
+
+	    if (carry === 0) return this.strip();
+
+	    // Subtraction overflow
+	    assert(carry === -1);
+	    carry = 0;
+	    for (i = 0; i < this.length; i++) {
+	      w = -(this.words[i] | 0) + carry;
+	      carry = w >> 26;
+	      this.words[i] = w & 0x3ffffff;
+	    }
+	    this.negative = 1;
+
+	    return this.strip();
+	  };
+
+	  BN.prototype._wordDiv = function _wordDiv (num, mode) {
+	    var shift = this.length - num.length;
+
+	    var a = this.clone();
+	    var b = num;
+
+	    // Normalize
+	    var bhi = b.words[b.length - 1] | 0;
+	    var bhiBits = this._countBits(bhi);
+	    shift = 26 - bhiBits;
+	    if (shift !== 0) {
+	      b = b.ushln(shift);
+	      a.iushln(shift);
+	      bhi = b.words[b.length - 1] | 0;
+	    }
+
+	    // Initialize quotient
+	    var m = a.length - b.length;
+	    var q;
+
+	    if (mode !== 'mod') {
+	      q = new BN(null);
+	      q.length = m + 1;
+	      q.words = new Array(q.length);
+	      for (var i = 0; i < q.length; i++) {
+	        q.words[i] = 0;
+	      }
+	    }
+
+	    var diff = a.clone()._ishlnsubmul(b, 1, m);
+	    if (diff.negative === 0) {
+	      a = diff;
+	      if (q) {
+	        q.words[m] = 1;
+	      }
+	    }
+
+	    for (var j = m - 1; j >= 0; j--) {
+	      var qj = (a.words[b.length + j] | 0) * 0x4000000 +
+	        (a.words[b.length + j - 1] | 0);
+
+	      // NOTE: (qj / bhi) is (0x3ffffff * 0x4000000 + 0x3ffffff) / 0x2000000 max
+	      // (0x7ffffff)
+	      qj = Math.min((qj / bhi) | 0, 0x3ffffff);
+
+	      a._ishlnsubmul(b, qj, j);
+	      while (a.negative !== 0) {
+	        qj--;
+	        a.negative = 0;
+	        a._ishlnsubmul(b, 1, j);
+	        if (!a.isZero()) {
+	          a.negative ^= 1;
+	        }
+	      }
+	      if (q) {
+	        q.words[j] = qj;
+	      }
+	    }
+	    if (q) {
+	      q.strip();
+	    }
+	    a.strip();
+
+	    // Denormalize
+	    if (mode !== 'div' && shift !== 0) {
+	      a.iushrn(shift);
+	    }
+
+	    return {
+	      div: q || null,
+	      mod: a
+	    };
+	  };
+
+	  // NOTE: 1) `mode` can be set to `mod` to request mod only,
+	  //       to `div` to request div only, or be absent to
+	  //       request both div & mod
+	  //       2) `positive` is true if unsigned mod is requested
+	  BN.prototype.divmod = function divmod (num, mode, positive) {
+	    assert(!num.isZero());
+
+	    if (this.isZero()) {
+	      return {
+	        div: new BN(0),
+	        mod: new BN(0)
+	      };
+	    }
+
+	    var div, mod, res;
+	    if (this.negative !== 0 && num.negative === 0) {
+	      res = this.neg().divmod(num, mode);
+
+	      if (mode !== 'mod') {
+	        div = res.div.neg();
+	      }
+
+	      if (mode !== 'div') {
+	        mod = res.mod.neg();
+	        if (positive && mod.negative !== 0) {
+	          mod.iadd(num);
+	        }
+	      }
+
+	      return {
+	        div: div,
+	        mod: mod
+	      };
+	    }
+
+	    if (this.negative === 0 && num.negative !== 0) {
+	      res = this.divmod(num.neg(), mode);
+
+	      if (mode !== 'mod') {
+	        div = res.div.neg();
+	      }
+
+	      return {
+	        div: div,
+	        mod: res.mod
+	      };
+	    }
+
+	    if ((this.negative & num.negative) !== 0) {
+	      res = this.neg().divmod(num.neg(), mode);
+
+	      if (mode !== 'div') {
+	        mod = res.mod.neg();
+	        if (positive && mod.negative !== 0) {
+	          mod.isub(num);
+	        }
+	      }
+
+	      return {
+	        div: res.div,
+	        mod: mod
+	      };
+	    }
+
+	    // Both numbers are positive at this point
+
+	    // Strip both numbers to approximate shift value
+	    if (num.length > this.length || this.cmp(num) < 0) {
+	      return {
+	        div: new BN(0),
+	        mod: this
+	      };
+	    }
+
+	    // Very short reduction
+	    if (num.length === 1) {
+	      if (mode === 'div') {
+	        return {
+	          div: this.divn(num.words[0]),
+	          mod: null
+	        };
+	      }
+
+	      if (mode === 'mod') {
+	        return {
+	          div: null,
+	          mod: new BN(this.modn(num.words[0]))
+	        };
+	      }
+
+	      return {
+	        div: this.divn(num.words[0]),
+	        mod: new BN(this.modn(num.words[0]))
+	      };
+	    }
+
+	    return this._wordDiv(num, mode);
+	  };
+
+	  // Find `this` / `num`
+	  BN.prototype.div = function div (num) {
+	    return this.divmod(num, 'div', false).div;
+	  };
+
+	  // Find `this` % `num`
+	  BN.prototype.mod = function mod (num) {
+	    return this.divmod(num, 'mod', false).mod;
+	  };
+
+	  BN.prototype.umod = function umod (num) {
+	    return this.divmod(num, 'mod', true).mod;
+	  };
+
+	  // Find Round(`this` / `num`)
+	  BN.prototype.divRound = function divRound (num) {
+	    var dm = this.divmod(num);
+
+	    // Fast case - exact division
+	    if (dm.mod.isZero()) return dm.div;
+
+	    var mod = dm.div.negative !== 0 ? dm.mod.isub(num) : dm.mod;
+
+	    var half = num.ushrn(1);
+	    var r2 = num.andln(1);
+	    var cmp = mod.cmp(half);
+
+	    // Round down
+	    if (cmp < 0 || r2 === 1 && cmp === 0) return dm.div;
+
+	    // Round up
+	    return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
+	  };
+
+	  BN.prototype.modn = function modn (num) {
+	    assert(num <= 0x3ffffff);
+	    var p = (1 << 26) % num;
+
+	    var acc = 0;
+	    for (var i = this.length - 1; i >= 0; i--) {
+	      acc = (p * acc + (this.words[i] | 0)) % num;
+	    }
+
+	    return acc;
+	  };
+
+	  // In-place division by number
+	  BN.prototype.idivn = function idivn (num) {
+	    assert(num <= 0x3ffffff);
+
+	    var carry = 0;
+	    for (var i = this.length - 1; i >= 0; i--) {
+	      var w = (this.words[i] | 0) + carry * 0x4000000;
+	      this.words[i] = (w / num) | 0;
+	      carry = w % num;
+	    }
+
+	    return this.strip();
+	  };
+
+	  BN.prototype.divn = function divn (num) {
+	    return this.clone().idivn(num);
+	  };
+
+	  BN.prototype.egcd = function egcd (p) {
+	    assert(p.negative === 0);
+	    assert(!p.isZero());
+
+	    var x = this;
+	    var y = p.clone();
+
+	    if (x.negative !== 0) {
+	      x = x.umod(p);
+	    } else {
+	      x = x.clone();
+	    }
+
+	    // A * x + B * y = x
+	    var A = new BN(1);
+	    var B = new BN(0);
+
+	    // C * x + D * y = y
+	    var C = new BN(0);
+	    var D = new BN(1);
+
+	    var g = 0;
+
+	    while (x.isEven() && y.isEven()) {
+	      x.iushrn(1);
+	      y.iushrn(1);
+	      ++g;
+	    }
+
+	    var yp = y.clone();
+	    var xp = x.clone();
+
+	    while (!x.isZero()) {
+	      for (var i = 0, im = 1; (x.words[0] & im) === 0 && i < 26; ++i, im <<= 1);
+	      if (i > 0) {
+	        x.iushrn(i);
+	        while (i-- > 0) {
+	          if (A.isOdd() || B.isOdd()) {
+	            A.iadd(yp);
+	            B.isub(xp);
+	          }
+
+	          A.iushrn(1);
+	          B.iushrn(1);
+	        }
+	      }
+
+	      for (var j = 0, jm = 1; (y.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1);
+	      if (j > 0) {
+	        y.iushrn(j);
+	        while (j-- > 0) {
+	          if (C.isOdd() || D.isOdd()) {
+	            C.iadd(yp);
+	            D.isub(xp);
+	          }
+
+	          C.iushrn(1);
+	          D.iushrn(1);
+	        }
+	      }
+
+	      if (x.cmp(y) >= 0) {
+	        x.isub(y);
+	        A.isub(C);
+	        B.isub(D);
+	      } else {
+	        y.isub(x);
+	        C.isub(A);
+	        D.isub(B);
+	      }
+	    }
+
+	    return {
+	      a: C,
+	      b: D,
+	      gcd: y.iushln(g)
+	    };
+	  };
+
+	  // This is reduced incarnation of the binary EEA
+	  // above, designated to invert members of the
+	  // _prime_ fields F(p) at a maximal speed
+	  BN.prototype._invmp = function _invmp (p) {
+	    assert(p.negative === 0);
+	    assert(!p.isZero());
+
+	    var a = this;
+	    var b = p.clone();
+
+	    if (a.negative !== 0) {
+	      a = a.umod(p);
+	    } else {
+	      a = a.clone();
+	    }
+
+	    var x1 = new BN(1);
+	    var x2 = new BN(0);
+
+	    var delta = b.clone();
+
+	    while (a.cmpn(1) > 0 && b.cmpn(1) > 0) {
+	      for (var i = 0, im = 1; (a.words[0] & im) === 0 && i < 26; ++i, im <<= 1);
+	      if (i > 0) {
+	        a.iushrn(i);
+	        while (i-- > 0) {
+	          if (x1.isOdd()) {
+	            x1.iadd(delta);
+	          }
+
+	          x1.iushrn(1);
+	        }
+	      }
+
+	      for (var j = 0, jm = 1; (b.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1);
+	      if (j > 0) {
+	        b.iushrn(j);
+	        while (j-- > 0) {
+	          if (x2.isOdd()) {
+	            x2.iadd(delta);
+	          }
+
+	          x2.iushrn(1);
+	        }
+	      }
+
+	      if (a.cmp(b) >= 0) {
+	        a.isub(b);
+	        x1.isub(x2);
+	      } else {
+	        b.isub(a);
+	        x2.isub(x1);
+	      }
+	    }
+
+	    var res;
+	    if (a.cmpn(1) === 0) {
+	      res = x1;
+	    } else {
+	      res = x2;
+	    }
+
+	    if (res.cmpn(0) < 0) {
+	      res.iadd(p);
+	    }
+
+	    return res;
+	  };
+
+	  BN.prototype.gcd = function gcd (num) {
+	    if (this.isZero()) return num.abs();
+	    if (num.isZero()) return this.abs();
+
+	    var a = this.clone();
+	    var b = num.clone();
+	    a.negative = 0;
+	    b.negative = 0;
+
+	    // Remove common factor of two
+	    for (var shift = 0; a.isEven() && b.isEven(); shift++) {
+	      a.iushrn(1);
+	      b.iushrn(1);
+	    }
+
+	    do {
+	      while (a.isEven()) {
+	        a.iushrn(1);
+	      }
+	      while (b.isEven()) {
+	        b.iushrn(1);
+	      }
+
+	      var r = a.cmp(b);
+	      if (r < 0) {
+	        // Swap `a` and `b` to make `a` always bigger than `b`
+	        var t = a;
+	        a = b;
+	        b = t;
+	      } else if (r === 0 || b.cmpn(1) === 0) {
+	        break;
+	      }
+
+	      a.isub(b);
+	    } while (true);
+
+	    return b.iushln(shift);
+	  };
+
+	  // Invert number in the field F(num)
+	  BN.prototype.invm = function invm (num) {
+	    return this.egcd(num).a.umod(num);
+	  };
+
+	  BN.prototype.isEven = function isEven () {
+	    return (this.words[0] & 1) === 0;
+	  };
+
+	  BN.prototype.isOdd = function isOdd () {
+	    return (this.words[0] & 1) === 1;
+	  };
+
+	  // And first word and num
+	  BN.prototype.andln = function andln (num) {
+	    return this.words[0] & num;
+	  };
+
+	  // Increment at the bit position in-line
+	  BN.prototype.bincn = function bincn (bit) {
+	    assert(typeof bit === 'number');
+	    var r = bit % 26;
+	    var s = (bit - r) / 26;
+	    var q = 1 << r;
+
+	    // Fast case: bit is much higher than all existing words
+	    if (this.length <= s) {
+	      this._expand(s + 1);
+	      this.words[s] |= q;
+	      return this;
+	    }
+
+	    // Add bit and propagate, if needed
+	    var carry = q;
+	    for (var i = s; carry !== 0 && i < this.length; i++) {
+	      var w = this.words[i] | 0;
+	      w += carry;
+	      carry = w >>> 26;
+	      w &= 0x3ffffff;
+	      this.words[i] = w;
+	    }
+	    if (carry !== 0) {
+	      this.words[i] = carry;
+	      this.length++;
+	    }
+	    return this;
+	  };
+
+	  BN.prototype.isZero = function isZero () {
+	    return this.length === 1 && this.words[0] === 0;
+	  };
+
+	  BN.prototype.cmpn = function cmpn (num) {
+	    var negative = num < 0;
+
+	    if (this.negative !== 0 && !negative) return -1;
+	    if (this.negative === 0 && negative) return 1;
+
+	    this.strip();
+
+	    var res;
+	    if (this.length > 1) {
+	      res = 1;
+	    } else {
+	      if (negative) {
+	        num = -num;
+	      }
+
+	      assert(num <= 0x3ffffff, 'Number is too big');
+
+	      var w = this.words[0] | 0;
+	      res = w === num ? 0 : w < num ? -1 : 1;
+	    }
+	    if (this.negative !== 0) return -res | 0;
+	    return res;
+	  };
+
+	  // Compare two numbers and return:
+	  // 1 - if `this` > `num`
+	  // 0 - if `this` == `num`
+	  // -1 - if `this` < `num`
+	  BN.prototype.cmp = function cmp (num) {
+	    if (this.negative !== 0 && num.negative === 0) return -1;
+	    if (this.negative === 0 && num.negative !== 0) return 1;
+
+	    var res = this.ucmp(num);
+	    if (this.negative !== 0) return -res | 0;
+	    return res;
+	  };
+
+	  // Unsigned comparison
+	  BN.prototype.ucmp = function ucmp (num) {
+	    // At this point both numbers have the same sign
+	    if (this.length > num.length) return 1;
+	    if (this.length < num.length) return -1;
+
+	    var res = 0;
+	    for (var i = this.length - 1; i >= 0; i--) {
+	      var a = this.words[i] | 0;
+	      var b = num.words[i] | 0;
+
+	      if (a === b) continue;
+	      if (a < b) {
+	        res = -1;
+	      } else if (a > b) {
+	        res = 1;
+	      }
+	      break;
+	    }
+	    return res;
+	  };
+
+	  BN.prototype.gtn = function gtn (num) {
+	    return this.cmpn(num) === 1;
+	  };
+
+	  BN.prototype.gt = function gt (num) {
+	    return this.cmp(num) === 1;
+	  };
+
+	  BN.prototype.gten = function gten (num) {
+	    return this.cmpn(num) >= 0;
+	  };
+
+	  BN.prototype.gte = function gte (num) {
+	    return this.cmp(num) >= 0;
+	  };
+
+	  BN.prototype.ltn = function ltn (num) {
+	    return this.cmpn(num) === -1;
+	  };
+
+	  BN.prototype.lt = function lt (num) {
+	    return this.cmp(num) === -1;
+	  };
+
+	  BN.prototype.lten = function lten (num) {
+	    return this.cmpn(num) <= 0;
+	  };
+
+	  BN.prototype.lte = function lte (num) {
+	    return this.cmp(num) <= 0;
+	  };
+
+	  BN.prototype.eqn = function eqn (num) {
+	    return this.cmpn(num) === 0;
+	  };
+
+	  BN.prototype.eq = function eq (num) {
+	    return this.cmp(num) === 0;
+	  };
+
+	  //
+	  // A reduce context, could be using montgomery or something better, depending
+	  // on the `m` itself.
+	  //
+	  BN.red = function red (num) {
+	    return new Red(num);
+	  };
+
+	  BN.prototype.toRed = function toRed (ctx) {
+	    assert(!this.red, 'Already a number in reduction context');
+	    assert(this.negative === 0, 'red works only with positives');
+	    return ctx.convertTo(this)._forceRed(ctx);
+	  };
+
+	  BN.prototype.fromRed = function fromRed () {
+	    assert(this.red, 'fromRed works only with numbers in reduction context');
+	    return this.red.convertFrom(this);
+	  };
+
+	  BN.prototype._forceRed = function _forceRed (ctx) {
+	    this.red = ctx;
+	    return this;
+	  };
+
+	  BN.prototype.forceRed = function forceRed (ctx) {
+	    assert(!this.red, 'Already a number in reduction context');
+	    return this._forceRed(ctx);
+	  };
+
+	  BN.prototype.redAdd = function redAdd (num) {
+	    assert(this.red, 'redAdd works only with red numbers');
+	    return this.red.add(this, num);
+	  };
+
+	  BN.prototype.redIAdd = function redIAdd (num) {
+	    assert(this.red, 'redIAdd works only with red numbers');
+	    return this.red.iadd(this, num);
+	  };
+
+	  BN.prototype.redSub = function redSub (num) {
+	    assert(this.red, 'redSub works only with red numbers');
+	    return this.red.sub(this, num);
+	  };
+
+	  BN.prototype.redISub = function redISub (num) {
+	    assert(this.red, 'redISub works only with red numbers');
+	    return this.red.isub(this, num);
+	  };
+
+	  BN.prototype.redShl = function redShl (num) {
+	    assert(this.red, 'redShl works only with red numbers');
+	    return this.red.shl(this, num);
+	  };
+
+	  BN.prototype.redMul = function redMul (num) {
+	    assert(this.red, 'redMul works only with red numbers');
+	    this.red._verify2(this, num);
+	    return this.red.mul(this, num);
+	  };
+
+	  BN.prototype.redIMul = function redIMul (num) {
+	    assert(this.red, 'redMul works only with red numbers');
+	    this.red._verify2(this, num);
+	    return this.red.imul(this, num);
+	  };
+
+	  BN.prototype.redSqr = function redSqr () {
+	    assert(this.red, 'redSqr works only with red numbers');
+	    this.red._verify1(this);
+	    return this.red.sqr(this);
+	  };
+
+	  BN.prototype.redISqr = function redISqr () {
+	    assert(this.red, 'redISqr works only with red numbers');
+	    this.red._verify1(this);
+	    return this.red.isqr(this);
+	  };
+
+	  // Square root over p
+	  BN.prototype.redSqrt = function redSqrt () {
+	    assert(this.red, 'redSqrt works only with red numbers');
+	    this.red._verify1(this);
+	    return this.red.sqrt(this);
+	  };
+
+	  BN.prototype.redInvm = function redInvm () {
+	    assert(this.red, 'redInvm works only with red numbers');
+	    this.red._verify1(this);
+	    return this.red.invm(this);
+	  };
+
+	  // Return negative clone of `this` % `red modulo`
+	  BN.prototype.redNeg = function redNeg () {
+	    assert(this.red, 'redNeg works only with red numbers');
+	    this.red._verify1(this);
+	    return this.red.neg(this);
+	  };
+
+	  BN.prototype.redPow = function redPow (num) {
+	    assert(this.red && !num.red, 'redPow(normalNum)');
+	    this.red._verify1(this);
+	    return this.red.pow(this, num);
+	  };
+
+	  // Prime numbers with efficient reduction
+	  var primes = {
+	    k256: null,
+	    p224: null,
+	    p192: null,
+	    p25519: null
+	  };
+
+	  // Pseudo-Mersenne prime
+	  function MPrime (name, p) {
+	    // P = 2 ^ N - K
+	    this.name = name;
+	    this.p = new BN(p, 16);
+	    this.n = this.p.bitLength();
+	    this.k = new BN(1).iushln(this.n).isub(this.p);
+
+	    this.tmp = this._tmp();
+	  }
+
+	  MPrime.prototype._tmp = function _tmp () {
+	    var tmp = new BN(null);
+	    tmp.words = new Array(Math.ceil(this.n / 13));
+	    return tmp;
+	  };
+
+	  MPrime.prototype.ireduce = function ireduce (num) {
+	    // Assumes that `num` is less than `P^2`
+	    // num = HI * (2 ^ N - K) + HI * K + LO = HI * K + LO (mod P)
+	    var r = num;
+	    var rlen;
+
+	    do {
+	      this.split(r, this.tmp);
+	      r = this.imulK(r);
+	      r = r.iadd(this.tmp);
+	      rlen = r.bitLength();
+	    } while (rlen > this.n);
+
+	    var cmp = rlen < this.n ? -1 : r.ucmp(this.p);
+	    if (cmp === 0) {
+	      r.words[0] = 0;
+	      r.length = 1;
+	    } else if (cmp > 0) {
+	      r.isub(this.p);
+	    } else {
+	      r.strip();
+	    }
+
+	    return r;
+	  };
+
+	  MPrime.prototype.split = function split (input, out) {
+	    input.iushrn(this.n, 0, out);
+	  };
+
+	  MPrime.prototype.imulK = function imulK (num) {
+	    return num.imul(this.k);
+	  };
+
+	  function K256 () {
+	    MPrime.call(
+	      this,
+	      'k256',
+	      'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f');
+	  }
+	  inherits(K256, MPrime);
+
+	  K256.prototype.split = function split (input, output) {
+	    // 256 = 9 * 26 + 22
+	    var mask = 0x3fffff;
+
+	    var outLen = Math.min(input.length, 9);
+	    for (var i = 0; i < outLen; i++) {
+	      output.words[i] = input.words[i];
+	    }
+	    output.length = outLen;
+
+	    if (input.length <= 9) {
+	      input.words[0] = 0;
+	      input.length = 1;
+	      return;
+	    }
+
+	    // Shift by 9 limbs
+	    var prev = input.words[9];
+	    output.words[output.length++] = prev & mask;
+
+	    for (i = 10; i < input.length; i++) {
+	      var next = input.words[i] | 0;
+	      input.words[i - 10] = ((next & mask) << 4) | (prev >>> 22);
+	      prev = next;
+	    }
+	    prev >>>= 22;
+	    input.words[i - 10] = prev;
+	    if (prev === 0 && input.length > 10) {
+	      input.length -= 10;
+	    } else {
+	      input.length -= 9;
+	    }
+	  };
+
+	  K256.prototype.imulK = function imulK (num) {
+	    // K = 0x1000003d1 = [ 0x40, 0x3d1 ]
+	    num.words[num.length] = 0;
+	    num.words[num.length + 1] = 0;
+	    num.length += 2;
+
+	    // bounded at: 0x40 * 0x3ffffff + 0x3d0 = 0x100000390
+	    var lo = 0;
+	    for (var i = 0; i < num.length; i++) {
+	      var w = num.words[i] | 0;
+	      lo += w * 0x3d1;
+	      num.words[i] = lo & 0x3ffffff;
+	      lo = w * 0x40 + ((lo / 0x4000000) | 0);
+	    }
+
+	    // Fast length reduction
+	    if (num.words[num.length - 1] === 0) {
+	      num.length--;
+	      if (num.words[num.length - 1] === 0) {
+	        num.length--;
+	      }
+	    }
+	    return num;
+	  };
+
+	  function P224 () {
+	    MPrime.call(
+	      this,
+	      'p224',
+	      'ffffffff ffffffff ffffffff ffffffff 00000000 00000000 00000001');
+	  }
+	  inherits(P224, MPrime);
+
+	  function P192 () {
+	    MPrime.call(
+	      this,
+	      'p192',
+	      'ffffffff ffffffff ffffffff fffffffe ffffffff ffffffff');
+	  }
+	  inherits(P192, MPrime);
+
+	  function P25519 () {
+	    // 2 ^ 255 - 19
+	    MPrime.call(
+	      this,
+	      '25519',
+	      '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed');
+	  }
+	  inherits(P25519, MPrime);
+
+	  P25519.prototype.imulK = function imulK (num) {
+	    // K = 0x13
+	    var carry = 0;
+	    for (var i = 0; i < num.length; i++) {
+	      var hi = (num.words[i] | 0) * 0x13 + carry;
+	      var lo = hi & 0x3ffffff;
+	      hi >>>= 26;
+
+	      num.words[i] = lo;
+	      carry = hi;
+	    }
+	    if (carry !== 0) {
+	      num.words[num.length++] = carry;
+	    }
+	    return num;
+	  };
+
+	  // Exported mostly for testing purposes, use plain name instead
+	  BN._prime = function prime (name) {
+	    // Cached version of prime
+	    if (primes[name]) return primes[name];
+
+	    var prime;
+	    if (name === 'k256') {
+	      prime = new K256();
+	    } else if (name === 'p224') {
+	      prime = new P224();
+	    } else if (name === 'p192') {
+	      prime = new P192();
+	    } else if (name === 'p25519') {
+	      prime = new P25519();
+	    } else {
+	      throw new Error('Unknown prime ' + name);
+	    }
+	    primes[name] = prime;
+
+	    return prime;
+	  };
+
+	  //
+	  // Base reduction engine
+	  //
+	  function Red (m) {
+	    if (typeof m === 'string') {
+	      var prime = BN._prime(m);
+	      this.m = prime.p;
+	      this.prime = prime;
+	    } else {
+	      assert(m.gtn(1), 'modulus must be greater than 1');
+	      this.m = m;
+	      this.prime = null;
+	    }
+	  }
+
+	  Red.prototype._verify1 = function _verify1 (a) {
+	    assert(a.negative === 0, 'red works only with positives');
+	    assert(a.red, 'red works only with red numbers');
+	  };
+
+	  Red.prototype._verify2 = function _verify2 (a, b) {
+	    assert((a.negative | b.negative) === 0, 'red works only with positives');
+	    assert(a.red && a.red === b.red,
+	      'red works only with red numbers');
+	  };
+
+	  Red.prototype.imod = function imod (a) {
+	    if (this.prime) return this.prime.ireduce(a)._forceRed(this);
+	    return a.umod(this.m)._forceRed(this);
+	  };
+
+	  Red.prototype.neg = function neg (a) {
+	    if (a.isZero()) {
+	      return a.clone();
+	    }
+
+	    return this.m.sub(a)._forceRed(this);
+	  };
+
+	  Red.prototype.add = function add (a, b) {
+	    this._verify2(a, b);
+
+	    var res = a.add(b);
+	    if (res.cmp(this.m) >= 0) {
+	      res.isub(this.m);
+	    }
+	    return res._forceRed(this);
+	  };
+
+	  Red.prototype.iadd = function iadd (a, b) {
+	    this._verify2(a, b);
+
+	    var res = a.iadd(b);
+	    if (res.cmp(this.m) >= 0) {
+	      res.isub(this.m);
+	    }
+	    return res;
+	  };
+
+	  Red.prototype.sub = function sub (a, b) {
+	    this._verify2(a, b);
+
+	    var res = a.sub(b);
+	    if (res.cmpn(0) < 0) {
+	      res.iadd(this.m);
+	    }
+	    return res._forceRed(this);
+	  };
+
+	  Red.prototype.isub = function isub (a, b) {
+	    this._verify2(a, b);
+
+	    var res = a.isub(b);
+	    if (res.cmpn(0) < 0) {
+	      res.iadd(this.m);
+	    }
+	    return res;
+	  };
+
+	  Red.prototype.shl = function shl (a, num) {
+	    this._verify1(a);
+	    return this.imod(a.ushln(num));
+	  };
+
+	  Red.prototype.imul = function imul (a, b) {
+	    this._verify2(a, b);
+	    return this.imod(a.imul(b));
+	  };
+
+	  Red.prototype.mul = function mul (a, b) {
+	    this._verify2(a, b);
+	    return this.imod(a.mul(b));
+	  };
+
+	  Red.prototype.isqr = function isqr (a) {
+	    return this.imul(a, a.clone());
+	  };
+
+	  Red.prototype.sqr = function sqr (a) {
+	    return this.mul(a, a);
+	  };
+
+	  Red.prototype.sqrt = function sqrt (a) {
+	    if (a.isZero()) return a.clone();
+
+	    var mod3 = this.m.andln(3);
+	    assert(mod3 % 2 === 1);
+
+	    // Fast case
+	    if (mod3 === 3) {
+	      var pow = this.m.add(new BN(1)).iushrn(2);
+	      return this.pow(a, pow);
+	    }
+
+	    // Tonelli-Shanks algorithm (Totally unoptimized and slow)
+	    //
+	    // Find Q and S, that Q * 2 ^ S = (P - 1)
+	    var q = this.m.subn(1);
+	    var s = 0;
+	    while (!q.isZero() && q.andln(1) === 0) {
+	      s++;
+	      q.iushrn(1);
+	    }
+	    assert(!q.isZero());
+
+	    var one = new BN(1).toRed(this);
+	    var nOne = one.redNeg();
+
+	    // Find quadratic non-residue
+	    // NOTE: Max is such because of generalized Riemann hypothesis.
+	    var lpow = this.m.subn(1).iushrn(1);
+	    var z = this.m.bitLength();
+	    z = new BN(2 * z * z).toRed(this);
+
+	    while (this.pow(z, lpow).cmp(nOne) !== 0) {
+	      z.redIAdd(nOne);
+	    }
+
+	    var c = this.pow(z, q);
+	    var r = this.pow(a, q.addn(1).iushrn(1));
+	    var t = this.pow(a, q);
+	    var m = s;
+	    while (t.cmp(one) !== 0) {
+	      var tmp = t;
+	      for (var i = 0; tmp.cmp(one) !== 0; i++) {
+	        tmp = tmp.redSqr();
+	      }
+	      assert(i < m);
+	      var b = this.pow(c, new BN(1).iushln(m - i - 1));
+
+	      r = r.redMul(b);
+	      c = b.redSqr();
+	      t = t.redMul(c);
+	      m = i;
+	    }
+
+	    return r;
+	  };
+
+	  Red.prototype.invm = function invm (a) {
+	    var inv = a._invmp(this.m);
+	    if (inv.negative !== 0) {
+	      inv.negative = 0;
+	      return this.imod(inv).redNeg();
+	    } else {
+	      return this.imod(inv);
+	    }
+	  };
+
+	  Red.prototype.pow = function pow (a, num) {
+	    if (num.isZero()) return new BN(1).toRed(this);
+	    if (num.cmpn(1) === 0) return a.clone();
+
+	    var windowSize = 4;
+	    var wnd = new Array(1 << windowSize);
+	    wnd[0] = new BN(1).toRed(this);
+	    wnd[1] = a;
+	    for (var i = 2; i < wnd.length; i++) {
+	      wnd[i] = this.mul(wnd[i - 1], a);
+	    }
+
+	    var res = wnd[0];
+	    var current = 0;
+	    var currentLen = 0;
+	    var start = num.bitLength() % 26;
+	    if (start === 0) {
+	      start = 26;
+	    }
+
+	    for (i = num.length - 1; i >= 0; i--) {
+	      var word = num.words[i];
+	      for (var j = start - 1; j >= 0; j--) {
+	        var bit = (word >> j) & 1;
+	        if (res !== wnd[0]) {
+	          res = this.sqr(res);
+	        }
+
+	        if (bit === 0 && current === 0) {
+	          currentLen = 0;
+	          continue;
+	        }
+
+	        current <<= 1;
+	        current |= bit;
+	        currentLen++;
+	        if (currentLen !== windowSize && (i !== 0 || j !== 0)) continue;
+
+	        res = this.mul(res, wnd[current]);
+	        currentLen = 0;
+	        current = 0;
+	      }
+	      start = 26;
+	    }
+
+	    return res;
+	  };
+
+	  Red.prototype.convertTo = function convertTo (num) {
+	    var r = num.umod(this.m);
+
+	    return r === num ? r.clone() : r;
+	  };
+
+	  Red.prototype.convertFrom = function convertFrom (num) {
+	    var res = num.clone();
+	    res.red = null;
+	    return res;
+	  };
+
+	  //
+	  // Montgomery method engine
+	  //
+
+	  BN.mont = function mont (num) {
+	    return new Mont(num);
+	  };
+
+	  function Mont (m) {
+	    Red.call(this, m);
+
+	    this.shift = this.m.bitLength();
+	    if (this.shift % 26 !== 0) {
+	      this.shift += 26 - (this.shift % 26);
+	    }
+
+	    this.r = new BN(1).iushln(this.shift);
+	    this.r2 = this.imod(this.r.sqr());
+	    this.rinv = this.r._invmp(this.m);
+
+	    this.minv = this.rinv.mul(this.r).isubn(1).div(this.m);
+	    this.minv = this.minv.umod(this.r);
+	    this.minv = this.r.sub(this.minv);
+	  }
+	  inherits(Mont, Red);
+
+	  Mont.prototype.convertTo = function convertTo (num) {
+	    return this.imod(num.ushln(this.shift));
+	  };
+
+	  Mont.prototype.convertFrom = function convertFrom (num) {
+	    var r = this.imod(num.mul(this.rinv));
+	    r.red = null;
+	    return r;
+	  };
+
+	  Mont.prototype.imul = function imul (a, b) {
+	    if (a.isZero() || b.isZero()) {
+	      a.words[0] = 0;
+	      a.length = 1;
+	      return a;
+	    }
+
+	    var t = a.imul(b);
+	    var c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m);
+	    var u = t.isub(c).iushrn(this.shift);
+	    var res = u;
+
+	    if (u.cmp(this.m) >= 0) {
+	      res = u.isub(this.m);
+	    } else if (u.cmpn(0) < 0) {
+	      res = u.iadd(this.m);
+	    }
+
+	    return res._forceRed(this);
+	  };
+
+	  Mont.prototype.mul = function mul (a, b) {
+	    if (a.isZero() || b.isZero()) return new BN(0)._forceRed(this);
+
+	    var t = a.mul(b);
+	    var c = t.maskn(this.shift).mul(this.minv).imaskn(this.shift).mul(this.m);
+	    var u = t.isub(c).iushrn(this.shift);
+	    var res = u;
+	    if (u.cmp(this.m) >= 0) {
+	      res = u.isub(this.m);
+	    } else if (u.cmpn(0) < 0) {
+	      res = u.iadd(this.m);
+	    }
+
+	    return res._forceRed(this);
+	  };
+
+	  Mont.prototype.invm = function invm (a) {
+	    // (AR)^-1 * R^2 = (A^-1 * R^-1) * R^2 = A^-1 * R
+	    var res = this.imod(a._invmp(this.m).mul(this.r2));
+	    return res._forceRed(this);
+	  };
+	})(typeof module === 'undefined' || module, this);
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(18)(module)))
+
+/***/ }),
+/* 205 */
+/***/ (function(module, exports) {
+
+	/* (ignored) */
+
+/***/ }),
+/* 206 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var asn1 = __webpack_require__(203);
+	var inherits = __webpack_require__(27);
+
+	var api = exports;
+
+	api.define = function define(name, body) {
+	  return new Entity(name, body);
+	};
+
+	function Entity(name, body) {
+	  this.name = name;
+	  this.body = body;
+
+	  this.decoders = {};
+	  this.encoders = {};
+	};
+
+	Entity.prototype._createNamed = function createNamed(base) {
+	  var named;
+	  try {
+	    named = __webpack_require__(105).runInThisContext(
+	      '(function ' + this.name + '(entity) {\n' +
+	      '  this._initNamed(entity);\n' +
+	      '})'
+	    );
+	  } catch (e) {
+	    named = function (entity) {
+	      this._initNamed(entity);
+	    };
+	  }
+	  inherits(named, base);
+	  named.prototype._initNamed = function initnamed(entity) {
+	    base.call(this, entity);
+	  };
+
+	  return new named(this);
+	};
+
+	Entity.prototype._getDecoder = function _getDecoder(enc) {
+	  enc = enc || 'der';
+	  // Lazily create decoder
+	  if (!this.decoders.hasOwnProperty(enc))
+	    this.decoders[enc] = this._createNamed(asn1.decoders[enc]);
+	  return this.decoders[enc];
+	};
+
+	Entity.prototype.decode = function decode(data, enc, options) {
+	  return this._getDecoder(enc).decode(data, options);
+	};
+
+	Entity.prototype._getEncoder = function _getEncoder(enc) {
+	  enc = enc || 'der';
+	  // Lazily create encoder
+	  if (!this.encoders.hasOwnProperty(enc))
+	    this.encoders[enc] = this._createNamed(asn1.encoders[enc]);
+	  return this.encoders[enc];
+	};
+
+	Entity.prototype.encode = function encode(data, enc, /* internal */ reporter) {
+	  return this._getEncoder(enc).encode(data, reporter);
+	};
+
+
+/***/ }),
+/* 207 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var base = exports;
+
+	base.Reporter = __webpack_require__(208).Reporter;
+	base.DecoderBuffer = __webpack_require__(209).DecoderBuffer;
+	base.EncoderBuffer = __webpack_require__(209).EncoderBuffer;
+	base.Node = __webpack_require__(210);
+
+
+/***/ }),
+/* 208 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+
+	function Reporter(options) {
+	  this._reporterState = {
+	    obj: null,
+	    path: [],
+	    options: options || {},
+	    errors: []
+	  };
+	}
+	exports.Reporter = Reporter;
+
+	Reporter.prototype.isError = function isError(obj) {
+	  return obj instanceof ReporterError;
+	};
+
+	Reporter.prototype.save = function save() {
+	  var state = this._reporterState;
+
+	  return { obj: state.obj, pathLen: state.path.length };
+	};
+
+	Reporter.prototype.restore = function restore(data) {
+	  var state = this._reporterState;
+
+	  state.obj = data.obj;
+	  state.path = state.path.slice(0, data.pathLen);
+	};
+
+	Reporter.prototype.enterKey = function enterKey(key) {
+	  return this._reporterState.path.push(key);
+	};
+
+	Reporter.prototype.exitKey = function exitKey(index) {
+	  var state = this._reporterState;
+
+	  state.path = state.path.slice(0, index - 1);
+	};
+
+	Reporter.prototype.leaveKey = function leaveKey(index, key, value) {
+	  var state = this._reporterState;
+
+	  this.exitKey(index);
+	  if (state.obj !== null)
+	    state.obj[key] = value;
+	};
+
+	Reporter.prototype.path = function path() {
+	  return this._reporterState.path.join('/');
+	};
+
+	Reporter.prototype.enterObject = function enterObject() {
+	  var state = this._reporterState;
+
+	  var prev = state.obj;
+	  state.obj = {};
+	  return prev;
+	};
+
+	Reporter.prototype.leaveObject = function leaveObject(prev) {
+	  var state = this._reporterState;
+
+	  var now = state.obj;
+	  state.obj = prev;
+	  return now;
+	};
+
+	Reporter.prototype.error = function error(msg) {
+	  var err;
+	  var state = this._reporterState;
+
+	  var inherited = msg instanceof ReporterError;
+	  if (inherited) {
+	    err = msg;
+	  } else {
+	    err = new ReporterError(state.path.map(function(elem) {
+	      return '[' + JSON.stringify(elem) + ']';
+	    }).join(''), msg.message || msg, msg.stack);
+	  }
+
+	  if (!state.options.partial)
+	    throw err;
+
+	  if (!inherited)
+	    state.errors.push(err);
+
+	  return err;
+	};
+
+	Reporter.prototype.wrapResult = function wrapResult(result) {
+	  var state = this._reporterState;
+	  if (!state.options.partial)
+	    return result;
+
+	  return {
+	    result: this.isError(result) ? null : result,
+	    errors: state.errors
+	  };
+	};
+
+	function ReporterError(path, msg) {
+	  this.path = path;
+	  this.rethrow(msg);
+	};
+	inherits(ReporterError, Error);
+
+	ReporterError.prototype.rethrow = function rethrow(msg) {
+	  this.message = msg + ' at: ' + (this.path || '(shallow)');
+	  if (Error.captureStackTrace)
+	    Error.captureStackTrace(this, ReporterError);
+
+	  if (!this.stack) {
+	    try {
+	      // IE only adds stack when thrown
+	      throw new Error(this.message);
+	    } catch (e) {
+	      this.stack = e.stack;
+	    }
+	  }
+	  return this;
+	};
+
+
+/***/ }),
+/* 209 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+	var Reporter = __webpack_require__(207).Reporter;
+	var Buffer = __webpack_require__(19).Buffer;
+
+	function DecoderBuffer(base, options) {
+	  Reporter.call(this, options);
+	  if (!Buffer.isBuffer(base)) {
+	    this.error('Input not Buffer');
+	    return;
+	  }
+
+	  this.base = base;
+	  this.offset = 0;
+	  this.length = base.length;
+	}
+	inherits(DecoderBuffer, Reporter);
+	exports.DecoderBuffer = DecoderBuffer;
+
+	DecoderBuffer.prototype.save = function save() {
+	  return { offset: this.offset, reporter: Reporter.prototype.save.call(this) };
+	};
+
+	DecoderBuffer.prototype.restore = function restore(save) {
+	  // Return skipped data
+	  var res = new DecoderBuffer(this.base);
+	  res.offset = save.offset;
+	  res.length = this.offset;
+
+	  this.offset = save.offset;
+	  Reporter.prototype.restore.call(this, save.reporter);
+
+	  return res;
+	};
+
+	DecoderBuffer.prototype.isEmpty = function isEmpty() {
+	  return this.offset === this.length;
+	};
+
+	DecoderBuffer.prototype.readUInt8 = function readUInt8(fail) {
+	  if (this.offset + 1 <= this.length)
+	    return this.base.readUInt8(this.offset++, true);
+	  else
+	    return this.error(fail || 'DecoderBuffer overrun');
+	}
+
+	DecoderBuffer.prototype.skip = function skip(bytes, fail) {
+	  if (!(this.offset + bytes <= this.length))
+	    return this.error(fail || 'DecoderBuffer overrun');
+
+	  var res = new DecoderBuffer(this.base);
+
+	  // Share reporter state
+	  res._reporterState = this._reporterState;
+
+	  res.offset = this.offset;
+	  res.length = this.offset + bytes;
+	  this.offset += bytes;
+	  return res;
+	}
+
+	DecoderBuffer.prototype.raw = function raw(save) {
+	  return this.base.slice(save ? save.offset : this.offset, this.length);
+	}
+
+	function EncoderBuffer(value, reporter) {
+	  if (Array.isArray(value)) {
+	    this.length = 0;
+	    this.value = value.map(function(item) {
+	      if (!(item instanceof EncoderBuffer))
+	        item = new EncoderBuffer(item, reporter);
+	      this.length += item.length;
+	      return item;
+	    }, this);
+	  } else if (typeof value === 'number') {
+	    if (!(0 <= value && value <= 0xff))
+	      return reporter.error('non-byte EncoderBuffer value');
+	    this.value = value;
+	    this.length = 1;
+	  } else if (typeof value === 'string') {
+	    this.value = value;
+	    this.length = Buffer.byteLength(value);
+	  } else if (Buffer.isBuffer(value)) {
+	    this.value = value;
+	    this.length = value.length;
+	  } else {
+	    return reporter.error('Unsupported type: ' + typeof value);
+	  }
+	}
+	exports.EncoderBuffer = EncoderBuffer;
+
+	EncoderBuffer.prototype.join = function join(out, offset) {
+	  if (!out)
+	    out = new Buffer(this.length);
+	  if (!offset)
+	    offset = 0;
+
+	  if (this.length === 0)
+	    return out;
+
+	  if (Array.isArray(this.value)) {
+	    this.value.forEach(function(item) {
+	      item.join(out, offset);
+	      offset += item.length;
+	    });
+	  } else {
+	    if (typeof this.value === 'number')
+	      out[offset] = this.value;
+	    else if (typeof this.value === 'string')
+	      out.write(this.value, offset);
+	    else if (Buffer.isBuffer(this.value))
+	      this.value.copy(out, offset);
+	    offset += this.length;
+	  }
+
+	  return out;
+	};
+
+
+/***/ }),
+/* 210 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var Reporter = __webpack_require__(207).Reporter;
+	var EncoderBuffer = __webpack_require__(207).EncoderBuffer;
+	var DecoderBuffer = __webpack_require__(207).DecoderBuffer;
+	var assert = __webpack_require__(20);
+
+	// Supported tags
+	var tags = [
+	  'seq', 'seqof', 'set', 'setof', 'objid', 'bool',
+	  'gentime', 'utctime', 'null_', 'enum', 'int', 'objDesc',
+	  'bitstr', 'bmpstr', 'charstr', 'genstr', 'graphstr', 'ia5str', 'iso646str',
+	  'numstr', 'octstr', 'printstr', 't61str', 'unistr', 'utf8str', 'videostr'
+	];
+
+	// Public methods list
+	var methods = [
+	  'key', 'obj', 'use', 'optional', 'explicit', 'implicit', 'def', 'choice',
+	  'any', 'contains'
+	].concat(tags);
+
+	// Overrided methods list
+	var overrided = [
+	  '_peekTag', '_decodeTag', '_use',
+	  '_decodeStr', '_decodeObjid', '_decodeTime',
+	  '_decodeNull', '_decodeInt', '_decodeBool', '_decodeList',
+
+	  '_encodeComposite', '_encodeStr', '_encodeObjid', '_encodeTime',
+	  '_encodeNull', '_encodeInt', '_encodeBool'
+	];
+
+	function Node(enc, parent) {
+	  var state = {};
+	  this._baseState = state;
+
+	  state.enc = enc;
+
+	  state.parent = parent || null;
+	  state.children = null;
+
+	  // State
+	  state.tag = null;
+	  state.args = null;
+	  state.reverseArgs = null;
+	  state.choice = null;
+	  state.optional = false;
+	  state.any = false;
+	  state.obj = false;
+	  state.use = null;
+	  state.useDecoder = null;
+	  state.key = null;
+	  state['default'] = null;
+	  state.explicit = null;
+	  state.implicit = null;
+	  state.contains = null;
+
+	  // Should create new instance on each method
+	  if (!state.parent) {
+	    state.children = [];
+	    this._wrap();
+	  }
+	}
+	module.exports = Node;
+
+	var stateProps = [
+	  'enc', 'parent', 'children', 'tag', 'args', 'reverseArgs', 'choice',
+	  'optional', 'any', 'obj', 'use', 'alteredUse', 'key', 'default', 'explicit',
+	  'implicit', 'contains'
+	];
+
+	Node.prototype.clone = function clone() {
+	  var state = this._baseState;
+	  var cstate = {};
+	  stateProps.forEach(function(prop) {
+	    cstate[prop] = state[prop];
+	  });
+	  var res = new this.constructor(cstate.parent);
+	  res._baseState = cstate;
+	  return res;
+	};
+
+	Node.prototype._wrap = function wrap() {
+	  var state = this._baseState;
+	  methods.forEach(function(method) {
+	    this[method] = function _wrappedMethod() {
+	      var clone = new this.constructor(this);
+	      state.children.push(clone);
+	      return clone[method].apply(clone, arguments);
+	    };
+	  }, this);
+	};
+
+	Node.prototype._init = function init(body) {
+	  var state = this._baseState;
+
+	  assert(state.parent === null);
+	  body.call(this);
+
+	  // Filter children
+	  state.children = state.children.filter(function(child) {
+	    return child._baseState.parent === this;
+	  }, this);
+	  assert.equal(state.children.length, 1, 'Root node can have only one child');
+	};
+
+	Node.prototype._useArgs = function useArgs(args) {
+	  var state = this._baseState;
+
+	  // Filter children and args
+	  var children = args.filter(function(arg) {
+	    return arg instanceof this.constructor;
+	  }, this);
+	  args = args.filter(function(arg) {
+	    return !(arg instanceof this.constructor);
+	  }, this);
+
+	  if (children.length !== 0) {
+	    assert(state.children === null);
+	    state.children = children;
+
+	    // Replace parent to maintain backward link
+	    children.forEach(function(child) {
+	      child._baseState.parent = this;
+	    }, this);
+	  }
+	  if (args.length !== 0) {
+	    assert(state.args === null);
+	    state.args = args;
+	    state.reverseArgs = args.map(function(arg) {
+	      if (typeof arg !== 'object' || arg.constructor !== Object)
+	        return arg;
+
+	      var res = {};
+	      Object.keys(arg).forEach(function(key) {
+	        if (key == (key | 0))
+	          key |= 0;
+	        var value = arg[key];
+	        res[value] = key;
+	      });
+	      return res;
+	    });
+	  }
+	};
+
+	//
+	// Overrided methods
+	//
+
+	overrided.forEach(function(method) {
+	  Node.prototype[method] = function _overrided() {
+	    var state = this._baseState;
+	    throw new Error(method + ' not implemented for encoding: ' + state.enc);
+	  };
+	});
+
+	//
+	// Public methods
+	//
+
+	tags.forEach(function(tag) {
+	  Node.prototype[tag] = function _tagMethod() {
+	    var state = this._baseState;
+	    var args = Array.prototype.slice.call(arguments);
+
+	    assert(state.tag === null);
+	    state.tag = tag;
+
+	    this._useArgs(args);
+
+	    return this;
+	  };
+	});
+
+	Node.prototype.use = function use(item) {
+	  assert(item);
+	  var state = this._baseState;
+
+	  assert(state.use === null);
+	  state.use = item;
+
+	  return this;
+	};
+
+	Node.prototype.optional = function optional() {
+	  var state = this._baseState;
+
+	  state.optional = true;
+
+	  return this;
+	};
+
+	Node.prototype.def = function def(val) {
+	  var state = this._baseState;
+
+	  assert(state['default'] === null);
+	  state['default'] = val;
+	  state.optional = true;
+
+	  return this;
+	};
+
+	Node.prototype.explicit = function explicit(num) {
+	  var state = this._baseState;
+
+	  assert(state.explicit === null && state.implicit === null);
+	  state.explicit = num;
+
+	  return this;
+	};
+
+	Node.prototype.implicit = function implicit(num) {
+	  var state = this._baseState;
+
+	  assert(state.explicit === null && state.implicit === null);
+	  state.implicit = num;
+
+	  return this;
+	};
+
+	Node.prototype.obj = function obj() {
+	  var state = this._baseState;
+	  var args = Array.prototype.slice.call(arguments);
+
+	  state.obj = true;
+
+	  if (args.length !== 0)
+	    this._useArgs(args);
+
+	  return this;
+	};
+
+	Node.prototype.key = function key(newKey) {
+	  var state = this._baseState;
+
+	  assert(state.key === null);
+	  state.key = newKey;
+
+	  return this;
+	};
+
+	Node.prototype.any = function any() {
+	  var state = this._baseState;
+
+	  state.any = true;
+
+	  return this;
+	};
+
+	Node.prototype.choice = function choice(obj) {
+	  var state = this._baseState;
+
+	  assert(state.choice === null);
+	  state.choice = obj;
+	  this._useArgs(Object.keys(obj).map(function(key) {
+	    return obj[key];
+	  }));
+
+	  return this;
+	};
+
+	Node.prototype.contains = function contains(item) {
+	  var state = this._baseState;
+
+	  assert(state.use === null);
+	  state.contains = item;
+
+	  return this;
+	};
+
+	//
+	// Decoding
+	//
+
+	Node.prototype._decode = function decode(input, options) {
+	  var state = this._baseState;
+
+	  // Decode root node
+	  if (state.parent === null)
+	    return input.wrapResult(state.children[0]._decode(input, options));
+
+	  var result = state['default'];
+	  var present = true;
+
+	  var prevKey = null;
+	  if (state.key !== null)
+	    prevKey = input.enterKey(state.key);
+
+	  // Check if tag is there
+	  if (state.optional) {
+	    var tag = null;
+	    if (state.explicit !== null)
+	      tag = state.explicit;
+	    else if (state.implicit !== null)
+	      tag = state.implicit;
+	    else if (state.tag !== null)
+	      tag = state.tag;
+
+	    if (tag === null && !state.any) {
+	      // Trial and Error
+	      var save = input.save();
+	      try {
+	        if (state.choice === null)
+	          this._decodeGeneric(state.tag, input, options);
+	        else
+	          this._decodeChoice(input, options);
+	        present = true;
+	      } catch (e) {
+	        present = false;
+	      }
+	      input.restore(save);
+	    } else {
+	      present = this._peekTag(input, tag, state.any);
+
+	      if (input.isError(present))
+	        return present;
+	    }
+	  }
+
+	  // Push object on stack
+	  var prevObj;
+	  if (state.obj && present)
+	    prevObj = input.enterObject();
+
+	  if (present) {
+	    // Unwrap explicit values
+	    if (state.explicit !== null) {
+	      var explicit = this._decodeTag(input, state.explicit);
+	      if (input.isError(explicit))
+	        return explicit;
+	      input = explicit;
+	    }
+
+	    var start = input.offset;
+
+	    // Unwrap implicit and normal values
+	    if (state.use === null && state.choice === null) {
+	      if (state.any)
+	        var save = input.save();
+	      var body = this._decodeTag(
+	        input,
+	        state.implicit !== null ? state.implicit : state.tag,
+	        state.any
+	      );
+	      if (input.isError(body))
+	        return body;
+
+	      if (state.any)
+	        result = input.raw(save);
+	      else
+	        input = body;
+	    }
+
+	    if (options && options.track && state.tag !== null)
+	      options.track(input.path(), start, input.length, 'tagged');
+
+	    if (options && options.track && state.tag !== null)
+	      options.track(input.path(), input.offset, input.length, 'content');
+
+	    // Select proper method for tag
+	    if (state.any)
+	      result = result;
+	    else if (state.choice === null)
+	      result = this._decodeGeneric(state.tag, input, options);
+	    else
+	      result = this._decodeChoice(input, options);
+
+	    if (input.isError(result))
+	      return result;
+
+	    // Decode children
+	    if (!state.any && state.choice === null && state.children !== null) {
+	      state.children.forEach(function decodeChildren(child) {
+	        // NOTE: We are ignoring errors here, to let parser continue with other
+	        // parts of encoded data
+	        child._decode(input, options);
+	      });
+	    }
+
+	    // Decode contained/encoded by schema, only in bit or octet strings
+	    if (state.contains && (state.tag === 'octstr' || state.tag === 'bitstr')) {
+	      var data = new DecoderBuffer(result);
+	      result = this._getUse(state.contains, input._reporterState.obj)
+	          ._decode(data, options);
+	    }
+	  }
+
+	  // Pop object
+	  if (state.obj && present)
+	    result = input.leaveObject(prevObj);
+
+	  // Set key
+	  if (state.key !== null && (result !== null || present === true))
+	    input.leaveKey(prevKey, state.key, result);
+	  else if (prevKey !== null)
+	    input.exitKey(prevKey);
+
+	  return result;
+	};
+
+	Node.prototype._decodeGeneric = function decodeGeneric(tag, input, options) {
+	  var state = this._baseState;
+
+	  if (tag === 'seq' || tag === 'set')
+	    return null;
+	  if (tag === 'seqof' || tag === 'setof')
+	    return this._decodeList(input, tag, state.args[0], options);
+	  else if (/str$/.test(tag))
+	    return this._decodeStr(input, tag, options);
+	  else if (tag === 'objid' && state.args)
+	    return this._decodeObjid(input, state.args[0], state.args[1], options);
+	  else if (tag === 'objid')
+	    return this._decodeObjid(input, null, null, options);
+	  else if (tag === 'gentime' || tag === 'utctime')
+	    return this._decodeTime(input, tag, options);
+	  else if (tag === 'null_')
+	    return this._decodeNull(input, options);
+	  else if (tag === 'bool')
+	    return this._decodeBool(input, options);
+	  else if (tag === 'objDesc')
+	    return this._decodeStr(input, tag, options);
+	  else if (tag === 'int' || tag === 'enum')
+	    return this._decodeInt(input, state.args && state.args[0], options);
+
+	  if (state.use !== null) {
+	    return this._getUse(state.use, input._reporterState.obj)
+	        ._decode(input, options);
+	  } else {
+	    return input.error('unknown tag: ' + tag);
+	  }
+	};
+
+	Node.prototype._getUse = function _getUse(entity, obj) {
+
+	  var state = this._baseState;
+	  // Create altered use decoder if implicit is set
+	  state.useDecoder = this._use(entity, obj);
+	  assert(state.useDecoder._baseState.parent === null);
+	  state.useDecoder = state.useDecoder._baseState.children[0];
+	  if (state.implicit !== state.useDecoder._baseState.implicit) {
+	    state.useDecoder = state.useDecoder.clone();
+	    state.useDecoder._baseState.implicit = state.implicit;
+	  }
+	  return state.useDecoder;
+	};
+
+	Node.prototype._decodeChoice = function decodeChoice(input, options) {
+	  var state = this._baseState;
+	  var result = null;
+	  var match = false;
+
+	  Object.keys(state.choice).some(function(key) {
+	    var save = input.save();
+	    var node = state.choice[key];
+	    try {
+	      var value = node._decode(input, options);
+	      if (input.isError(value))
+	        return false;
+
+	      result = { type: key, value: value };
+	      match = true;
+	    } catch (e) {
+	      input.restore(save);
+	      return false;
+	    }
+	    return true;
+	  }, this);
+
+	  if (!match)
+	    return input.error('Choice not matched');
+
+	  return result;
+	};
+
+	//
+	// Encoding
+	//
+
+	Node.prototype._createEncoderBuffer = function createEncoderBuffer(data) {
+	  return new EncoderBuffer(data, this.reporter);
+	};
+
+	Node.prototype._encode = function encode(data, reporter, parent) {
+	  var state = this._baseState;
+	  if (state['default'] !== null && state['default'] === data)
+	    return;
+
+	  var result = this._encodeValue(data, reporter, parent);
+	  if (result === undefined)
+	    return;
+
+	  if (this._skipDefault(result, reporter, parent))
+	    return;
+
+	  return result;
+	};
+
+	Node.prototype._encodeValue = function encode(data, reporter, parent) {
+	  var state = this._baseState;
+
+	  // Decode root node
+	  if (state.parent === null)
+	    return state.children[0]._encode(data, reporter || new Reporter());
+
+	  var result = null;
+
+	  // Set reporter to share it with a child class
+	  this.reporter = reporter;
+
+	  // Check if data is there
+	  if (state.optional && data === undefined) {
+	    if (state['default'] !== null)
+	      data = state['default']
+	    else
+	      return;
+	  }
+
+	  // Encode children first
+	  var content = null;
+	  var primitive = false;
+	  if (state.any) {
+	    // Anything that was given is translated to buffer
+	    result = this._createEncoderBuffer(data);
+	  } else if (state.choice) {
+	    result = this._encodeChoice(data, reporter);
+	  } else if (state.contains) {
+	    content = this._getUse(state.contains, parent)._encode(data, reporter);
+	    primitive = true;
+	  } else if (state.children) {
+	    content = state.children.map(function(child) {
+	      if (child._baseState.tag === 'null_')
+	        return child._encode(null, reporter, data);
+
+	      if (child._baseState.key === null)
+	        return reporter.error('Child should have a key');
+	      var prevKey = reporter.enterKey(child._baseState.key);
+
+	      if (typeof data !== 'object')
+	        return reporter.error('Child expected, but input is not object');
+
+	      var res = child._encode(data[child._baseState.key], reporter, data);
+	      reporter.leaveKey(prevKey);
+
+	      return res;
+	    }, this).filter(function(child) {
+	      return child;
+	    });
+	    content = this._createEncoderBuffer(content);
+	  } else {
+	    if (state.tag === 'seqof' || state.tag === 'setof') {
+	      // TODO(indutny): this should be thrown on DSL level
+	      if (!(state.args && state.args.length === 1))
+	        return reporter.error('Too many args for : ' + state.tag);
+
+	      if (!Array.isArray(data))
+	        return reporter.error('seqof/setof, but data is not Array');
+
+	      var child = this.clone();
+	      child._baseState.implicit = null;
+	      content = this._createEncoderBuffer(data.map(function(item) {
+	        var state = this._baseState;
+
+	        return this._getUse(state.args[0], data)._encode(item, reporter);
+	      }, child));
+	    } else if (state.use !== null) {
+	      result = this._getUse(state.use, parent)._encode(data, reporter);
+	    } else {
+	      content = this._encodePrimitive(state.tag, data);
+	      primitive = true;
+	    }
+	  }
+
+	  // Encode data itself
+	  var result;
+	  if (!state.any && state.choice === null) {
+	    var tag = state.implicit !== null ? state.implicit : state.tag;
+	    var cls = state.implicit === null ? 'universal' : 'context';
+
+	    if (tag === null) {
+	      if (state.use === null)
+	        reporter.error('Tag could be ommited only for .use()');
+	    } else {
+	      if (state.use === null)
+	        result = this._encodeComposite(tag, primitive, cls, content);
+	    }
+	  }
+
+	  // Wrap in explicit
+	  if (state.explicit !== null)
+	    result = this._encodeComposite(state.explicit, false, 'context', result);
+
+	  return result;
+	};
+
+	Node.prototype._encodeChoice = function encodeChoice(data, reporter) {
+	  var state = this._baseState;
+
+	  var node = state.choice[data.type];
+	  if (!node) {
+	    assert(
+	        false,
+	        data.type + ' not found in ' +
+	            JSON.stringify(Object.keys(state.choice)));
+	  }
+	  return node._encode(data.value, reporter);
+	};
+
+	Node.prototype._encodePrimitive = function encodePrimitive(tag, data) {
+	  var state = this._baseState;
+
+	  if (/str$/.test(tag))
+	    return this._encodeStr(data, tag);
+	  else if (tag === 'objid' && state.args)
+	    return this._encodeObjid(data, state.reverseArgs[0], state.args[1]);
+	  else if (tag === 'objid')
+	    return this._encodeObjid(data, null, null);
+	  else if (tag === 'gentime' || tag === 'utctime')
+	    return this._encodeTime(data, tag);
+	  else if (tag === 'null_')
+	    return this._encodeNull();
+	  else if (tag === 'int' || tag === 'enum')
+	    return this._encodeInt(data, state.args && state.reverseArgs[0]);
+	  else if (tag === 'bool')
+	    return this._encodeBool(data);
+	  else if (tag === 'objDesc')
+	    return this._encodeStr(data, tag);
+	  else
+	    throw new Error('Unsupported tag: ' + tag);
+	};
+
+	Node.prototype._isNumstr = function isNumstr(str) {
+	  return /^[0-9 ]*$/.test(str);
+	};
+
+	Node.prototype._isPrintstr = function isPrintstr(str) {
+	  return /^[A-Za-z0-9 '\(\)\+,\-\.\/:=\?]*$/.test(str);
+	};
+
+
+/***/ }),
+/* 211 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var constants = exports;
+
+	// Helper
+	constants._reverse = function reverse(map) {
+	  var res = {};
+
+	  Object.keys(map).forEach(function(key) {
+	    // Convert key to integer if it is stringified
+	    if ((key | 0) == key)
+	      key = key | 0;
+
+	    var value = map[key];
+	    res[value] = key;
+	  });
+
+	  return res;
+	};
+
+	constants.der = __webpack_require__(212);
+
+
+/***/ }),
+/* 212 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var constants = __webpack_require__(211);
+
+	exports.tagClass = {
+	  0: 'universal',
+	  1: 'application',
+	  2: 'context',
+	  3: 'private'
+	};
+	exports.tagClassByName = constants._reverse(exports.tagClass);
+
+	exports.tag = {
+	  0x00: 'end',
+	  0x01: 'bool',
+	  0x02: 'int',
+	  0x03: 'bitstr',
+	  0x04: 'octstr',
+	  0x05: 'null_',
+	  0x06: 'objid',
+	  0x07: 'objDesc',
+	  0x08: 'external',
+	  0x09: 'real',
+	  0x0a: 'enum',
+	  0x0b: 'embed',
+	  0x0c: 'utf8str',
+	  0x0d: 'relativeOid',
+	  0x10: 'seq',
+	  0x11: 'set',
+	  0x12: 'numstr',
+	  0x13: 'printstr',
+	  0x14: 't61str',
+	  0x15: 'videostr',
+	  0x16: 'ia5str',
+	  0x17: 'utctime',
+	  0x18: 'gentime',
+	  0x19: 'graphstr',
+	  0x1a: 'iso646str',
+	  0x1b: 'genstr',
+	  0x1c: 'unistr',
+	  0x1d: 'charstr',
+	  0x1e: 'bmpstr'
+	};
+	exports.tagByName = constants._reverse(exports.tag);
+
+
+/***/ }),
+/* 213 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var decoders = exports;
+
+	decoders.der = __webpack_require__(214);
+	decoders.pem = __webpack_require__(215);
+
+
+/***/ }),
+/* 214 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+
+	var asn1 = __webpack_require__(203);
+	var base = asn1.base;
+	var bignum = asn1.bignum;
+
+	// Import DER constants
+	var der = asn1.constants.der;
+
+	function DERDecoder(entity) {
+	  this.enc = 'der';
+	  this.name = entity.name;
+	  this.entity = entity;
+
+	  // Construct base tree
+	  this.tree = new DERNode();
+	  this.tree._init(entity.body);
+	};
+	module.exports = DERDecoder;
+
+	DERDecoder.prototype.decode = function decode(data, options) {
+	  if (!(data instanceof base.DecoderBuffer))
+	    data = new base.DecoderBuffer(data, options);
+
+	  return this.tree._decode(data, options);
+	};
+
+	// Tree methods
+
+	function DERNode(parent) {
+	  base.Node.call(this, 'der', parent);
+	}
+	inherits(DERNode, base.Node);
+
+	DERNode.prototype._peekTag = function peekTag(buffer, tag, any) {
+	  if (buffer.isEmpty())
+	    return false;
+
+	  var state = buffer.save();
+	  var decodedTag = derDecodeTag(buffer, 'Failed to peek tag: "' + tag + '"');
+	  if (buffer.isError(decodedTag))
+	    return decodedTag;
+
+	  buffer.restore(state);
+
+	  return decodedTag.tag === tag || decodedTag.tagStr === tag ||
+	    (decodedTag.tagStr + 'of') === tag || any;
+	};
+
+	DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
+	  var decodedTag = derDecodeTag(buffer,
+	                                'Failed to decode tag of "' + tag + '"');
+	  if (buffer.isError(decodedTag))
+	    return decodedTag;
+
+	  var len = derDecodeLen(buffer,
+	                         decodedTag.primitive,
+	                         'Failed to get length of "' + tag + '"');
+
+	  // Failure
+	  if (buffer.isError(len))
+	    return len;
+
+	  if (!any &&
+	      decodedTag.tag !== tag &&
+	      decodedTag.tagStr !== tag &&
+	      decodedTag.tagStr + 'of' !== tag) {
+	    return buffer.error('Failed to match tag: "' + tag + '"');
+	  }
+
+	  if (decodedTag.primitive || len !== null)
+	    return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+
+	  // Indefinite length... find END tag
+	  var state = buffer.save();
+	  var res = this._skipUntilEnd(
+	      buffer,
+	      'Failed to skip indefinite length body: "' + this.tag + '"');
+	  if (buffer.isError(res))
+	    return res;
+
+	  len = buffer.offset - state.offset;
+	  buffer.restore(state);
+	  return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+	};
+
+	DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
+	  while (true) {
+	    var tag = derDecodeTag(buffer, fail);
+	    if (buffer.isError(tag))
+	      return tag;
+	    var len = derDecodeLen(buffer, tag.primitive, fail);
+	    if (buffer.isError(len))
+	      return len;
+
+	    var res;
+	    if (tag.primitive || len !== null)
+	      res = buffer.skip(len)
+	    else
+	      res = this._skipUntilEnd(buffer, fail);
+
+	    // Failure
+	    if (buffer.isError(res))
+	      return res;
+
+	    if (tag.tagStr === 'end')
+	      break;
+	  }
+	};
+
+	DERNode.prototype._decodeList = function decodeList(buffer, tag, decoder,
+	                                                    options) {
+	  var result = [];
+	  while (!buffer.isEmpty()) {
+	    var possibleEnd = this._peekTag(buffer, 'end');
+	    if (buffer.isError(possibleEnd))
+	      return possibleEnd;
+
+	    var res = decoder.decode(buffer, 'der', options);
+	    if (buffer.isError(res) && possibleEnd)
+	      break;
+	    result.push(res);
+	  }
+	  return result;
+	};
+
+	DERNode.prototype._decodeStr = function decodeStr(buffer, tag) {
+	  if (tag === 'bitstr') {
+	    var unused = buffer.readUInt8();
+	    if (buffer.isError(unused))
+	      return unused;
+	    return { unused: unused, data: buffer.raw() };
+	  } else if (tag === 'bmpstr') {
+	    var raw = buffer.raw();
+	    if (raw.length % 2 === 1)
+	      return buffer.error('Decoding of string type: bmpstr length mismatch');
+
+	    var str = '';
+	    for (var i = 0; i < raw.length / 2; i++) {
+	      str += String.fromCharCode(raw.readUInt16BE(i * 2));
+	    }
+	    return str;
+	  } else if (tag === 'numstr') {
+	    var numstr = buffer.raw().toString('ascii');
+	    if (!this._isNumstr(numstr)) {
+	      return buffer.error('Decoding of string type: ' +
+	                          'numstr unsupported characters');
+	    }
+	    return numstr;
+	  } else if (tag === 'octstr') {
+	    return buffer.raw();
+	  } else if (tag === 'objDesc') {
+	    return buffer.raw();
+	  } else if (tag === 'printstr') {
+	    var printstr = buffer.raw().toString('ascii');
+	    if (!this._isPrintstr(printstr)) {
+	      return buffer.error('Decoding of string type: ' +
+	                          'printstr unsupported characters');
+	    }
+	    return printstr;
+	  } else if (/str$/.test(tag)) {
+	    return buffer.raw().toString();
+	  } else {
+	    return buffer.error('Decoding of string type: ' + tag + ' unsupported');
+	  }
+	};
+
+	DERNode.prototype._decodeObjid = function decodeObjid(buffer, values, relative) {
+	  var result;
+	  var identifiers = [];
+	  var ident = 0;
+	  while (!buffer.isEmpty()) {
+	    var subident = buffer.readUInt8();
+	    ident <<= 7;
+	    ident |= subident & 0x7f;
+	    if ((subident & 0x80) === 0) {
+	      identifiers.push(ident);
+	      ident = 0;
+	    }
+	  }
+	  if (subident & 0x80)
+	    identifiers.push(ident);
+
+	  var first = (identifiers[0] / 40) | 0;
+	  var second = identifiers[0] % 40;
+
+	  if (relative)
+	    result = identifiers;
+	  else
+	    result = [first, second].concat(identifiers.slice(1));
+
+	  if (values) {
+	    var tmp = values[result.join(' ')];
+	    if (tmp === undefined)
+	      tmp = values[result.join('.')];
+	    if (tmp !== undefined)
+	      result = tmp;
+	  }
+
+	  return result;
+	};
+
+	DERNode.prototype._decodeTime = function decodeTime(buffer, tag) {
+	  var str = buffer.raw().toString();
+	  if (tag === 'gentime') {
+	    var year = str.slice(0, 4) | 0;
+	    var mon = str.slice(4, 6) | 0;
+	    var day = str.slice(6, 8) | 0;
+	    var hour = str.slice(8, 10) | 0;
+	    var min = str.slice(10, 12) | 0;
+	    var sec = str.slice(12, 14) | 0;
+	  } else if (tag === 'utctime') {
+	    var year = str.slice(0, 2) | 0;
+	    var mon = str.slice(2, 4) | 0;
+	    var day = str.slice(4, 6) | 0;
+	    var hour = str.slice(6, 8) | 0;
+	    var min = str.slice(8, 10) | 0;
+	    var sec = str.slice(10, 12) | 0;
+	    if (year < 70)
+	      year = 2000 + year;
+	    else
+	      year = 1900 + year;
+	  } else {
+	    return buffer.error('Decoding ' + tag + ' time is not supported yet');
+	  }
+
+	  return Date.UTC(year, mon - 1, day, hour, min, sec, 0);
+	};
+
+	DERNode.prototype._decodeNull = function decodeNull(buffer) {
+	  return null;
+	};
+
+	DERNode.prototype._decodeBool = function decodeBool(buffer) {
+	  var res = buffer.readUInt8();
+	  if (buffer.isError(res))
+	    return res;
+	  else
+	    return res !== 0;
+	};
+
+	DERNode.prototype._decodeInt = function decodeInt(buffer, values) {
+	  // Bigint, return as it is (assume big endian)
+	  var raw = buffer.raw();
+	  var res = new bignum(raw);
+
+	  if (values)
+	    res = values[res.toString(10)] || res;
+
+	  return res;
+	};
+
+	DERNode.prototype._use = function use(entity, obj) {
+	  if (typeof entity === 'function')
+	    entity = entity(obj);
+	  return entity._getDecoder('der').tree;
+	};
+
+	// Utility methods
+
+	function derDecodeTag(buf, fail) {
+	  var tag = buf.readUInt8(fail);
+	  if (buf.isError(tag))
+	    return tag;
+
+	  var cls = der.tagClass[tag >> 6];
+	  var primitive = (tag & 0x20) === 0;
+
+	  // Multi-octet tag - load
+	  if ((tag & 0x1f) === 0x1f) {
+	    var oct = tag;
+	    tag = 0;
+	    while ((oct & 0x80) === 0x80) {
+	      oct = buf.readUInt8(fail);
+	      if (buf.isError(oct))
+	        return oct;
+
+	      tag <<= 7;
+	      tag |= oct & 0x7f;
+	    }
+	  } else {
+	    tag &= 0x1f;
+	  }
+	  var tagStr = der.tag[tag];
+
+	  return {
+	    cls: cls,
+	    primitive: primitive,
+	    tag: tag,
+	    tagStr: tagStr
+	  };
+	}
+
+	function derDecodeLen(buf, primitive, fail) {
+	  var len = buf.readUInt8(fail);
+	  if (buf.isError(len))
+	    return len;
+
+	  // Indefinite form
+	  if (!primitive && len === 0x80)
+	    return null;
+
+	  // Definite form
+	  if ((len & 0x80) === 0) {
+	    // Short form
+	    return len;
+	  }
+
+	  // Long form
+	  var num = len & 0x7f;
+	  if (num > 4)
+	    return buf.error('length octect is too long');
+
+	  len = 0;
+	  for (var i = 0; i < num; i++) {
+	    len <<= 8;
+	    var j = buf.readUInt8(fail);
+	    if (buf.isError(j))
+	      return j;
+	    len |= j;
+	  }
+
+	  return len;
+	}
+
+
+/***/ }),
+/* 215 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+	var Buffer = __webpack_require__(19).Buffer;
+
+	var DERDecoder = __webpack_require__(214);
+
+	function PEMDecoder(entity) {
+	  DERDecoder.call(this, entity);
+	  this.enc = 'pem';
+	};
+	inherits(PEMDecoder, DERDecoder);
+	module.exports = PEMDecoder;
+
+	PEMDecoder.prototype.decode = function decode(data, options) {
+	  var lines = data.toString().split(/[\r\n]+/g);
+
+	  var label = options.label.toUpperCase();
+
+	  var re = /^-----(BEGIN|END) ([^-]+)-----$/;
+	  var start = -1;
+	  var end = -1;
+	  for (var i = 0; i < lines.length; i++) {
+	    var match = lines[i].match(re);
+	    if (match === null)
+	      continue;
+
+	    if (match[2] !== label)
+	      continue;
+
+	    if (start === -1) {
+	      if (match[1] !== 'BEGIN')
+	        break;
+	      start = i;
+	    } else {
+	      if (match[1] !== 'END')
+	        break;
+	      end = i;
+	      break;
+	    }
+	  }
+	  if (start === -1 || end === -1)
+	    throw new Error('PEM section not found for: ' + label);
+
+	  var base64 = lines.slice(start + 1, end).join('');
+	  // Remove excessive symbols
+	  base64.replace(/[^a-z0-9\+\/=]+/gi, '');
+
+	  var input = new Buffer(base64, 'base64');
+	  return DERDecoder.prototype.decode.call(this, input, options);
+	};
+
+
+/***/ }),
+/* 216 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var encoders = exports;
+
+	encoders.der = __webpack_require__(217);
+	encoders.pem = __webpack_require__(218);
+
+
+/***/ }),
+/* 217 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+	var Buffer = __webpack_require__(19).Buffer;
+
+	var asn1 = __webpack_require__(203);
+	var base = asn1.base;
+
+	// Import DER constants
+	var der = asn1.constants.der;
+
+	function DEREncoder(entity) {
+	  this.enc = 'der';
+	  this.name = entity.name;
+	  this.entity = entity;
+
+	  // Construct base tree
+	  this.tree = new DERNode();
+	  this.tree._init(entity.body);
+	};
+	module.exports = DEREncoder;
+
+	DEREncoder.prototype.encode = function encode(data, reporter) {
+	  return this.tree._encode(data, reporter).join();
+	};
+
+	// Tree methods
+
+	function DERNode(parent) {
+	  base.Node.call(this, 'der', parent);
+	}
+	inherits(DERNode, base.Node);
+
+	DERNode.prototype._encodeComposite = function encodeComposite(tag,
+	                                                              primitive,
+	                                                              cls,
+	                                                              content) {
+	  var encodedTag = encodeTag(tag, primitive, cls, this.reporter);
+
+	  // Short form
+	  if (content.length < 0x80) {
+	    var header = new Buffer(2);
+	    header[0] = encodedTag;
+	    header[1] = content.length;
+	    return this._createEncoderBuffer([ header, content ]);
+	  }
+
+	  // Long form
+	  // Count octets required to store length
+	  var lenOctets = 1;
+	  for (var i = content.length; i >= 0x100; i >>= 8)
+	    lenOctets++;
+
+	  var header = new Buffer(1 + 1 + lenOctets);
+	  header[0] = encodedTag;
+	  header[1] = 0x80 | lenOctets;
+
+	  for (var i = 1 + lenOctets, j = content.length; j > 0; i--, j >>= 8)
+	    header[i] = j & 0xff;
+
+	  return this._createEncoderBuffer([ header, content ]);
+	};
+
+	DERNode.prototype._encodeStr = function encodeStr(str, tag) {
+	  if (tag === 'bitstr') {
+	    return this._createEncoderBuffer([ str.unused | 0, str.data ]);
+	  } else if (tag === 'bmpstr') {
+	    var buf = new Buffer(str.length * 2);
+	    for (var i = 0; i < str.length; i++) {
+	      buf.writeUInt16BE(str.charCodeAt(i), i * 2);
+	    }
+	    return this._createEncoderBuffer(buf);
+	  } else if (tag === 'numstr') {
+	    if (!this._isNumstr(str)) {
+	      return this.reporter.error('Encoding of string type: numstr supports ' +
+	                                 'only digits and space');
+	    }
+	    return this._createEncoderBuffer(str);
+	  } else if (tag === 'printstr') {
+	    if (!this._isPrintstr(str)) {
+	      return this.reporter.error('Encoding of string type: printstr supports ' +
+	                                 'only latin upper and lower case letters, ' +
+	                                 'digits, space, apostrophe, left and rigth ' +
+	                                 'parenthesis, plus sign, comma, hyphen, ' +
+	                                 'dot, slash, colon, equal sign, ' +
+	                                 'question mark');
+	    }
+	    return this._createEncoderBuffer(str);
+	  } else if (/str$/.test(tag)) {
+	    return this._createEncoderBuffer(str);
+	  } else if (tag === 'objDesc') {
+	    return this._createEncoderBuffer(str);
+	  } else {
+	    return this.reporter.error('Encoding of string type: ' + tag +
+	                               ' unsupported');
+	  }
+	};
+
+	DERNode.prototype._encodeObjid = function encodeObjid(id, values, relative) {
+	  if (typeof id === 'string') {
+	    if (!values)
+	      return this.reporter.error('string objid given, but no values map found');
+	    if (!values.hasOwnProperty(id))
+	      return this.reporter.error('objid not found in values map');
+	    id = values[id].split(/[\s\.]+/g);
+	    for (var i = 0; i < id.length; i++)
+	      id[i] |= 0;
+	  } else if (Array.isArray(id)) {
+	    id = id.slice();
+	    for (var i = 0; i < id.length; i++)
+	      id[i] |= 0;
+	  }
+
+	  if (!Array.isArray(id)) {
+	    return this.reporter.error('objid() should be either array or string, ' +
+	                               'got: ' + JSON.stringify(id));
+	  }
+
+	  if (!relative) {
+	    if (id[1] >= 40)
+	      return this.reporter.error('Second objid identifier OOB');
+	    id.splice(0, 2, id[0] * 40 + id[1]);
+	  }
+
+	  // Count number of octets
+	  var size = 0;
+	  for (var i = 0; i < id.length; i++) {
+	    var ident = id[i];
+	    for (size++; ident >= 0x80; ident >>= 7)
+	      size++;
+	  }
+
+	  var objid = new Buffer(size);
+	  var offset = objid.length - 1;
+	  for (var i = id.length - 1; i >= 0; i--) {
+	    var ident = id[i];
+	    objid[offset--] = ident & 0x7f;
+	    while ((ident >>= 7) > 0)
+	      objid[offset--] = 0x80 | (ident & 0x7f);
+	  }
+
+	  return this._createEncoderBuffer(objid);
+	};
+
+	function two(num) {
+	  if (num < 10)
+	    return '0' + num;
+	  else
+	    return num;
+	}
+
+	DERNode.prototype._encodeTime = function encodeTime(time, tag) {
+	  var str;
+	  var date = new Date(time);
+
+	  if (tag === 'gentime') {
+	    str = [
+	      two(date.getFullYear()),
+	      two(date.getUTCMonth() + 1),
+	      two(date.getUTCDate()),
+	      two(date.getUTCHours()),
+	      two(date.getUTCMinutes()),
+	      two(date.getUTCSeconds()),
+	      'Z'
+	    ].join('');
+	  } else if (tag === 'utctime') {
+	    str = [
+	      two(date.getFullYear() % 100),
+	      two(date.getUTCMonth() + 1),
+	      two(date.getUTCDate()),
+	      two(date.getUTCHours()),
+	      two(date.getUTCMinutes()),
+	      two(date.getUTCSeconds()),
+	      'Z'
+	    ].join('');
+	  } else {
+	    this.reporter.error('Encoding ' + tag + ' time is not supported yet');
+	  }
+
+	  return this._encodeStr(str, 'octstr');
+	};
+
+	DERNode.prototype._encodeNull = function encodeNull() {
+	  return this._createEncoderBuffer('');
+	};
+
+	DERNode.prototype._encodeInt = function encodeInt(num, values) {
+	  if (typeof num === 'string') {
+	    if (!values)
+	      return this.reporter.error('String int or enum given, but no values map');
+	    if (!values.hasOwnProperty(num)) {
+	      return this.reporter.error('Values map doesn\'t contain: ' +
+	                                 JSON.stringify(num));
+	    }
+	    num = values[num];
+	  }
+
+	  // Bignum, assume big endian
+	  if (typeof num !== 'number' && !Buffer.isBuffer(num)) {
+	    var numArray = num.toArray();
+	    if (!num.sign && numArray[0] & 0x80) {
+	      numArray.unshift(0);
+	    }
+	    num = new Buffer(numArray);
+	  }
+
+	  if (Buffer.isBuffer(num)) {
+	    var size = num.length;
+	    if (num.length === 0)
+	      size++;
+
+	    var out = new Buffer(size);
+	    num.copy(out);
+	    if (num.length === 0)
+	      out[0] = 0
+	    return this._createEncoderBuffer(out);
+	  }
+
+	  if (num < 0x80)
+	    return this._createEncoderBuffer(num);
+
+	  if (num < 0x100)
+	    return this._createEncoderBuffer([0, num]);
+
+	  var size = 1;
+	  for (var i = num; i >= 0x100; i >>= 8)
+	    size++;
+
+	  var out = new Array(size);
+	  for (var i = out.length - 1; i >= 0; i--) {
+	    out[i] = num & 0xff;
+	    num >>= 8;
+	  }
+	  if(out[0] & 0x80) {
+	    out.unshift(0);
+	  }
+
+	  return this._createEncoderBuffer(new Buffer(out));
+	};
+
+	DERNode.prototype._encodeBool = function encodeBool(value) {
+	  return this._createEncoderBuffer(value ? 0xff : 0);
+	};
+
+	DERNode.prototype._use = function use(entity, obj) {
+	  if (typeof entity === 'function')
+	    entity = entity(obj);
+	  return entity._getEncoder('der').tree;
+	};
+
+	DERNode.prototype._skipDefault = function skipDefault(dataBuffer, reporter, parent) {
+	  var state = this._baseState;
+	  var i;
+	  if (state['default'] === null)
+	    return false;
+
+	  var data = dataBuffer.join();
+	  if (state.defaultBuffer === undefined)
+	    state.defaultBuffer = this._encodeValue(state['default'], reporter, parent).join();
+
+	  if (data.length !== state.defaultBuffer.length)
+	    return false;
+
+	  for (i=0; i < data.length; i++)
+	    if (data[i] !== state.defaultBuffer[i])
+	      return false;
+
+	  return true;
+	};
+
+	// Utility methods
+
+	function encodeTag(tag, primitive, cls, reporter) {
+	  var res;
+
+	  if (tag === 'seqof')
+	    tag = 'seq';
+	  else if (tag === 'setof')
+	    tag = 'set';
+
+	  if (der.tagByName.hasOwnProperty(tag))
+	    res = der.tagByName[tag];
+	  else if (typeof tag === 'number' && (tag | 0) === tag)
+	    res = tag;
+	  else
+	    return reporter.error('Unknown tag: ' + tag);
+
+	  if (res >= 0x1f)
+	    return reporter.error('Multi-octet tag encoding unsupported');
+
+	  if (!primitive)
+	    res |= 0x20;
+
+	  res |= (der.tagClassByName[cls || 'universal'] << 6);
+
+	  return res;
+	}
+
+
+/***/ }),
+/* 218 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var inherits = __webpack_require__(27);
+
+	var DEREncoder = __webpack_require__(217);
+
+	function PEMEncoder(entity) {
+	  DEREncoder.call(this, entity);
+	  this.enc = 'pem';
+	};
+	inherits(PEMEncoder, DEREncoder);
+	module.exports = PEMEncoder;
+
+	PEMEncoder.prototype.encode = function encode(data, options) {
+	  var buf = DEREncoder.prototype.encode.call(this, data);
+
+	  var p = buf.toString('base64');
+	  var out = [ '-----BEGIN ' + options.label + '-----' ];
+	  for (var i = 0; i < p.length; i += 64)
+	    out.push(p.slice(i, i + 64));
+	  out.push('-----END ' + options.label + '-----');
+	  return out.join('\n');
+	};
+
+
+/***/ }),
+/* 219 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -20031,14 +38764,30 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return MissingParametersError;
 	}(Error);
 
+	var InvalidTokenError = exports.InvalidTokenError = function (_Error2) {
+	  _inherits(InvalidTokenError, _Error2);
+
+	  function InvalidTokenError(message) {
+	    _classCallCheck(this, InvalidTokenError);
+
+	    var _this2 = _possibleConstructorReturn(this, (InvalidTokenError.__proto__ || Object.getPrototypeOf(InvalidTokenError)).call(this));
+
+	    _this2.name = 'InvalidTokenError';
+	    _this2.message = message || '';
+	    return _this2;
+	  }
+
+	  return InvalidTokenError;
+	}(Error);
+
 /***/ }),
-/* 103 */
+/* 220 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	Object.defineProperty(exports, "__esModule", {
-	    value: true
+	  value: true
 	});
 	exports.decodeToken = decodeToken;
 
@@ -20046,25 +38795,32 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _base64url2 = _interopRequireDefault(_base64url);
 
+	var _errors = __webpack_require__(219);
+
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	function decodeToken(token) {
-	    // decompose the token into parts
-	    var tokenParts = token.split('.');
-	    var header = JSON.parse(_base64url2.default.decode(tokenParts[0]));
-	    var payload = JSON.parse(_base64url2.default.decode(tokenParts[1]));
-	    var signature = tokenParts[2];
+	  // decompose the token into parts
+	  var tokenParts = token.split('.');
 
-	    // return the token object
-	    return {
-	        header: header,
-	        payload: payload,
-	        signature: signature
-	    };
+	  if (tokenParts.length !== 3) {
+	    throw new _errors.InvalidTokenError('tokens should have 3 parts');
+	  }
+
+	  var header = JSON.parse(_base64url2.default.decode(tokenParts[0]));
+	  var payload = JSON.parse(_base64url2.default.decode(tokenParts[1]));
+	  var signature = tokenParts[2];
+
+	  // return the token object
+	  return {
+	    header: header,
+	    payload: payload,
+	    signature: signature
+	  };
 	}
 
 /***/ }),
-/* 104 */
+/* 221 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -20082,7 +38838,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _cryptoClients = __webpack_require__(12);
 
-	var _decode = __webpack_require__(103);
+	var _decode = __webpack_require__(220);
 
 	var _decode2 = _interopRequireDefault(_decode);
 
@@ -20131,7 +38887,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}();
 
 /***/ }),
-/* 105 */
+/* 222 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -20143,13 +38899,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.decode = decode;
 	exports.isMNID = isMNID;
 
-	var _jsSha = __webpack_require__(106);
+	var _jsSha = __webpack_require__(223);
 
 	var _buffer = __webpack_require__(19);
 
 	var BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-	var base58 = __webpack_require__(107)(BASE58);
-	var hex = __webpack_require__(107)('0123456789abcdef');
+	var base58 = __webpack_require__(224)(BASE58);
+	var hex = __webpack_require__(224)('0123456789abcdef');
 
 	function checksum(payload) {
 	  return new _buffer.Buffer((0, _jsSha.sha3_256)(_buffer.Buffer.concat(payload)), 'hex').slice(0, 4);
@@ -20191,7 +38947,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 106 */
+/* 223 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process, global) {/**
@@ -20673,7 +39429,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(53), (function() { return this; }())))
 
 /***/ }),
-/* 107 */
+/* 224 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {// base-x encoding
@@ -20769,16 +39525,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
-/* 108 */
+/* 225 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	var BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-	var base58 = __webpack_require__(107)(BASE58);
-	var hex = __webpack_require__(107)('0123456789abcdef');
+	var base58 = __webpack_require__(224)(BASE58);
+	var hex = __webpack_require__(224)('0123456789abcdef');
 
-	var XMLHttpRequest = typeof window !== 'undefined' ? window.XMLHttpRequest : __webpack_require__(109).XMLHttpRequest;
+	var XMLHttpRequest = typeof window !== 'undefined' ? window.XMLHttpRequest : __webpack_require__(226).XMLHttpRequest;
 
 	var functionSignature = '0x447885f0';
 
@@ -20970,16 +39726,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = UportLite;
 
 /***/ }),
-/* 109 */
+/* 226 */
 /***/ (function(module, exports) {
 
 	/* (ignored) */
 
 /***/ }),
-/* 110 */
+/* 227 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(process, Buffer) {var req = __webpack_require__(111)
+	/* WEBPACK VAR INJECTION */(function(process, Buffer) {var req = __webpack_require__(228)
 
 	module.exports = Nets
 
@@ -21007,14 +39763,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(53), __webpack_require__(7).Buffer))
 
 /***/ }),
-/* 111 */
+/* 228 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var window = __webpack_require__(112)
-	var isFunction = __webpack_require__(113)
-	var parseHeaders = __webpack_require__(114)
-	var xtend = __webpack_require__(117)
+	var window = __webpack_require__(229)
+	var isFunction = __webpack_require__(230)
+	var parseHeaders = __webpack_require__(231)
+	var xtend = __webpack_require__(234)
 
 	module.exports = createXHR
 	createXHR.XMLHttpRequest = window.XMLHttpRequest || noop
@@ -21254,7 +40010,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 112 */
+/* 229 */
 /***/ (function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {var win;
@@ -21274,7 +40030,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ }),
-/* 113 */
+/* 230 */
 /***/ (function(module, exports) {
 
 	module.exports = isFunction
@@ -21295,11 +40051,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 114 */
+/* 231 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var trim = __webpack_require__(115)
-	  , forEach = __webpack_require__(116)
+	var trim = __webpack_require__(232)
+	  , forEach = __webpack_require__(233)
 	  , isArray = function(arg) {
 	      return Object.prototype.toString.call(arg) === '[object Array]';
 	    }
@@ -21331,7 +40087,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 115 */
+/* 232 */
 /***/ (function(module, exports) {
 
 	
@@ -21351,10 +40107,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 116 */
+/* 233 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var isFunction = __webpack_require__(113)
+	var isFunction = __webpack_require__(230)
 
 	module.exports = forEach
 
@@ -21403,7 +40159,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 117 */
+/* 234 */
 /***/ (function(module, exports) {
 
 	module.exports = extend
@@ -21428,7 +40184,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 118 */
+/* 235 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -21463,7 +40219,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 119 */
+/* 236 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -21490,7 +40246,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	}
 
-	var arrayContainsArray = __webpack_require__(120).arrayContainsArray;
+	var arrayContainsArray = __webpack_require__(237).arrayContainsArray;
 
 	// A derivative work of Nick Dodson's eths-contract https://github.com/ethjs/ethjs-contract/blob/master/src/index.js
 
@@ -21595,13 +40351,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.Contract = Contract;
 
 /***/ }),
-/* 120 */
+/* 237 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {'use strict';
 
-	var isHexPrefixed = __webpack_require__(121);
-	var stripHexPrefix = __webpack_require__(122);
+	var isHexPrefixed = __webpack_require__(238);
+	var stripHexPrefix = __webpack_require__(239);
 
 	/**
 	 * Pads a `String` to have an even length
@@ -21821,7 +40577,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
-/* 121 */
+/* 238 */
 /***/ (function(module, exports) {
 
 	/**
@@ -21840,10 +40596,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 122 */
+/* 239 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var isHexPrefixed = __webpack_require__(121);
+	var isHexPrefixed = __webpack_require__(238);
 
 	/**
 	 * Removes '0x' from a given `String` is present

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "ethjs-util": "^0.1.3",
-    "jsontokens": "^0.6.5",
+    "jsontokens": "^0.7.6",
     "mnid": "^0.1.1",
     "nets": "^3.2.0",
     "uport-lite": "^1.0.0"

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -88,7 +88,7 @@ class Credentials {
     if (params.exp) { //checks for expiration on requests, if none is provided the default is 10 min
       payload.exp = params.exp
     } else {
-      payload.exp = new Date().getTime() + 600000
+      payload.exp = Date().getTime() / 1000 + 600
     }
     return createJWT(this.settings, {...payload, type: 'shareReq'})
   }
@@ -194,7 +194,7 @@ class Credentials {
   * @param    {Object}            [credential]           a unsigned credential object
   * @param    {String}            credential.sub         subject of credential (a uPort address)
   * @param    {String}            credential.claim       claim about subject single key value or key mapping to object with multiple values (ie { address: {street: ..., zip: ..., country: ...}})
-  * @param    {String}            credential.exp         time at which this claim expires and is no longer valid
+  * @param    {String}            credential.exp         time at which this claim expires and is no longer valid (seconds since epoch)
   * @return   {Promise<Object, Error>}                   a promise which resolves with a credential (JWT) or rejects with an error
   */
   attest ({sub, claim, exp}) {

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -16,7 +16,7 @@ class Credentials {
    *
    * @example
    * import { Credentials, SimpleSigner } from 'uport'
-   * const networks = {  '0x94365e3b': { rpcUrl: 'https://private.chain/rpc', address: '0x0101.... }}
+   * const networks = {  '0x94365e3b': { rpcUrl: 'https://private.chain/rpc', registry: '0x0101.... }}
    * const setttings = { networks, address: '5A8bRWU3F7j3REx3vkJ...', signer: new SimpleSigner(process.env.PRIVATE_KEY)}
    * const credentials = new Credentials(settings)
    *
@@ -133,7 +133,7 @@ class Credentials {
             }
           })
         } else {
-          console.log('Challenge was not included in response')
+          throw new Error('Challenge was not included in response')
         }
       } else {
         return processPayload(this.settings)

--- a/src/JWT.js
+++ b/src/JWT.js
@@ -10,6 +10,7 @@ function encodeSection (data) {
 
 const ENCODED_HEADER = encodeSection(JOSE_HEADER)
 
+const LEGACY_MS = 1000000000000
 /**  @module uport-js/JWT */
 
 /**
@@ -71,10 +72,10 @@ export function verifyJWT ({registry, address}, jwt, callbackUrl = null) {
       const publicKey = profile.publicKey.match(/^0x/) ? profile.publicKey.slice(2) : profile.publicKey
       const verifier = new TokenVerifier('ES256K', publicKey)
       if (verifier.verify(jwt)) {
-        if (payload.iat > Date.now() / 1000) {
+        if ((payload.iat >=LEGACY_MS && payload.iat > Date.now()) || ( payload.iat < LEGACY_MS && payload.iat > Date.now() / 1000)) {
           return reject(new Error('JWT not valid yet (issued in the future)'))
         }
-        if (payload.exp && payload.exp <= Date.now() / 1000) {
+        if (payload.exp && (payload.exp >=LEGACY_MS && payload.exp <= Date.now()) || (payload.iat < LEGACY_MS && payload.exp <= Date.now() / 1000)) {
           return reject(new Error('JWT has expired'))
         }
         if (payload.aud) {

--- a/src/JWT.js
+++ b/src/JWT.js
@@ -1,7 +1,14 @@
-import { createUnsignedToken, TokenVerifier, decodeToken } from 'jsontokens'
+import { TokenVerifier, decodeToken } from 'jsontokens'
 import { isMNID, decode} from 'mnid'
+import base64url from 'base64url'
 
 const JOSE_HEADER = {typ: 'JWT', alg: 'ES256K'}
+
+function encodeSection (data) {
+  return base64url.encode(JSON.stringify(data))
+}
+
+const ENCODED_HEADER = encodeSection(JOSE_HEADER)
 
 /**  @module uport-js/JWT */
 
@@ -21,10 +28,10 @@ const JOSE_HEADER = {typ: 'JWT', alg: 'ES256K'}
 *  @return   {Promise<Object, Error>}               a promise which resolves with a signed JSON Web Token or rejects with an error
 */
 export function createJWT ({address, signer}, payload) {
-  const signingInput = createUnsignedToken(
-    JOSE_HEADER,
-    {iss: address, iat: ( Date.now() / 1000), ...payload }
-  )
+  const signingInput = [ENCODED_HEADER,
+    encodeSection({iss: address, iat: ( Date.now() / 1000), ...payload })
+  ].join('.')
+
   return new Promise((resolve, reject) => {
     if (!signer) return reject(new Error('No Signer functionality has been configured'))
     if (!address) return reject(new Error('No application identity address has been configured'))

--- a/tutorial/createcredential.js
+++ b/tutorial/createcredential.js
@@ -17,8 +17,8 @@ var credentials = new uport.Credentials({
 
 app.get('/', function (req, res) {
   credentials.attest({
-    sub: '2opT3phRXKtkaqjv6LAyR9pqkVwADVECZwx',
-    exp: 1552046024213,
+    sub: '2ovkMrL4jxwRbr1ia9CUUMN5TddtBx9zKmN',
+    exp: 1552046024,
     claim: {'Custom Attestation' : 'Custom Value'}
   }).then(function (att) {
     console.log(att)
@@ -31,6 +31,6 @@ app.get('/', function (req, res) {
   })
 })
 
-var server = app.listen(8081, function () {  
+var server = app.listen(8081, function () {
   console.log("Tutorial app running...")
 })

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -26,12 +26,12 @@ var credentials = new uport.Credentials({
 })
 ```
 
-When we hit the default route using `app.get('/')` we will call `credentials.attest()` in order to sign the credential. For the fields of the credential, the `sub` field is the subject. Set this to the uPort Id of the user that is supposed to receive the credential. For testing purposes this would be the uPort identity shown on the mobile app of the reader. The `exp` field is the expiry of the token, in Unix time. As `claim` field, put your own custom object. We have here `{'Custom Attestation' : 'Custom Value'}` as an example.
+When we hit the default route using `app.get('/')` we will call `credentials.attest()` in order to sign the credential. For the fields of the credential, the `sub` field is the subject. Set this to the uPort Id of the user that is supposed to receive the credential. For testing purposes this would be the uPort identity shown on the mobile app of the reader. The `exp` field is the expiry of the token, in Unix time (seconds precision). As `claim` field, put your own custom object. We have here `{'Custom Attestation' : 'Custom Value'}` as an example.
 
 ```js
 credentials.attest({
   sub: '2oVV33jifY2nPBLowRS8H7Rkh7fCUDN7hNb',
-  exp: 1552046024213,
+  exp: 1552046024,
   claim: {'Custom Attestation' : 'Custom Value'}
 })
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,6 +185,22 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
+asn1.js@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-2.2.1.tgz#c8ba4dd68e84431288126230cb2045bdfa9fbfe1"
+  dependencies:
+    bn.js "^2.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
+asn1.js@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.1.tgz#48ba240b45a9280e94748990ba597d216617fd40"
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -818,10 +834,6 @@ base64-js@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
 
-base64-url@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/base64-url/-/base64-url-1.3.3.tgz#f8b6c537f09a4fc58c99cb86e0b0e9c61461a20f"
-
 base64url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
@@ -853,6 +865,18 @@ bluebird@~3.4.6:
 bluebird@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+
+bn.js@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-2.2.0.tgz#12162bc2ae71fc40a5626c33438f3a875cd37625"
+
+bn.js@^3.1.1, bn.js@^3.1.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-3.3.0.tgz#1138e577889fdc97bbdab51844f2190dfc0ae3d7"
+
+bn.js@^4.0.0:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
 bn.js@^4.4.0:
   version "4.11.6"
@@ -1447,6 +1471,15 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+elliptic@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-5.2.1.tgz#fa294b6563c6ddbc9ba3dc8594687ae840858f10"
+  dependencies:
+    bn.js "^3.1.1"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
 
 elliptic@^6.3.2:
   version "6.4.0"
@@ -2598,14 +2631,16 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsontokens@^0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/jsontokens/-/jsontokens-0.6.5.tgz#dc31a053219e49f2dd3381a3652176f9b8b830e8"
+jsontokens@^0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/jsontokens/-/jsontokens-0.7.6.tgz#e23dd75ea10b1028ea9d5d7512dcb249c598d4ad"
   dependencies:
-    base64-url "^1.3.3"
+    asn1.js "^4.9.1"
     base64url "^2.0.0"
     crypto "0.0.3"
     elliptic "^6.3.2"
+    key-encoder "^1.1.6"
+    validator "^7.0.0"
 
 jsprim@^1.2.2:
   version "1.4.0"
@@ -2615,6 +2650,14 @@ jsprim@^1.2.2:
     extsprintf "1.0.2"
     json-schema "0.2.3"
     verror "1.3.6"
+
+key-encoder@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/key-encoder/-/key-encoder-1.1.6.tgz#0135582cd3d0a7eb792d94eca387b681e8e5a2ad"
+  dependencies:
+    asn1.js "^2.2.0"
+    bn.js "^3.1.2"
+    elliptic "^5.1.0"
 
 kind-of@^3.0.2:
   version "3.1.0"
@@ -4086,6 +4129,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+validator@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-7.2.0.tgz#a63dcbaba51d4350bf8df20988e0d5a54d711791"
 
 vary@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
The JWT specs states that the `iat` and `exp` should be in NumericDate  which is `seconds since epoch`. 

Specs: https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#page-6

The javascript to do that is:

```
new Date.now() / 1000
```

Now it works because the library use miliseconds for creating a JWT and verifying, but is not standard compatible. 