### PR TITLE
WIP: Attestation requests

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -91,6 +91,7 @@ The Credentials class allows you to easily create the signed payloads used in uP
 * [Credentials](#Credentials)
     * [new Credentials([settings])](#new_Credentials_new)
     * [.createRequest([params])](#Credentials+createRequest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+    * [.createVerificationRequest(unsignedClaim, sub)](#Credentials+createVerificationRequest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
     * [.receive(token, [callbackUrl])](#Credentials+receive) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
     * [.push(token, payload, pubEncKey)](#Credentials+push) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
     * [.attest([credential])](#Credentials+attest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
@@ -153,6 +154,36 @@ const req = { requested: ['name', 'country'],
  requested: ['name','phone','identity_no'],
     callbackUrl: 'https://....' // URL to send the response of the request to
     notifications: true
+
+ 
+```
+<a name="Credentials+createVerificationRequest"></a>
+
+### credentials.createVerificationRequest(unsignedClaim, sub) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+Creates a signed request for the user to attest a list of claims.
+
+**Kind**: instance method of <code>[Credentials](#Credentials)</code>  
+**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a signed JSON Web Token or rejects with an error  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| unsignedClaim | <code>Object</code> | an object that is an unsigned claim which you want the user to attest |
+| sub | <code>String</code> | the DID of the identity you want to sign the attestation |
+
+**Example**  
+```js
+const unsignedClaim = {
+   claim: {
+     "Citizen of city X": {
+       "Allowed to vote": true,
+       "Document": "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
+     }
+   },
+   sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
+ }
+ credentials.createVerificationRequest(unsignedClaim).then(jwt => {
+   ...
+ })
 
  
 ```

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -81,13 +81,13 @@ describe('createRequest', () => {
 
 describe('createAttestationRequest', () => {
   it('creates a valid JWT for a request', () => {
-    return uport.createAttestationRequest({claim: { test: {prop1: 1, prop2: 2}}}).then((jwt) => {
+    return uport.createAttestationRequest([{claim: { test: {prop1: 1, prop2: 2}}}], 'did:uport:223ab45').then((jwt) => {
       return expect(verifier.verify(jwt)).toBeTruthy()
     })
   })
 
   it('has correct payload in JWT for a request', () => {
-    return uport.createAttestationRequest({claim: { test: {prop1: 1, prop2: 2}}}).then((jwt) => {
+    return uport.createAttestationRequest([{claim: { test: {prop1: 1, prop2: 2}}}], 'did:uport:223ab45').then((jwt) => {
       return expect(decodeToken(jwt)).toMatchSnapshot()
     })
   })

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -79,15 +79,15 @@ describe('createRequest', () => {
   })
 })
 
-describe('createAttestationRequest', () => {
+describe('createVerificationRequest', () => {
   it('creates a valid JWT for a request', () => {
-    return uport.createAttestationRequest([{claim: { test: {prop1: 1, prop2: 2}}}], 'did:uport:223ab45').then((jwt) => {
+    return uport.createVerificationRequest({claim: { test: {prop1: 1, prop2: 2}}}, 'did:uport:223ab45').then((jwt) => {
       return expect(verifier.verify(jwt)).toBeTruthy()
     })
   })
 
   it('has correct payload in JWT for a request', () => {
-    return uport.createAttestationRequest([{claim: { test: {prop1: 1, prop2: 2}}}], 'did:uport:223ab45').then((jwt) => {
+    return uport.createVerificationRequest({claim: { test: {prop1: 1, prop2: 2}}}, 'did:uport:223ab45').then((jwt) => {
       return expect(decodeToken(jwt)).toMatchSnapshot()
     })
   })

--- a/__tests__/Credentials-test.js
+++ b/__tests__/Credentials-test.js
@@ -79,6 +79,20 @@ describe('createRequest', () => {
   })
 })
 
+describe('createAttestationRequest', () => {
+  it('creates a valid JWT for a request', () => {
+    return uport.createAttestationRequest({claim: { test: {prop1: 1, prop2: 2}}}).then((jwt) => {
+      return expect(verifier.verify(jwt)).toBeTruthy()
+    })
+  })
+
+  it('has correct payload in JWT for a request', () => {
+    return uport.createAttestationRequest({claim: { test: {prop1: 1, prop2: 2}}}).then((jwt) => {
+      return expect(decodeToken(jwt)).toMatchSnapshot()
+    })
+  })
+})
+
 describe('attest', () => {
   it('creates a valid JWT for an attestation', () => {
     return uport.attest({sub: '0x112233', claim: {email: 'bingbangbung@email.com'}, exp: 1485321133 + 1}).then((jwt) => {

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -23,32 +23,6 @@ exports[`configNetworks should require a registry address 1`] = `"Malformed netw
 
 exports[`configNetworks should require a rpcUrl 1`] = `"Malformed network config object, object must have \'rpcUrl\' key specified."`;
 
-exports[`createAttestationRequest has correct payload in JWT for a request 1`] = `
-Object {
-  "header": Object {
-    "alg": "ES256K",
-    "typ": "JWT",
-  },
-  "payload": Object {
-    "iat": 1485321133,
-    "iss": "0x001122",
-    "sub": "did:uport:223ab45",
-    "type": "attReq",
-    "unsignedClaims": Array [
-      Object {
-        "claim": Object {
-          "test": Object {
-            "prop1": 1,
-            "prop2": 2,
-          },
-        },
-      },
-    ],
-  },
-  "signature": "YM7DQRvh5vi4pLlWPJ5JHacmxJarnt2HhfYqwd0njEwwcYLsSMaK0yPFPDUqXwbdDdeLE7Sbc1ezbLm_Fw78TQ",
-}
-`;
-
 exports[`createRequest has correct payload in JWT for a plain request for public details 1`] = `
 Object {
   "header": Object {

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -218,6 +218,30 @@ Object {
 }
 `;
 
+exports[`createVerificationRequest has correct payload in JWT for a request 1`] = `
+Object {
+  "header": Object {
+    "alg": "ES256K",
+    "typ": "JWT",
+  },
+  "payload": Object {
+    "iat": 1485321133,
+    "iss": "0x001122",
+    "sub": "did:uport:223ab45",
+    "type": "verReq",
+    "unsignedClaim": Object {
+      "claim": Object {
+        "test": Object {
+          "prop1": 1,
+          "prop2": 2,
+        },
+      },
+    },
+  },
+  "signature": "nWJtwvzKk6H_Q81PrCtZu2VctOtn8Foyb2KFmW6PFPmjhX5KaUCuWIhxjeEpe6yAYOBGtOH3iSlgmMEdRgGkxA",
+}
+`;
+
 exports[`receive returns profile mixing public and private claims 1`] = `
 Object {
   "address": "0x001122",

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -23,6 +23,29 @@ exports[`configNetworks should require a registry address 1`] = `"Malformed netw
 
 exports[`configNetworks should require a rpcUrl 1`] = `"Malformed network config object, object must have \'rpcUrl\' key specified."`;
 
+exports[`createAttestationRequest has correct payload in JWT for a request 1`] = `
+Object {
+  "header": Object {
+    "alg": "ES256K",
+    "typ": "JWT",
+  },
+  "payload": Object {
+    "iat": 1485321133,
+    "iss": "0x001122",
+    "type": "attReq",
+    "unsignedClaims": Object {
+      "claim": Object {
+        "test": Object {
+          "prop1": 1,
+          "prop2": 2,
+        },
+      },
+    },
+  },
+  "signature": "5ATBwfBccgrenNemi5oLR3eFRNjWZATITAH-ujw5iPdPtaHd9i4jUuChyNxQj1VHvv41upuLY27VO9U5GbisJw",
+}
+`;
+
 exports[`createRequest has correct payload in JWT for a plain request for public details 1`] = `
 Object {
   "header": Object {

--- a/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/__tests__/__snapshots__/Credentials-test.js.snap
@@ -32,17 +32,20 @@ Object {
   "payload": Object {
     "iat": 1485321133,
     "iss": "0x001122",
+    "sub": "did:uport:223ab45",
     "type": "attReq",
-    "unsignedClaims": Object {
-      "claim": Object {
-        "test": Object {
-          "prop1": 1,
-          "prop2": 2,
+    "unsignedClaims": Array [
+      Object {
+        "claim": Object {
+          "test": Object {
+            "prop1": 1,
+            "prop2": 2,
+          },
         },
       },
-    },
+    ],
   },
-  "signature": "5ATBwfBccgrenNemi5oLR3eFRNjWZATITAH-ujw5iPdPtaHd9i4jUuChyNxQj1VHvv41upuLY27VO9U5GbisJw",
+  "signature": "YM7DQRvh5vi4pLlWPJ5JHacmxJarnt2HhfYqwd0njEwwcYLsSMaK0yPFPDUqXwbdDdeLE7Sbc1ezbLm_Fw78TQ",
 }
 `;
 

--- a/dist/uport.js
+++ b/dist/uport.js
@@ -253,6 +253,34 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    /**
+	     *  Creates a signed request for the user to attest a list of claims.
+	     *
+	     *  @example
+	     *  const unsignedClaim = {
+	     *    claim: {
+	     *      "Citizen of city X": {
+	     *        "Allowed to vote": true,
+	     *        "Document": "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
+	     *      }
+	     *    },
+	     *    sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
+	     *  }
+	     *  credentials.createVerificationRequest(unsignedClaim).then(jwt => {
+	     *    ...
+	     *  })
+	     *
+	     *  @param    {Object}              unsignedClaim       an object that is an unsigned claim which you want the user to attest
+	     *  @param    {String}             sub                  the DID of the identity you want to sign the attestation
+	     *  @return   {Promise<Object, Error>}                  a promise which resolves with a signed JSON Web Token or rejects with an error
+	     */
+
+	  }, {
+	    key: 'createVerificationRequest',
+	    value: function createVerificationRequest(unsignedClaim, sub) {
+	      return (0, _JWT.createJWT)(this.settings, { unsignedClaim: unsignedClaim, sub: sub, type: 'verReq' });
+	    }
+
+	    /**
 	      *  Receive signed response token from mobile app. Verifies and parses the given response token.
 	      *
 	      *  @example

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -119,11 +119,12 @@ class Credentials {
  *    ...
  *  })
  *
- *  @param    {Array}              unsignedClaims      an array of unsigned claims which you want the user to attest
- *  @return   {Promise<Object, Error>}                   a promise which resolves with a signed JSON Web Token or rejects with an error
+ *  @param    {Array}              unsignedClaims       an array of unsigned claims which you want the user to attest
+ *  @param    {String}             sub                  the DID of the identity you want to sign the attestation
+ *  @return   {Promise<Object, Error>}                  a promise which resolves with a signed JSON Web Token or rejects with an error
  */
-  createAttestationRequest(unsignedClaims) {
-    return createJWT(this.settings, {unsignedClaims, type: 'attReq'})
+  createAttestationRequest(unsignedClaims, sub) {
+    return createJWT(this.settings, {unsignedClaims, sub, type: 'attReq'})
   }
 
 /**

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -90,7 +90,7 @@ class Credentials {
     if (params.network_id) {
       payload.net = params.network_id
     }
-    if (params.accountType 
+    if (params.accountType
           && ['general', 'segregated', 'keypair', 'devicekey', 'none'].indexOf(params.accountType) >= 0) {
       payload.act = params.accountType
     }
@@ -100,6 +100,30 @@ class Credentials {
       payload.exp = Math.floor(Date.now() / 1000) + 600
     }
     return createJWT(this.settings, {...payload, type: 'shareReq'})
+  }
+
+/**
+ *  Creates a signed request for the user to attest a list of claims.
+ *
+ *  @example
+ *  const unsignedClaims = [{
+ *    claim: {
+ *      "Citizen of city X": {
+ *        "Allowed to vote": true,
+ *        "Document": "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
+ *      }
+ *    },
+ *    sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
+ *  }]
+ *  credentials.createAttestationRequest(unsignedClaims).then(jwt => {
+ *    ...
+ *  })
+ *
+ *  @param    {Array}              unsignedClaims      an array of unsigned claims which you want the user to attest
+ *  @return   {Promise<Object, Error>}                   a promise which resolves with a signed JSON Web Token or rejects with an error
+ */
+  createAttestationRequest(unsignedClaims) {
+    return createJWT(this.settings, {unsignedClaims, type: 'attReq'})
   }
 
 /**

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -106,7 +106,7 @@ class Credentials {
  *  Creates a signed request for the user to attest a list of claims.
  *
  *  @example
- *  const unsignedClaims = [{
+ *  const unsignedClaim = {
  *    claim: {
  *      "Citizen of city X": {
  *        "Allowed to vote": true,
@@ -114,17 +114,17 @@ class Credentials {
  *      }
  *    },
  *    sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
- *  }]
- *  credentials.createAttestationRequest(unsignedClaims).then(jwt => {
+ *  }
+ *  credentials.createVerificationRequest(unsignedClaim).then(jwt => {
  *    ...
  *  })
  *
- *  @param    {Array}              unsignedClaims       an array of unsigned claims which you want the user to attest
+ *  @param    {Object}              unsignedClaim       an object that is an unsigned claim which you want the user to attest
  *  @param    {String}             sub                  the DID of the identity you want to sign the attestation
  *  @return   {Promise<Object, Error>}                  a promise which resolves with a signed JSON Web Token or rejects with an error
  */
-  createAttestationRequest(unsignedClaims, sub) {
-    return createJWT(this.settings, {unsignedClaims, sub, type: 'attReq'})
+  createVerificationRequest(unsignedClaim, sub) {
+    return createJWT(this.settings, {unsignedClaim, sub, type: 'verReq'})
   }
 
 /**


### PR DESCRIPTION
This PR adds a simple method for creating attestation requests.

However I think we need to update the [specs for this](https://github.com/uport-project/specs/pull/6) since the request does not specify which identity that should sign the request. So if the user has multiple accounts/identities it's unclear what will happen.