### PR TITLE
feat: jwt transaction requests

### DIFF
--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -803,6 +803,17 @@ Object {
 }
 `;
 
+exports[`txRequest() creates a valid JWT for a request 1`] = `
+Object {
+  "exp": 1485321733,
+  "fn": "updateStatus(string 'hello')",
+  "iat": 1485321133,
+  "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "to": "0x70A804cCE17149deB6030039798701a38667ca3B",
+  "type": "ethtx",
+}
+`;
+
 exports[`verifyProfile() returns profile mixing public and private claims 1`] = `
 Object {
   "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",


### PR DESCRIPTION
Notes: 

Rather than placing the contract object in credentials, contract could also consume a credentials object 

May need better way to set network, easy in connect, but not as much here