### PR TITLE
Checks for signner instead of address when verifying challenge/response

### DIFF
--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -127,7 +127,7 @@ class Credentials {
         }
       }
 
-      if(this.settings.address) {
+      if(this.settings.signer) {
         if(payload.req) {
           return verifyJWT(this.settings, payload.req).then((challenge) => {
             if(challenge.payload.iss === this.settings.address && challenge.payload.type === 'shareReq') {


### PR DESCRIPTION
This broke the appmanager before, since it has an address defined, but not a signer.