### PR TITLE
Backwards Compatibility, optional DID requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport",
-  "version": "0.7.0-alpha-minor-8",
+  "version": "0.7.0-alpha-minor-9",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport",
-  "version": "0.7.0-alpha-minor-9",
+  "version": "0.7.0-alpha-minor-12",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [
@@ -29,7 +29,7 @@
     "ethr-did-resolver": "^0.0.7",
     "mnid": "^0.1.1",
     "muport-did-resolver": "^0.1.0",
-    "uport-core": "0.0.36",
+    "uport-core": "^0.0.43",
     "uport-did-resolver": "^0.0.3",
     "uport-lite": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport",
-  "version": "0.7.0-alpha-5",
+  "version": "0.7.0-alpha-minor-5",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [
@@ -29,7 +29,8 @@
     "ethr-did-resolver": "^0.0.7",
     "mnid": "^0.1.1",
     "muport-did-resolver": "^0.1.0",
-    "uport-did-resolver": "^0.0.2",
+    "uport-core": "0.0.36",
+    "uport-did-resolver": "^0.0.3",
     "uport-lite": "^1.0.2"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport",
-  "version": "0.7.0-alpha-minor-5",
+  "version": "0.7.0-alpha-minor-8",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -244,7 +244,7 @@ async disclose (payload = {}, expiresIn = 600 ) {
 }
 
 async processDisclosurePayload ({doc, payload}) {
-  const credentials = {...doc.uportProfile || {}, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
+  const credentials = {...doc.uportProfile || {}, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.nad, did: payload.iss}
   if (payload.nad) {
     credentials.networkAddress = payload.nad
   }
@@ -256,8 +256,9 @@ async processDisclosurePayload ({doc, payload}) {
   try {
     if (doc.publicKey[0].publicKeyHex) credentials.publicKey = '0x' + doc.publicKey[0].publicKeyHex
     if (doc.publicKey[1].publicKeyBase64) credentials.publicEncKey = doc.publicKey[1].publicKeyBase64
-    if (!doc.publicKey[1].publicKeyBase64 & !!payload.publicEncKey) credentials.publicEncKey = payload.publicEncKey
   } catch (err) {}
+
+  if (!credentials.publicEncKey) credentials.publicEncKey = payload.publicEncKey
 
   if (payload.verified) {
     const verified = await Promise.all(payload.verified.map(token => verifyJWT(token, {audience: this.givenDID ? this.did : this.address})))

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -209,6 +209,7 @@ class Credentials {
 *  @return   {Promise<Object, Error>}                     a promise which resolves with successful status or rejects with an error
 */
 push (token, pubEncKey, payload) {
+  // TODO remove url once
   return transport.push.send(token, pubEncKey)(payload.url, {message: payload.message})
 }
 
@@ -254,6 +255,7 @@ async processDisclosurePayload ({doc, payload}) {
   try {
     if (doc.publicKey[0].publicKeyHex) credentials.publicKey = '0x' + doc.publicKey[0].publicKeyHex
     if (doc.publicKey[1].publicKeyBase64) credentials.publicEncKey = doc.publicKey[1].publicKeyBase64
+    if (!doc.publicKey[1].publicKeyBase64 & !!payload.publicEncKey) credentials.publicEncKey = payload.publicEncKey
   } catch (err) {}
 
   if (payload.verified) {

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -209,8 +209,9 @@ class Credentials {
 *  @return   {Promise<Object, Error>}                     a promise which resolves with successful status or rejects with an error
 */
 push (token, pubEncKey, payload) {
-  // TODO remove url once
-  return transport.push.send(token, pubEncKey)(payload.url, {message: payload.message})
+  const iss = decodeJWT(token).payload.iss
+  const pushUrl = iss.match(/did/) ? 'https://api.uport.me/pututu/sns' : 'https://pututu.uport.space/api/v2/sns'
+  return transport.push.send(token, pubEncKey, pushUrl)(payload.url, {message: payload.message})
 }
 
 /**

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -1,4 +1,4 @@
-import { createJWT, verifyJWT, SimpleSigner } from 'did-jwt'
+import { createJWT, verifyJWT, SimpleSigner, decodeJWT } from 'did-jwt'
 import UportLite from 'uport-lite'
 const MNID = require('mnid')
 import UportDIDResolver from 'uport-did-resolver'
@@ -7,6 +7,7 @@ import EthrDIDResolver from 'ethr-did-resolver'
 import { toEthereumAddress } from 'did-jwt/lib/Digest'
 import { ec as EC } from 'elliptic'
 import { ContractFactory } from './Contract.js'
+import { transport } from 'uport-core'
 const secp256k1 = new EC('secp256k1')
 /**
 *    The Credentials class allows you to easily create the signed payloads used in uPort inlcuding
@@ -80,11 +81,15 @@ class Credentials {
       this.signer = signer
     } else if (privateKey) {
       this.signer = SimpleSigner(privateKey)
-
     }
+
+    this.givenDID = false
+
     if (did) {
       this.did = did
+      this.givenDID = true
     } else if (address) {
+      this.address = address
       if (MNID.isMNID(address)) {
         this.did = `did:uport:${address}`
       }
@@ -97,7 +102,7 @@ class Credentials {
       this.did = `did:ethr:${address}`
     }
 
-    this.signJWT = (payload, expiresIn) => createJWT(payload, {issuer: this.did, signer: this.signer, alg: this.did.match('^did:uport:') ? 'ES256K' : 'ES256K-R', expiresIn })
+    this.signJWT = (payload, expiresIn) => createJWT(payload, {issuer: this.givenDID ? this.did : this.address, signer: this.signer, alg: this.did.match('^did:uport:') ? 'ES256K' : 'ES256K-R', expiresIn })
 
     UportDIDResolver(registry || UportLite({networks: networks ? configNetworks(networks) : {}}))
     EthrDIDResolver(ethrConfig || {})
@@ -193,6 +198,21 @@ class Credentials {
   }
 
 /**
+*  Send a push notification to a user, consumes a token which allows you to send push notifications
+*  and a url/uri request you want to send to the user.
+*
+*  @param    {String}                  token              a push notification token (get a pn token by requesting push permissions in a request)
+*  @param    {Object}                  payload            push notification payload
+*  @param    {String}                  payload.url        a uport request url
+*  @param    {String}                  payload.message    a message to display to the user
+*  @param    {String}                  pubEncKey          the public encryption key of the receiver, encoded as a base64 string
+*  @return   {Promise<Object, Error>}                     a promise which resolves with successful status or rejects with an error
+*/
+push (token, pubEncKey, payload) {
+  return transport.push.send(token, pubEncKey)(payload.url, {message: payload.message})
+}
+
+/**
  * Creates a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
  *
  * This can either be used to share information about the signing identity or as the response to a
@@ -229,8 +249,15 @@ async processDisclosurePayload ({doc, payload}) {
   if (payload.dad) {
     credentials.deviceKey = payload.dad
   }
+
+  // Backwards support
+  try {
+    if (doc.publicKey[0].publicKeyHex) credentials.publicKey = '0x' + doc.publicKey[0].publicKeyHex
+    if (doc.publicKey[1].publicKeyBase64) credentials.publicEncKey = doc.publicKey[1].publicKeyBase64
+  } catch (err) {}
+
   if (payload.verified) {
-    const verified = await Promise.all(payload.verified.map(token => verifyJWT(token, {audience: this.did})))
+    const verified = await Promise.all(payload.verified.map(token => verifyJWT(token, {audience: this.givenDID ? this.did : this.address})))
     return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
   } else {
     return credentials
@@ -256,7 +283,7 @@ async processDisclosurePayload ({doc, payload}) {
   *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
   */
   async authenticate (token, callbackUrl = null) {
-    const { payload, doc } = await verifyJWT(token, {audience: this.did, callbackUrl, auth: true})
+    const { payload, doc } = await verifyJWT(token, {audience: this.givenDID ? this.did : this.address, callbackUrl, auth: true})
 
     if(payload.req) {
       const challenge = await verifyJWT(payload.req)
@@ -312,7 +339,7 @@ async processDisclosurePayload ({doc, payload}) {
   *  @deprecated
   */
   receive (token, callbackUrl = null) {
-    return this.authenticate(token, callbackUrl)
+    return decodeJWT(token).req ? this.authenticate(token, callbackUrl) : this.verifyProfile(token, callbackUrl)
   }
 
   /**
@@ -332,8 +359,8 @@ async processDisclosurePayload ({doc, payload}) {
   *  @param    {String}                  token                 a response token
   *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
   */
- async verifyProfile (token) {
-  const { payload, doc } = await verifyJWT(token, {audience: this.did})
+ async verifyProfile (token, callbackUrl = null) {
+  const { payload, doc } = await verifyJWT(token, {audience: this.givenDID ? this.did : this.address, callbackUrl})
   return this.processDisclosurePayload({ payload, doc })
  }
 
@@ -402,22 +429,22 @@ async processDisclosurePayload ({doc, payload}) {
     return this.signJWT({...payload, ...txObj, type: 'ethtx'}, exp )
   }
 
-// /**
-//   *  Look up a profile in the registry for a given uPort address. Address must be MNID encoded.
-//   *
-//   *  @example
-//   *  credentials.lookup('5A8bRWU3F7j3REx3vkJ...').then(profile => {
-//   *     const name = profile.name
-//   *     const pubkey = profile.pubkey
-//   *     ...
-//   *   })
-//   *
-//   * @param    {String}            address             a MNID encoded address
-//   * @return   {Promise<Object, Error>}                a promise which resolves with parsed profile or rejects with an error
-//   */
-//   lookup (address) {
-//     return this.settings.registry(address)
-//   }
+/**
+  *  Look up a profile in the registry for a given uPort address. Address must be MNID encoded.
+  *
+  *  @example
+  *  credentials.lookup('5A8bRWU3F7j3REx3vkJ...').then(profile => {
+  *     const name = profile.name
+  *     const pubkey = profile.pubkey
+  *     ...
+  *   })
+  *
+  * @param    {String}            address             a MNID encoded address
+  * @return   {Promise<Object, Error>}                a promise which resolves with parsed profile or rejects with an error
+  */
+  lookup (address) {
+    return this.settings.registry(address)
+  }
 }
 
 const configNetworks = (nets) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,14 @@
 import Credentials from './Credentials'
-import { SimpleSigner } from 'did-jwt'
+import { SimpleSigner, createJWT, verifyJWT } from 'did-jwt'
 import { Contract, ContractFactory } from './Contract'
-module.exports = { Credentials, SimpleSigner, Contract, ContractFactory }
+import UportDIDResolver from 'uport-did-resolver'
+
+const createJWTWrap = ({address, signer}, payload) => createJWT(payload, {issuer: address, signer})
+
+const verifyJWTWrap = ({registry, address}, jwt, callbackUrl = null) => {
+  if (registry) UportDIDResolver(registry)
+  return verifyJWT(jwt, {callbackUrl, audience: address})
+}
+const JWT = { createJWT: createJWTWrap , verifyJWT: verifyJWTWrap }
+
+module.exports = { Credentials, SimpleSigner, Contract, ContractFactory, JWT }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,7 +1290,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.5:
+buffer@^5.0.5, buffer@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
   dependencies:
@@ -2064,6 +2064,21 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
+did-jwt@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-0.0.8.tgz#2e20557220821a71ad7849499114086e9f820c9a"
+  dependencies:
+    babel-runtime "^6.26.0"
+    base64url "^2.0.0"
+    buffer "^5.1.0"
+    did-resolver "^0.0.4"
+    elliptic "^6.4.0"
+    js-sha256 "^0.9.0"
+    js-sha3 "^0.7.0"
+    mnid "^0.1.1"
+    uport-did-resolver "^0.0.2"
+    uport-lite "^1.0.2"
+
 did-jwt@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-0.0.7.tgz#f38a4f24154f20c084bd17810970be9f91b9530c"
@@ -2116,6 +2131,10 @@ dmd@^1.4.1:
     stream-handlebars "~0.1.6"
     string-tools "^1.0.0"
     walk-back "^2.0.1"
+
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -2732,6 +2751,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+for-each@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2927,6 +2952,13 @@ global-prefix@^1.0.1:
     ini "^1.3.4"
     is-windows "^1.0.1"
     which "^1.2.14"
+
+global@~4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -3468,6 +3500,10 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-function@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -4581,6 +4617,12 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -4755,6 +4797,13 @@ negotiator@0.6.1:
 neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
+
+nets@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nets/-/nets-3.2.0.tgz#d511fbab7af11da013f21b97ee91747d33852d38"
+  dependencies:
+    request "^2.65.0"
+    xhr "^2.1.0"
 
 nice-try@^1.0.4:
   version "1.0.4"
@@ -5152,6 +5201,13 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
+parse-headers@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.1.tgz#6ae83a7aa25a9d9b700acc28698cd1f1ed7e9536"
+  dependencies:
+    for-each "^0.3.2"
+    trim "0.0.1"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -5324,6 +5380,10 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -5390,9 +5450,17 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
+qr-image@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/qr-image/-/qr-image-3.2.0.tgz#9fa8295beae50c4a149cf9f909a1db464a8672e8"
+
 qs@6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+qs@^6.2.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 query-string@^5.0.1:
   version "5.1.1"
@@ -5661,6 +5729,31 @@ request-promise-native@^1.0.5:
     request-promise-core "1.1.1"
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
+
+request@^2.65.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 request@^2.83.0:
   version "2.85.0"
@@ -6503,6 +6596,10 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -6512,6 +6609,10 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
+
+tweetnacl-util@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz#4576c1cee5e2d63d207fee52f1ba02819480bc75"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -6633,6 +6734,19 @@ upath@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
 
+uport-core@0.0.36:
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/uport-core/-/uport-core-0.0.36.tgz#7332f0bdd0b949ded475b65a63312b39c6d18078"
+  dependencies:
+    async "^2.6.0"
+    did-jwt "0.0.8"
+    mnid "^0.1.1"
+    nets "^3.2.0"
+    qr-image "^3.1.0"
+    qs "^6.2.1"
+    tweetnacl-util "^0.15.0"
+    uport-registry "^5.1.0"
+
 uport-did-resolver@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/uport-did-resolver/-/uport-did-resolver-0.0.2.tgz#b1e9deec8bf5d08d101d078ea876aa09ac727cce"
@@ -6647,6 +6761,10 @@ uport-lite@^1.0.2:
   dependencies:
     base-x "^3.0.0"
     xmlhttprequest "^1.8.0"
+
+uport-registry@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/uport-registry/-/uport-registry-5.1.0.tgz#2f310ce0d154f07450453d559e3cf3da3114794c"
 
 uri-js@^3.0.2:
   version "3.0.2"
@@ -7007,6 +7125,15 @@ ws@^4.0.0:
 xhr2@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.1.3.tgz#cbfc4759a69b4a888e78cf4f20b051038757bd11"
+
+xhr@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.5.0.tgz#bed8d1676d5ca36108667692b74b316c496e49dd"
+  dependencies:
+    global "~4.3.0"
+    is-function "^1.0.1"
+    parse-headers "^2.0.0"
+    xtend "^4.0.0"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
A possible release to support uport clients without any DID support. Can easily be added to uport-connect as well to make that a backwards compatible release as well. 

- pass currents tests, but should be tested against some tests in develop to ensure backwards compatibility 
- parse response still differ a bit, may need to change that 
- receive does not match past functionality, token which use to pass not fail 