### PR TITLE
Release 0.6.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v0.6.0
+* Support seconds (instead of milliseconds) for JWT timestamps
+* Support for encrypted push notifications
+* Docs update
+
 ## v0.5.2
 * Bugfix for `createRequest`
 * Use correct entry point for package

--- a/dist/uport.js
+++ b/dist/uport.js
@@ -291,7 +291,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          }
 	        }
 
-	        if (_this.settings.address) {
+	        if (_this.settings.signer) {
 	          if (payload.req) {
 	            return (0, _JWT.verifyJWT)(_this.settings, payload.req).then(function (challenge) {
 	              if (challenge.payload.iss === _this.settings.address && challenge.payload.type === 'shareReq') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport",
-  "version": "0.6.0-alpha-6",
+  "version": "0.6.0",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -127,7 +127,7 @@ class Credentials {
         }
       }
 
-      if(this.settings.address) {
+      if(this.settings.signer) {
         if(payload.req) {
           return verifyJWT(this.settings, payload.req).then((challenge) => {
             if(challenge.payload.iss === this.settings.address && challenge.payload.type === 'shareReq') {


### PR DESCRIPTION
 # Release Notes
 		 
## v0.6.0
* Support seconds (instead of milliseconds) for JWT timestamps
* Support for encrypted push notifications
* Docs update