### PR TITLE
Method name changes, tests, README updates

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,134 +1,54 @@
-## Modules
-
-<dl>
-<dt><a href="#module_uport-js/JWT">uport-js/JWT</a></dt>
-<dd></dd>
-</dl>
-
-## Classes
-
-<dl>
-<dt><a href="#Credentials">Credentials</a></dt>
-<dd><p>The Credentials class allows you to easily create the signed payloads used in uPort inlcuding
-   credentials and signed mobile app requests (ex. selective disclosure requests
-   for private data). It also provides signature verification over signed payloads and
-   allows you to send push notifications to users.</p>
-</dd>
-</dl>
-
-<a name="module_uport-js/JWT"></a>
-
-## uport-js/JWT
-
-* [uport-js/JWT](#module_uport-js/JWT)
-    * [.createJWT([config], payload)](#module_uport-js/JWT.createJWT) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-    * [.verifyJWT([config], jwt, callbackUrl)](#module_uport-js/JWT.verifyJWT) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-
-<a name="module_uport-js/JWT.createJWT"></a>
-
-### uport-js/JWT.createJWT([config], payload) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-Creates a signed JWT given an address which becomes the issuer, a signer, and a payload for which the signature is over.
-
-**Kind**: static method of <code>[uport-js/JWT](#module_uport-js/JWT)</code>  
-**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a signed JSON Web Token or rejects with an error  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| [config] | <code>Object</code> | an unsigned credential object |
-| config.address | <code>String</code> | address, typically the uPort address of the signer which becomes the issuer |
-| config.signer | <code>SimpleSigner</code> | a signer, reference our SimpleSigner.js |
-| payload | <code>Object</code> | payload object |
-
-**Example**  
-```js
-const signer = SimpleSigner(process.env.PRIVATE_KEY)
- createJWT({address: '5A8bRWU3F7j3REx3vkJ...', signer}, {key1: 'value', key2: ..., ... }).then(jwt => {
-     ...
- })
-
- 
-```
-<a name="module_uport-js/JWT.verifyJWT"></a>
-
-### uport-js/JWT.verifyJWT([config], jwt, callbackUrl) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-Verifies given JWT. Registry is used to resolve uPort address to public key for verification.
- If the JWT is valid, the promise returns an object including the JWT, the payload of the JWT,
- and the profile of the issuer of the JWT.
-
-**Kind**: static method of <code>[uport-js/JWT](#module_uport-js/JWT)</code>  
-**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a response object or rejects with an error  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| [config] | <code>Object</code> | an unsigned credential object |
-| config.address | <code>String</code> | address, typically the uPort address of the signer which becomes the issuer |
-| config.registry | <code>UportLite</code> | a uPort registry, reference our uport-lite library |
-| jwt | <code>String</code> | a JSON Web Token to verify |
-| callbackUrl | <code>String</code> | callback url in JWT |
-
-**Example**  
-```js
-const registry =  new UportLite()
- verifyJWT({registry, address: '5A8bRWU3F7j3REx3vkJ...'}, 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....').then(obj => {
-     const payload = obj.payload
-     const profile = obj.profile
-     const jwt = obj.jwt
-     ...
- })
-
- 
-```
 <a name="Credentials"></a>
 
 ## Credentials
-The Credentials class allows you to easily create the signed payloads used in uPort inlcuding
-   credentials and signed mobile app requests (ex. selective disclosure requests
-   for private data). It also provides signature verification over signed payloads and
-   allows you to send push notifications to users.
+The Credentials class allows you to easily create the signed payloads used in uPort including
+credentials and signed mobile app requests (ex. selective disclosure requests
+for private data). It also provides signature verification over signed payloads.
 
 **Kind**: global class  
 
 * [Credentials](#Credentials)
     * [new Credentials([settings])](#new_Credentials_new)
-    * [.createRequest([params])](#Credentials+createRequest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-    * [.createVerificationRequest(unsignedClaim, sub)](#Credentials+createVerificationRequest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-    * [.receive(token, [callbackUrl])](#Credentials+receive) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-    * [.push(token, payload, pubEncKey)](#Credentials+push) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-    * [.attest([credential])](#Credentials+attest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-    * [.lookup(address)](#Credentials+lookup) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+    * _instance_
+        * [.createDisclosureRequest([params], expiresIn)](#Credentials+createDisclosureRequest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+        * [.createVerification([credential])](#Credentials+createVerification) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+        * [.createSignVerificationRequest(unsignedClaim, aud, sub, callbackUrl)](#Credentials+createSignVerificationRequest) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+        * [.createTxRequest(txObj, [id])](#Credentials+createTxRequest) ⇒ <code>String</code>
+        * [.createDisclosureResponse([payload])](#Credentials+createDisclosureResponse) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+        * [.processDisclosurePayload(response)](#Credentials+processDisclosurePayload)
+        * [.verifyAuthentication(token, [callbackUrl])](#Credentials+verifyAuthentication) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+        * ~~[.receive(token, [callbackUrl])](#Credentials+receive) ⇒ <code>Promise.&lt;Object, Error&gt;</code>~~
+        * [.verifyProfile(token)](#Credentials+verifyProfile) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+        * [.contract(abi)](#Credentials+contract) ⇒ <code>Object</code>
+    * _static_
+        * [.createIdentity()](#Credentials.createIdentity) ⇒ <code>Object</code>
 
 <a name="new_Credentials_new"></a>
 
 ### new Credentials([settings])
 Instantiates a new uPort Credentials object
 
+The following example is just for testing purposes. *You should never store a private key in source code.*
+
 
 | Param | Type | Description |
 | --- | --- | --- |
 | [settings] | <code>Object</code> | setttings |
-| settings.networks | <code>Object</code> | networks config object, ie. {  '0x94365e3b': { rpcUrl: 'https://private.chain/rpc', address: '0x0101.... }} |
-| settings.registry | <code>UportLite</code> | a registry object from UportLite |
-| settings.signer | <code>SimpleSigner</code> | a signer object, see SimpleSigner.js |
-| settings.address | <code>Address</code> | your uPort address (may be the address of your application's uPort identity) |
+| settings.did | <code>DID</code> | Application [DID](https://w3c-ccg.github.io/did-spec/#decentralized-identifiers-dids) (unique identifier) for your application |
+| settings.privateKey | <code>String</code> | A hex encoded 32 byte private key |
+| settings.signer | <code>SimpleSigner</code> | a signer object, see [Signer Functions](https://github.com/uport-project/did-jwt#signer-functions) |
+| settings.ethrConfig | <code>Object</code> | Configuration object for ethr did resolver. See [ethr-did-resolver](https://github.com/uport-project/ethr-did-resolver) |
+| settings.muportConfig | <code>Object</code> | Configuration object for muport did resolver. See [muport-did-resolver](https://github.com/uport-project/muport-did-resolver) |
+| settings.address | <code>Address</code> | DEPRECATED your uPort address (may be the address of your application's uPort identity) |
+| settings.networks | <code>Object</code> | DEPRECATED networks config object, ie. {  '0x94365e3b': { rpcUrl: 'https://private.chain/rpc', address: '0x0101.... }} |
+| settings.registry | <code>UportLite</code> | DEPRECATED a registry object from UportLite |
 
-**Example**  
-```js
-import { Credentials, SimpleSigner } from 'uport-credentials'
-const networks = {  '0x94365e3b': { rpcUrl: 'https://private.chain/rpc', registry: '0x0101.... }}
-const setttings = { networks, address: '5A8bRWU3F7j3REx3vkJ...', signer: new SimpleSigner(process.env.PRIVATE_KEY)}
-const credentials = new Credentials(settings)
-```
-**Example**  
-```js
-import { Credentials } from 'uport-credentials'
-const credentials = new Credentials()
-```
-<a name="Credentials+createRequest"></a>
+<a name="Credentials+createDisclosureRequest"></a>
 
-### credentials.createRequest([params]) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-Creates a signed request token (JWT) given a request params object.
+### credentials.createDisclosureRequest([params], expiresIn) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+Creates a [Selective Disclosure Request JWT](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md)
 
-**Kind**: instance method of <code>[Credentials](#Credentials)</code>  
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
 **Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a signed JSON Web Token or rejects with an error  
 
 | Param | Type | Default | Description |
@@ -140,100 +60,25 @@ Creates a signed request token (JWT) given a request params object.
 | params.callbackUrl | <code>String</code> |  | the url which you want to receive the response of this request |
 | params.network_id | <code>String</code> |  | network id of Ethereum chain of identity eg. 0x4 for rinkeby |
 | params.accountType | <code>String</code> |  | Ethereum account type: "general", "segregated", "keypair", "devicekey" or "none" |
+| expiresIn | <code>Number</code> |  | Seconds until expiry |
 
 **Example**  
 ```js
 const req = { requested: ['name', 'country'],
                callbackUrl: 'https://myserver.com',
                notifications: true }
- credentials.createRequest(req).then(jwt => {
-     ...
- })
-
-
- requested: ['name','phone','identity_no'],
-    callbackUrl: 'https://....' // URL to send the response of the request to
-    notifications: true
-
- 
-```
-<a name="Credentials+createVerificationRequest"></a>
-
-### credentials.createVerificationRequest(unsignedClaim, sub) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-Creates a signed request for the user to attest a list of claims.
-
-**Kind**: instance method of <code>[Credentials](#Credentials)</code>  
-**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a signed JSON Web Token or rejects with an error  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| unsignedClaim | <code>Object</code> | an object that is an unsigned claim which you want the user to attest |
-| sub | <code>String</code> | the DID of the identity you want to sign the attestation |
-
-**Example**  
-```js
-const unsignedClaim = {
-   claim: {
-     "Citizen of city X": {
-       "Allowed to vote": true,
-       "Document": "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
-     }
-   },
-   sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
- }
- credentials.createVerificationRequest(unsignedClaim).then(jwt => {
-   ...
- })
-
- 
-```
-<a name="Credentials+receive"></a>
-
-### credentials.receive(token, [callbackUrl]) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-Receive signed response token from mobile app. Verifies and parses the given response token.
-
-**Kind**: instance method of <code>[Credentials](#Credentials)</code>  
-**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a parsed response or rejects with an error.  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| token | <code>String</code> |  | a response token |
-| [callbackUrl] | <code>String</code> | <code></code> | callbackUrl |
-
-**Example**  
-```js
-const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
- credentials.receive(resToken).then(res => {
-     const credentials = res.verified
-         const name =  res.name
+ credentials.requestDisclosure(req).then(jwt => {
      ...
  })
 
  
 ```
-<a name="Credentials+push"></a>
+<a name="Credentials+createVerification"></a>
 
-### credentials.push(token, payload, pubEncKey) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-Send a push notification to a user, consumes a token which allows you to send push notifications
- and a url/uri request you want to send to the user.
-
-**Kind**: instance method of <code>[Credentials](#Credentials)</code>  
-**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with successful status or rejects with an error  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| token | <code>String</code> | a push notification token (get a pn token by requesting push permissions in a request) |
-| payload | <code>Object</code> | push notification payload |
-| payload.url | <code>String</code> | a uport request url |
-| payload.message | <code>String</code> | a message to display to the user |
-| pubEncKey | <code>String</code> | the public encryption key of the receiver, encoded as a base64 string |
-
-<a name="Credentials+attest"></a>
-
-### credentials.attest([credential]) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+### credentials.createVerification([credential]) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
 Create a credential (a signed JSON Web Token)
 
-**Kind**: instance method of <code>[Credentials](#Credentials)</code>  
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
 **Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a credential (JWT) or rejects with an error  
 
 | Param | Type | Description |
@@ -253,23 +98,209 @@ credentials.attest({
   ...
  })
 ```
-<a name="Credentials+lookup"></a>
+<a name="Credentials+createSignVerificationRequest"></a>
 
-### credentials.lookup(address) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
-Look up a profile in the registry for a given uPort address. Address must be MNID encoded.
+### credentials.createSignVerificationRequest(unsignedClaim, aud, sub, callbackUrl) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+Creates a signed request for the user to attest a list of claims.
 
-**Kind**: instance method of <code>[Credentials](#Credentials)</code>  
-**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with parsed profile or rejects with an error  
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a signed JSON Web Token or rejects with an error  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| address | <code>String</code> | a MNID encoded address |
+| unsignedClaim | <code>Object</code> | an object that is an unsigned claim which you want the user to attest |
+| aud | <code>String</code> | the DID of the identity you want to sign the attestation |
+| sub | <code>String</code> | the DID which the unsigned claim is about |
+| callbackUrl | <code>String</code> | the url which you want to receive the response of this request |
 
 **Example**  
 ```js
-credentials.lookup('5A8bRWU3F7j3REx3vkJ...').then(profile => {
-    const name = profile.name
-    const pubkey = profile.pubkey
-    ...
-  })
+const unsignedClaim = {
+   claim: {
+     "Citizen of city X": {
+       "Allowed to vote": true,
+       "Document": "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
+     }
+   },
+   sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
+ }
+ credentials.createVerificationRequest(unsignedClaim).then(jwt => {
+   ...
+ })
+
+ 
+```
+<a name="Credentials+createTxRequest"></a>
+
+### credentials.createTxRequest(txObj, [id]) ⇒ <code>String</code>
+Given a transaction object, similarly defined as the web3 transaction object,
+ it creates a JWT transaction request and appends addtional request options.
+
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>String</code> - a transaction request jwt  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| txObj | <code>Object</code> |  |  |
+| [id] | <code>String</code> | <code>&#x27;addressReq&#x27;</code> | string to identify request, later used to get response |
+
+**Example**  
+```js
+const txobject = {
+   to: '0xc3245e75d3ecd1e81a9bfb6558b6dafe71e9f347',
+   value: '0.1',
+   fn: "setStatus(string 'hello', bytes32 '0xc3245e75d3ecd1e81a9bfb6558b6dafe71e9f347')",
+ }
+ connect.createTxRequest(txObject, {callbackUrl: 'http://mycb.domain'}).then(jwt => {
+   ...
+ })
+
+ 
+```
+<a name="Credentials+createDisclosureResponse"></a>
+
+### credentials.createDisclosureResponse([payload]) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+Creates a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
+
+This can either be used to share information about the signing identity or as the response to a
+[Selective Disclosure Flow](https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md), where it can be used to verifyAuthentication the identity.
+
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a signed JSON Web Token or rejects with an error  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [payload] | <code>Object</code> | <code>{}</code> | request params object |
+| payload.req | <code>JWT</code> |  | A selective disclosure Request JWT if this is returned as part of an authentication flow |
+| payload.own | <code>Object</code> |  | An object of self attested claims about the signer (eg. name etc) |
+| payload.verified | <code>Array</code> |  | An array of attestation JWT's to include |
+| payload.nad | <code>MNID</code> |  | An ethereum address encoded as an [MNID](https://github.com/uport-project/mnid) |
+| payload.capabilities | <code>Array</code> |  | An array of capability JWT's to include |
+
+**Example**  
+```js
+credentials.createDisclosureResponse({own: {name: 'Lourdes Valentina Gomez'}}).then(jwt => {
+     ...
+ })
+
+ 
+```
+<a name="Credentials+processDisclosurePayload"></a>
+
+### credentials.processDisclosurePayload(response)
+Parse a selective disclosure response, and verify signatures on each included signed claim ("verification")
+
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| response | <code>Object</code> | A selective disclosure response payload, with associated did doc |
+| response.doc | <code>Object</code> |  |
+
+<a name="Credentials+verifyAuthentication"></a>
+
+### credentials.verifyAuthentication(token, [callbackUrl]) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+Authenticates [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md) from mobile
+ app as part of the [Selective Disclosure Flow](https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md).
+
+ It Verifies and parses the given response token and verifies the challenge response flow.
+
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a parsed response or rejects with an error.  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| token | <code>String</code> |  | a response token |
+| [callbackUrl] | <code>String</code> | <code></code> | callbackUrl |
+
+**Example**  
+```js
+const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
+ credentials.verifyAuthentication(resToken).then(res => {
+     const credentials = res.verified
+      const name =  res.name
+     ...
+ })
+
+ 
+```
+<a name="Credentials+receive"></a>
+
+### ~~credentials.receive(token, [callbackUrl]) ⇒ <code>Promise.&lt;Object, Error&gt;</code>~~
+***Deprecated***
+
+Receive signed response token from mobile app. Verifies and parses the given response token.
+
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a parsed response or rejects with an error.  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| token | <code>String</code> |  | a response token |
+| [callbackUrl] | <code>String</code> | <code></code> | callbackUrl |
+
+**Example**  
+```js
+const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
+ credentials.receive(resToken).then(res => {
+     const credentials = res.verified
+     const name =  res.name
+     ...
+ })
+
+ 
+```
+<a name="Credentials+verifyProfile"></a>
+
+### credentials.verifyProfile(token) ⇒ <code>Promise.&lt;Object, Error&gt;</code>
+Verify and return profile from a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
+
+ The main difference between this and `verifyAuthentication()` is that it does not verify the challenge. This can be used to verify user profiles that have been shared
+ through other methods such as QR codes and messages.
+
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a parsed response or rejects with an error.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| token | <code>String</code> | a response token |
+
+**Example**  
+```js
+const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
+ credentials.verifyProfile(resToken).then(profile => {
+     const credentials = profile.verified
+     const name =  profile.name
+     ...
+ })
+
+ 
+```
+<a name="Credentials+contract"></a>
+
+### credentials.contract(abi) ⇒ <code>Object</code>
+Builds and returns a contract object which can be used to interact with
+ a given contract. Similar to web3.eth.contract but with promises. Once specifying .at(address)
+ you can call the contract functions with this object. Each call will create a request.
+
+**Kind**: instance method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>Object</code> - contract object  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| abi | <code>Object</code> | contract ABI |
+
+<a name="Credentials.createIdentity"></a>
+
+### Credentials.createIdentity() ⇒ <code>Object</code>
+Generate a DID and private key, effectively creating a new identity that can sign and verify data
+
+**Kind**: static method of [<code>Credentials</code>](#Credentials)  
+**Returns**: <code>Object</code> - keypair
+          - {String} keypair.did         An ethr-did string for the new identity
+          - {String} keypair.privateKey  The identity's private key, as a string  
+**Example**  
+```js
+const {did, privateKey} = Credentials.createIdentity()
+const credentials = new Credentials({did, privateKey, ...})
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -385,23 +385,6 @@
         "acorn": "5.7.1"
       }
     },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -436,15 +419,6 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
-    },
-    "ansi-escape-sequences": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
-      "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4"
-      }
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -481,20 +455,6 @@
         "normalize-path": "2.1.1"
       }
     },
-    "app-usage-stats": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/app-usage-stats/-/app-usage-stats-0.4.1.tgz",
-      "integrity": "sha1-l+ubibVnj6LdyXk7EphijMIYQp8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "home-path": "1.0.6",
-        "test-value": "2.1.0",
-        "usage-stats": "0.8.6"
-      }
-    },
     "append-transform": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
@@ -517,6 +477,47 @@
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
+      }
+    },
+    "argv-tools": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
+      "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
+      "dev": true,
+      "requires": {
+        "array-back": "2.0.0",
+        "find-replace": "2.0.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "dev": true,
+          "requires": {
+            "typical": "2.6.1"
+          }
+        },
+        "find-replace": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "test-value": "3.0.0"
+          }
+        },
+        "test-value": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "typical": "2.6.1"
+          }
+        }
       }
     },
     "arr-diff": {
@@ -567,28 +568,6 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
-    "array-tools": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-      "integrity": "sha1-FFdx9/nJTpjMXqQZapm4MjruGK4=",
-      "dev": true,
-      "requires": {
-        "object-tools": "1.6.7",
-        "typical": "2.6.1"
-      },
-      "dependencies": {
-        "object-tools": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-          "dev": true,
-          "requires": {
-            "array-tools": "1.8.6",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -614,12 +593,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -2070,19 +2043,6 @@
         }
       }
     },
-    "cache-point": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.4.tgz",
-      "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "fs-then-native": "1.0.2",
-        "mkdirp": "0.5.1"
-      }
-    },
     "cacheable-request": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
@@ -2262,18 +2222,6 @@
         }
       }
     },
-    "cli-commands": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cli-commands/-/cli-commands-0.1.0.tgz",
-      "integrity": "sha1-xXysxAa7z57iFkZgcWHtQy71oFo=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "command-line-args": "3.0.5",
-        "command-line-commands": "1.0.4",
-        "command-line-usage": "3.0.8"
-      }
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -2415,46 +2363,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "collect-all": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
-      "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
-      "dev": true,
-      "requires": {
-        "stream-connect": "1.0.2",
-        "stream-via": "0.1.1",
-        "typical": "2.6.1"
-      }
-    },
-    "collect-json": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-      "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
-      "dev": true,
-      "requires": {
-        "collect-all": "1.0.3",
-        "stream-connect": "1.0.2",
-        "stream-via": "1.0.4"
-      },
-      "dependencies": {
-        "collect-all": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-          "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
-          "dev": true,
-          "requires": {
-            "stream-connect": "1.0.2",
-            "stream-via": "1.0.4"
-          }
-        },
-        "stream-via": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-          "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-          "dev": true
-        }
-      }
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2486,74 +2394,6 @@
       "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
       "dev": true
     },
-    "column-layout": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
-      "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-back": "1.0.4",
-        "collect-json": "1.0.8",
-        "command-line-args": "2.1.6",
-        "core-js": "2.5.7",
-        "deep-extend": "0.4.2",
-        "feature-detect-es6": "1.4.1",
-        "object-tools": "2.0.6",
-        "typical": "2.6.1",
-        "wordwrapjs": "1.2.1"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-all": "0.2.1"
-          }
-        },
-        "command-line-args": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "command-line-usage": "2.0.5",
-            "core-js": "2.5.7",
-            "feature-detect-es6": "1.4.1",
-            "find-replace": "1.0.3",
-            "typical": "2.6.1"
-          }
-        },
-        "command-line-usage": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "column-layout": "2.1.4",
-            "feature-detect-es6": "1.4.1",
-            "typical": "2.6.1",
-            "wordwrapjs": "1.2.1"
-          }
-        },
-        "wordwrapjs": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
-          "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
     "combined-stream": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
@@ -2561,67 +2401,6 @@
       "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
-      }
-    },
-    "command-line-args": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
-      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
-      }
-    },
-    "command-line-commands": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-1.0.4.tgz",
-      "integrity": "sha1-A0+bFntRiK+9z2su+7FQ/IRCwys=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1"
-      }
-    },
-    "command-line-tool": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
-      "integrity": "sha1-+H1pd/VrvdLV38+UY0XdLNnGpTo=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-back": "1.0.4",
-        "command-line-args": "3.0.5",
-        "command-line-usage": "3.0.8",
-        "feature-detect-es6": "1.4.1",
-        "typical": "2.6.1"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-all": "0.2.1"
-          }
-        }
-      }
-    },
-    "command-line-usage": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
-      "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1",
-        "table-layout": "0.3.0",
-        "typical": "2.6.1"
       }
     },
     "commander": {
@@ -2669,17 +2448,6 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
-      }
-    },
-    "config-master": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/config-master/-/config-master-2.0.4.tgz",
-      "integrity": "sha1-50lQXF0/lG8vrTx23+cfymiXUdw=",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "6.26.0",
-        "feature-detect-es6": "1.4.1",
-        "walk-back": "2.0.1"
       }
     },
     "console-browserify": {
@@ -2888,75 +2656,6 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
-    "ddata": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/ddata/-/ddata-0.1.28.tgz",
-      "integrity": "sha1-UxOPr6PwF0nqJFHRK2tt2d8dWx8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "handlebars": "3.0.3",
-        "marked": "0.3.19",
-        "object-get": "2.1.0",
-        "reduce-flatten": "1.0.1",
-        "string-tools": "1.0.0",
-        "test-value": "2.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "handlebars": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-          "dev": true,
-          "requires": {
-            "optimist": "0.6.1",
-            "source-map": "0.1.43",
-            "uglify-js": "2.3.6"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wordwrap": "0.0.3"
-              }
-            }
-          }
-        }
-      }
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2987,12 +2686,6 @@
         "mimic-response": "1.0.0"
       }
     },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3015,12 +2708,6 @@
           "dev": true
         }
       }
-    },
-    "defer-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defer-promise/-/defer-promise-1.0.1.tgz",
-      "integrity": "sha1-HKb/7dvO8XFd16riXHYW+a4iky8=",
-      "dev": true
     },
     "define-properties": {
       "version": "1.1.2",
@@ -3200,30 +2887,6 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
-      }
-    },
-    "dmd": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
-      "integrity": "sha1-sTBLmKVwCmv+Xc+RvmV8mBcApLw=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "command-line-tool": "0.5.2",
-        "common-sequence": "1.0.2",
-        "ddata": "0.1.28",
-        "file-set": "1.1.1",
-        "handlebars-array": "0.2.1",
-        "handlebars-comparison": "2.0.1",
-        "handlebars-json": "1.0.1",
-        "handlebars-regexp": "1.0.1",
-        "handlebars-string": "2.0.2",
-        "object-tools": "2.0.6",
-        "reduce-unique": "1.0.0",
-        "reduce-without": "1.0.1",
-        "stream-handlebars": "0.1.6",
-        "string-tools": "1.0.0",
-        "walk-back": "2.0.1"
       }
     },
     "domain-browser": {
@@ -3461,24 +3124,6 @@
       "requires": {
         "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
-      }
-    },
-    "espree": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
-      "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0",
-        "acorn-jsx": "3.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -4316,15 +3961,6 @@
         "bser": "2.0.0"
       }
     },
-    "feature-detect-es6": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
-      "integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4"
-      }
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4332,16 +3968,6 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
-      }
-    },
-    "file-set": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
-      "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "glob": "7.1.2"
       }
     },
     "filename-regex": {
@@ -4371,27 +3997,6 @@
         "randomatic": "3.0.0",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
-      }
-    },
-    "filter-where": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
-      "integrity": "sha1-GwQlae3ONrwcTp9zdA0sTi/u930=",
-      "dev": true,
-      "requires": {
-        "test-value": "1.1.0"
-      },
-      "dependencies": {
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
       }
     },
     "finalhandler": {
@@ -4435,16 +4040,6 @@
         "commondir": "1.0.1",
         "make-dir": "1.3.0",
         "pkg-dir": "2.0.0"
-      }
-    },
-    "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
       }
     },
     "find-up": {
@@ -4554,15 +4149,6 @@
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
-    },
-    "fs-then-native": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-1.0.2.tgz",
-      "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
-      "dev": true,
-      "requires": {
-        "feature-detect-es6": "1.4.1"
-      }
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -5417,54 +5003,6 @@
         }
       }
     },
-    "handlebars-array": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
-      "integrity": "sha1-3Vg5WlJh1mGYjo13Ug67+q3GvSQ=",
-      "dev": true,
-      "requires": {
-        "array-tools": "1.8.6"
-      }
-    },
-    "handlebars-comparison": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
-      "integrity": "sha1-sXuV0sKYV45K6tOPX6xG6PYAWFU=",
-      "dev": true,
-      "requires": {
-        "array-tools": "1.8.6"
-      }
-    },
-    "handlebars-json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
-      "integrity": "sha1-Lvh7t4JVHNZFu0aRuCTpZT7AJQQ=",
-      "dev": true
-    },
-    "handlebars-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
-      "integrity": "sha1-X0fwZyYOm6jlLxooCRf3DeOfEeQ=",
-      "dev": true
-    },
-    "handlebars-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
-      "integrity": "sha1-ufkiCKl5z89R/0qQ3voYPcYpQso=",
-      "dev": true,
-      "requires": {
-        "array-tools": "1.8.6",
-        "string-tools": "0.1.8"
-      },
-      "dependencies": {
-        "string-tools": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
-          "integrity": "sha1-cIhOhqJu5RA6B4vvZwM9VY024zc=",
-          "dev": true
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -5623,12 +5161,6 @@
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
       }
-    },
-    "home-path": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
-      "integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -7168,31 +6700,49 @@
         }
       }
     },
-    "jsdoc-api": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
-      "integrity": "sha1-UBIjWSe/rR4nvIjQew3d2y06ilk=",
+    "jsdoc-to-markdown": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.0.tgz",
+      "integrity": "sha512-gADSefQtpV0Wmx40/P1rWnX8IwLSJld94PpClRylMq2J4Q4m7P43cHuCzwehWjqmi3DJewK6EWydhcqfe6qPEA==",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "cache-point": "0.3.4",
-        "collect-all": "1.0.3",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "file-set": "1.1.1",
-        "jsdoc-75lb": "3.6.0",
-        "object-to-spawn-args": "1.1.1",
-        "promise.prototype.finally": "1.0.1",
-        "temp-path": "1.0.0",
-        "then-fs": "2.0.0",
-        "walk-back": "2.0.1"
+        "array-back": "2.0.0",
+        "command-line-tool": "0.8.0",
+        "config-master": "3.1.0",
+        "dmd": "3.0.12",
+        "jsdoc-api": "4.0.3",
+        "jsdoc-parse": "3.0.1",
+        "walk-back": "3.0.0"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-          "dev": true
+        "ansi-escape-sequences": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
+          "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0"
+          }
+        },
+        "array-back": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "dev": true,
+          "requires": {
+            "typical": "2.6.1"
+          }
+        },
+        "cache-point": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
+          "integrity": "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "fs-then-native": "2.0.0",
+            "mkdirp2": "1.0.4"
+          }
         },
         "collect-all": {
           "version": "1.0.3",
@@ -7204,39 +6754,164 @@
             "stream-via": "1.0.4"
           }
         },
-        "js2xmlparser": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-          "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
-          "dev": true
-        },
-        "jsdoc-75lb": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
-          "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
+        "command-line-args": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
+          "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
           "dev": true,
           "requires": {
-            "bluebird": "3.4.7",
-            "catharsis": "0.8.9",
-            "escape-string-regexp": "1.0.5",
-            "espree": "3.1.7",
-            "js2xmlparser": "1.0.0",
-            "klaw": "1.3.1",
-            "marked": "0.3.19",
-            "mkdirp": "0.5.1",
-            "requizzle": "0.2.1",
-            "strip-json-comments": "2.0.1",
-            "taffydb": "2.6.2",
-            "underscore": "1.8.3"
+            "argv-tools": "0.1.1",
+            "array-back": "2.0.0",
+            "find-replace": "2.0.1",
+            "lodash.camelcase": "4.3.0",
+            "typical": "2.6.1"
           }
         },
-        "klaw": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+        "command-line-tool": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
+          "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "ansi-escape-sequences": "4.0.0",
+            "array-back": "2.0.0",
+            "command-line-args": "5.0.2",
+            "command-line-usage": "4.1.0",
+            "typical": "2.6.1"
+          }
+        },
+        "command-line-usage": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
+          "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "4.0.0",
+            "array-back": "2.0.0",
+            "table-layout": "0.4.4",
+            "typical": "2.6.1"
+          }
+        },
+        "config-master": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
+          "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
+          "dev": true,
+          "requires": {
+            "walk-back": "2.0.1"
+          },
+          "dependencies": {
+            "walk-back": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+              "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+              "dev": true
+            }
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+          "dev": true
+        },
+        "dmd": {
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.12.tgz",
+          "integrity": "sha512-79w644JdsB2TthYpVl2bDurX7i9Abaegg2E7X46Ajc135aASTMXxrHzJ9mOa5X5nbmnXwlBYiF68K+1baX+BzQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "cache-point": "0.4.1",
+            "common-sequence": "1.0.2",
+            "file-set": "2.0.0",
+            "handlebars": "4.0.11",
+            "marked": "0.3.19",
+            "object-get": "2.1.0",
+            "reduce-flatten": "1.0.1",
+            "reduce-unique": "1.0.0",
+            "reduce-without": "1.0.1",
+            "test-value": "3.0.0",
+            "walk-back": "3.0.0"
+          }
+        },
+        "file-set": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.0.tgz",
+          "integrity": "sha512-cCWXfw+nrYoIoUVmEF7Xsw91lGWuObtSnTEZ7AmdvZou1A/6Xx237HfxdQyC/ayKRvQSMbNOBwg62OjN5JxbXw==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "glob": "7.1.2"
+          }
+        },
+        "find-replace": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "test-value": "3.0.0"
+          }
+        },
+        "fs-then-native": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
+          "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
+          "dev": true
+        },
+        "jsdoc-api": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.3.tgz",
+          "integrity": "sha512-dfYq9JgB+XahY0XfSEw93PmXmocjwYcvJ5aMuQUJ/OdDRGWamf2SSOk3W06Bsj8qdjp/UdefzqpP/mpwsvHuvA==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "cache-point": "0.4.1",
+            "collect-all": "1.0.3",
+            "file-set": "2.0.0",
+            "fs-then-native": "2.0.0",
+            "jsdoc": "3.5.5",
+            "object-to-spawn-args": "1.1.1",
+            "temp-path": "1.0.0",
+            "walk-back": "3.0.0"
+          }
+        },
+        "jsdoc-parse": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
+          "integrity": "sha512-btZLp4wYl90vcAfgk4hoGQbO17iBVrhh3LJRMKZNtZgniO3F8H2CjxXld0owBIB1XxN+j3bAcWZnZKMnSj3iMA==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "lodash.omit": "4.5.0",
+            "lodash.pick": "4.4.0",
+            "reduce-extract": "1.0.0",
+            "sort-array": "2.0.0",
+            "test-value": "3.0.0"
+          }
+        },
+        "sort-array": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
+          "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "object-get": "2.1.0",
+            "typical": "2.6.1"
+          },
+          "dependencies": {
+            "array-back": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+              "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+              "dev": true,
+              "requires": {
+                "typical": "2.6.1"
+              }
+            }
           }
         },
         "stream-via": {
@@ -7244,174 +6919,46 @@
           "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
           "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
           "dev": true
-        }
-      }
-    },
-    "jsdoc-parse": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz",
-      "integrity": "sha1-VLdIGzzWvLfBc9xPpp7pJzXqJSU=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-tools": "2.0.9",
-        "collect-json": "1.0.8",
-        "command-line-args": "2.1.6",
-        "command-line-tool": "0.1.0",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "file-set": "0.2.8",
-        "jsdoc-api": "1.2.4",
-        "object-tools": "2.0.6",
-        "stream-connect": "1.0.2",
-        "test-value": "1.1.0"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-all": "0.2.1"
-          }
         },
-        "array-tools": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
-          "integrity": "sha1-WlEd56Qb4O7J/9zUkS0K+fDKyjU=",
+        "table-layout": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
+          "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
           "dev": true,
           "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "collect-json": "1.0.8",
-            "filter-where": "1.0.1",
-            "object-get": "2.1.0",
-            "reduce-extract": "1.0.0",
-            "reduce-flatten": "1.0.1",
-            "reduce-unique": "1.0.0",
-            "reduce-without": "1.0.1",
-            "sort-array": "1.1.2",
-            "test-value": "1.1.0"
-          }
-        },
-        "command-line-args": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "command-line-usage": "2.0.5",
-            "core-js": "2.5.7",
-            "feature-detect-es6": "1.4.1",
-            "find-replace": "1.0.3",
-            "typical": "2.6.1"
-          }
-        },
-        "command-line-tool": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
-          "integrity": "sha1-kaEbpIrGOkpodVQ2eYD3xkI8FJ0=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4"
-          }
-        },
-        "command-line-usage": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "column-layout": "2.1.4",
-            "feature-detect-es6": "1.4.1",
+            "array-back": "2.0.0",
+            "deep-extend": "0.6.0",
+            "lodash.padend": "4.6.1",
             "typical": "2.6.1",
-            "wordwrapjs": "1.2.1"
-          }
-        },
-        "file-set": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
-          "integrity": "sha1-c6ZXHpy+UaxZJsiL1WfREfg28Xg=",
-          "dev": true,
-          "requires": {
-            "array-tools": "2.0.9",
-            "glob": "4.5.3"
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
+            "wordwrapjs": "3.0.0"
           }
         },
         "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
           "dev": true,
           "requires": {
-            "array-back": "1.0.4",
+            "array-back": "2.0.0",
             "typical": "2.6.1"
           }
         },
+        "walk-back": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
+          "integrity": "sha1-I1h4ejXakQMtrV6S+AsSNw2HlcU=",
+          "dev": true
+        },
         "wordwrapjs": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
-          "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+          "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
           "dev": true,
           "requires": {
-            "array-back": "1.0.4",
+            "reduce-flatten": "1.0.1",
             "typical": "2.6.1"
           }
         }
-      }
-    },
-    "jsdoc-to-markdown": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-1.3.9.tgz",
-      "integrity": "sha1-d0wOzg69C8wyYbLJoqqNE5mmFHI=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "command-line-args": "3.0.5",
-        "command-line-usage": "3.0.8",
-        "config-master": "2.0.4",
-        "dmd": "1.4.2",
-        "jsdoc-parse": "1.2.7",
-        "jsdoc2md-stats": "1.0.6",
-        "object-tools": "2.0.6",
-        "stream-connect": "1.0.2"
-      }
-    },
-    "jsdoc2md-stats": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/jsdoc2md-stats/-/jsdoc2md-stats-1.0.6.tgz",
-      "integrity": "sha1-3A4AKuu9D7rlEjU0+Scyr7xlH78=",
-      "dev": true,
-      "requires": {
-        "app-usage-stats": "0.4.1",
-        "feature-detect-es6": "1.4.1"
       }
     },
     "jsdom": {
@@ -7795,10 +7342,28 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
     "lodash.pick": {
@@ -8669,31 +8234,6 @@
       "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
       "dev": true
     },
-    "object-tools": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-      "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "collect-json": "1.0.8",
-        "object-get": "2.1.0",
-        "test-value": "1.1.0",
-        "typical": "2.6.1"
-      },
-      "dependencies": {
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -9229,15 +8769,6 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "2.0.6"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -9252,12 +8783,6 @@
         "is-fn": "1.0.0",
         "set-immediate-shim": "1.0.1"
       }
-    },
-    "promise.prototype.finally": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
-      "integrity": "sha1-kRgvkckkhplXQPoF4NqUKsmGvvo=",
-      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -9692,19 +9217,6 @@
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
-    },
-    "req-then": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/req-then/-/req-then-0.5.1.tgz",
-      "integrity": "sha1-McbgtW9N3SrNbeC6G86ne2B5398=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "defer-promise": "1.0.1",
-        "feature-detect-es6": "1.4.1",
-        "lodash.pick": "4.4.0",
-        "typical": "2.6.1"
-      }
     },
     "request": {
       "version": "2.87.0",
@@ -10602,17 +10114,6 @@
         "kind-of": "3.2.2"
       }
     },
-    "sort-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
-      "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "object-get": "2.1.0",
-        "typical": "2.6.1"
-      }
-    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -10803,79 +10304,6 @@
         "stream-shift": "1.0.0"
       }
     },
-    "stream-handlebars": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
-      "integrity": "sha1-cwW1BkID2hcWCMR4rPZCoUmJKi8=",
-      "dev": true,
-      "requires": {
-        "handlebars": "3.0.3",
-        "object-tools": "1.6.7"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "handlebars": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-          "dev": true,
-          "requires": {
-            "optimist": "0.6.1",
-            "source-map": "0.1.43",
-            "uglify-js": "2.3.6"
-          }
-        },
-        "object-tools": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-          "dev": true,
-          "requires": {
-            "array-tools": "1.8.6",
-            "typical": "2.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wordwrap": "0.0.3"
-              }
-            }
-          }
-        }
-      }
-    },
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
@@ -10893,12 +10321,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
-    },
-    "stream-via": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
-      "integrity": "sha1-DO5d+clZ+x0/TtpIGfKJ1fkgWvw=",
       "dev": true
     },
     "strict-uri-encode": {
@@ -10938,12 +10360,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
       "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-      "dev": true
-    },
-    "string-tools": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
-      "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
       "dev": true
     },
     "string-width": {
@@ -11047,20 +10463,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
-    },
-    "table-layout": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
-      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.7",
-        "deep-extend": "0.4.2",
-        "feature-detect-es6": "1.4.1",
-        "typical": "2.6.1",
-        "wordwrapjs": "2.0.0"
-      }
     },
     "taffydb": {
       "version": "2.6.2",
@@ -11408,15 +10810,6 @@
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
       "integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==",
       "dev": true
-    },
-    "then-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
-      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
-      "dev": true,
-      "requires": {
-        "promise": "7.3.1"
-      }
     },
     "throat": {
       "version": "4.1.0",
@@ -11897,23 +11290,6 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
     },
-    "usage-stats": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/usage-stats/-/usage-stats-0.8.6.tgz",
-      "integrity": "sha512-QS1r7a1h5g1jo6KulvVGV+eQM+Jfj87AjJBfr1iaIJYz+N7+Qh7ezaVFCulwBGd8T1EidRiSYphG17gra2y0kg==",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "cli-commands": "0.1.0",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.4.1",
-        "home-path": "1.0.6",
-        "mkdirp2": "1.0.4",
-        "req-then": "0.5.1",
-        "typical": "2.6.1",
-        "uuid": "3.3.2"
-      }
-    },
     "use": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
@@ -12058,12 +11434,6 @@
       "requires": {
         "browser-process-hrtime": "0.1.2"
       }
-    },
-    "walk-back": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-      "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
-      "dev": true
     },
     "walker": {
       "version": "1.0.7",
@@ -13079,18 +12449,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
-    },
-    "wordwrapjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
-      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.4.1",
-        "reduce-flatten": "1.0.1",
-        "typical": "2.6.1"
-      }
     },
     "worker-farm": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "express": "^4.15.2",
     "jest": "^22.4.3",
     "jsdoc": "^3.4.3",
-    "jsdoc-to-markdown": "^1.3.7",
+    "jsdoc-to-markdown": "^4.0.0",
     "json-loader": "^0.5.4",
     "mockdate": "^2.0.1",
     "webpack": "^4.6.0",

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -1,25 +1,34 @@
+import { ec as EC } from 'elliptic'
+
 import { createJWT, verifyJWT, SimpleSigner } from 'did-jwt'
-import UportLite from 'uport-lite'
-const MNID = require('mnid')
+import { toEthereumAddress } from 'did-jwt/lib/Digest'
 import UportDIDResolver from 'uport-did-resolver'
 import MuportDIDResolver from 'muport-did-resolver'
 import EthrDIDResolver from 'ethr-did-resolver'
-import { toEthereumAddress } from 'did-jwt/lib/Digest'
-import { ec as EC } from 'elliptic'
-import { ContractFactory } from './Contract.js'
-const secp256k1 = new EC('secp256k1')
-/**
-*    The Credentials class allows you to easily create the signed payloads used in uPort inlcuding
-*    credentials and signed mobile app requests (ex. selective disclosure requests
-*    for private data). It also provides signature verification over signed payloads and
-*    allows you to send push notifications to users.
-*/
-class Credentials {
+import UportLite from 'uport-lite'
+import MNID from 'mnid'
 
+import { ContractFactory } from './Contract.js'
+
+const secp256k1 = new EC('secp256k1')
+
+const Types = {
+  SHARE_REQ: 'shareReq',
+  SHARE_RESP: 'shareResp',
+  VER_REQ: 'verReq',
+  ETH_TX: 'ethtx'
+}
+
+/**
+ * The Credentials class allows you to easily create the signed payloads used in uPort including
+ * credentials and signed mobile app requests (ex. selective disclosure requests
+ * for private data). It also provides signature verification over signed payloads.
+ */
+class Credentials {
   /**
    * Instantiates a new uPort Credentials object
    *
-   * The following example is just for testing purposes. You should never store a private key in source code.
+   * The following example is just for testing purposes. *You should never store a private key in source code.*
    *
    * @example
    * import { Credentials } from 'uport-credentials'
@@ -48,7 +57,7 @@ class Credentials {
    *
    * Instead of a private key you can pass in a [Signer Functions](https://github.com/uport-project/did-jwt#signer-functions) to
    * present UX or call a HSM.
-
+   *
    * @example
    * import { Credentials } from 'uport-credentials'
    *
@@ -80,8 +89,8 @@ class Credentials {
       this.signer = signer
     } else if (privateKey) {
       this.signer = SimpleSigner(privateKey)
-
     }
+    
     if (did) {
       this.did = did
     } else if (address) {
@@ -105,7 +114,15 @@ class Credentials {
   }
 
   /**
-   * generate a DID and private key
+   * Generate a DID and private key, effectively creating a new identity that can sign and verify data
+   *
+   * @example
+   * const {did, privateKey} = Credentials.createIdentity()
+   * const credentials = new Credentials({did, privateKey, ...})
+   *
+   * @returns {Object} keypair
+   *           - {String} keypair.did         An ethr-did string for the new identity
+   *           - {String} keypair.privateKey  The identity's private key, as a string
    */
   static createIdentity () {
     const kp = secp256k1.genKeyPair()
@@ -116,28 +133,28 @@ class Credentials {
     return {did, privateKey}
   }
 
-/**
- *  Creates a [Selective Disclosure Request JWT](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md)
- *
- *  @example
- *  const req = { requested: ['name', 'country'],
- *                callbackUrl: 'https://myserver.com',
- *                notifications: true }
- *  credentials.requestDisclosure(req).then(jwt => {
- *      ...
- *  })
- *
- *  @param    {Object}             [params={}]           request params object
- *  @param    {Array}              params.requested      an array of attributes for which you are requesting credentials to be shared for
- *  @param    {Array}              params.verified       an array of attributes for which you are requesting verified credentials to be shared for
- *  @param    {Boolean}            params.notifications  boolean if you want to request the ability to send push notifications
- *  @param    {String}             params.callbackUrl    the url which you want to receive the response of this request
- *  @param    {String}             params.network_id     network id of Ethereum chain of identity eg. 0x4 for rinkeby
- *  @param    {String}             params.accountType    Ethereum account type: "general", "segregated", "keypair", "devicekey" or "none"
- *  @param    {Number}             expiresIn             Seconds until expiry
- *  @return   {Promise<Object, Error>}                   a promise which resolves with a signed JSON Web Token or rejects with an error
- */
-  requestDisclosure (params = {}, expiresIn = 600) {
+  /**
+   *  Creates a [Selective Disclosure Request JWT](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md)
+   *
+   *  @example
+   *  const req = { requested: ['name', 'country'],
+   *                callbackUrl: 'https://myserver.com',
+   *                notifications: true }
+   *  credentials.requestDisclosure(req).then(jwt => {
+   *      ...
+   *  })
+   *
+   *  @param    {Object}             [params={}]           request params object
+   *  @param    {Array}              params.requested      an array of attributes for which you are requesting credentials to be shared for
+   *  @param    {Array}              params.verified       an array of attributes for which you are requesting verified credentials to be shared for
+   *  @param    {Boolean}            params.notifications  boolean if you want to request the ability to send push notifications
+   *  @param    {String}             params.callbackUrl    the url which you want to receive the response of this request
+   *  @param    {String}             params.network_id     network id of Ethereum chain of identity eg. 0x4 for rinkeby
+   *  @param    {String}             params.accountType    Ethereum account type: "general", "segregated", "keypair", "devicekey" or "none"
+   *  @param    {Number}             expiresIn             Seconds until expiry
+   *  @return   {Promise<Object, Error>}                   a promise which resolves with a signed JSON Web Token or rejects with an error
+   */
+  createDisclosureRequest (params = {}, expiresIn = 600) {
     const payload = {}
     if (params.requested) {
       payload.requested = params.requested
@@ -164,216 +181,56 @@ class Credentials {
     if (params.exp) {
       payload.exp = params.exp
     }
-    return this.signJWT({...payload, type: 'shareReq'}, params.exp ? undefined : expiresIn)
+    return this.signJWT({...payload, type: Types.SHARE_REQ}, params.exp ? undefined : expiresIn)
   }
-/**
- *  Creates a [Selective Disclosure Request JWT](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md)
- *
- *  @example
- *  const req = { requested: ['name', 'country'],
- *                callbackUrl: 'https://myserver.com',
- *                notifications: true }
- *  credentials.createRequest(req).then(jwt => {
- *      ...
- *  })
- *
- *  @param    {Object}             [params={}]           request params object
- *  @param    {Array}              params.requested      an array of attributes for which you are requesting credentials to be shared for
- *  @param    {Array}              params.verified       an array of attributes for which you are requesting verified credentials to be shared for
- *  @param    {Boolean}            params.notifications  boolean if you want to request the ability to send push notifications
- *  @param    {String}             params.callbackUrl    the url which you want to receive the response of this request
- *  @param    {String}             params.network_id     network id of Ethereum chain of identity eg. 0x4 for rinkeby
- *  @param    {String}             params.accountType    Ethereum account type: "general", "segregated", "keypair", "devicekey" or "none"
- *  @return   {Promise<Object, Error>}                   a promise which resolves with a signed JSON Web Token or rejects with an error
- * @deprecated
- */
-
-  createRequest (params = {}) {
-    return this.requestDisclosure(params)
-  }
-
-/**
- * Creates a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
- *
- * This can either be used to share information about the signing identity or as the response to a
- * [Selective Disclosure Flow](https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md), where it can be used to authenticate the identity.
- *
- *  @example
- *  credentials.disclose({own: {name: 'Lourdes Valentina Gomez'}}).then(jwt => {
- *      ...
- *  })
- *
- *  @param    {Object}             [params={}]           request params object
- *  @param    {JWT}                params.req            A selective disclosure Request JWT if this is returned as part of an authentication flow
- *  @param    {Object}             params.own            An object of self attested claims about the signer (eg. name etc)
- *  @param    {Array}              params.verified       An array of attestation JWT's to include
- *  @param    {MNID}               params.nad            An ethereum address encoded as an [MNID](https://github.com/uport-project/mnid)
- *  @param    {Array}              params.capabilities   An array of capability JWT's to include
- *  @return   {Promise<Object, Error>}                   a promise which resolves with a signed JSON Web Token or rejects with an error
- */
-async disclose (payload = {}, expiresIn = 600 ) {
-  if (payload.req) {
-    const verified = await verifyJWT(payload.req)
-    if (verified.issuer) {
-      payload.aud = verified.issuer
-    }
-  }
-  return this.signJWT({...payload, type: 'shareResp'}, expiresIn)
-}
-
-async processDisclosurePayload ({doc, payload}) {
-  const credentials = {...doc.uportProfile || {}, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
-  if (payload.nad) {
-    credentials.networkAddress = payload.nad
-  }
-  if (payload.dad) {
-    credentials.deviceKey = payload.dad
-  }
-  if (payload.verified) {
-    const verified = await Promise.all(payload.verified.map(token => verifyJWT(token, {audience: this.did})))
-    return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
-  } else {
-    return credentials
-  }
-}
-
-/**
-  *  Authenticates [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md) from mobile
-  *  app as part of the [Selective Disclosure Flow](https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md).
-  *
-  *  It Verifies and parses the given response token and verifies the challenge response flow.
-  *
-  *  @example
-  *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
-  *  credentials.authenticate(resToken).then(res => {
-  *      const credentials = res.verified
-  *       const name =  res.name
-  *      ...
-  *  })
-  *
-  *  @param    {String}                  token                 a response token
-  *  @param    {String}                  [callbackUrl=null]    callbackUrl
-  *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
-  */
-  async authenticate (token, callbackUrl = null) {
-    const { payload, doc } = await verifyJWT(token, {audience: this.did, callbackUrl, auth: true})
-
-    if(payload.req) {
-      const challenge = await verifyJWT(payload.req)
-      if(challenge.payload.iss === this.did && challenge.payload.type === 'shareReq') {
-        return this.processDisclosurePayload({payload, doc})
-      }
-    } else {
-      throw new Error('Challenge was not included in response')
-    }
-  }
-
+  
   /**
- *  Creates a signed request for the user to attest a list of claims.
- *
- *  @example
- *  const unsignedClaim = {
- *    claim: {
- *      "Citizen of city X": {
- *        "Allowed to vote": true,
- *        "Document": "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
- *      }
- *    },
- *    sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
- *  }
- *  credentials.createVerificationRequest(unsignedClaim).then(jwt => {
- *    ...
- *  })
- *
- *  @param    {Object}      unsignedClaim     an object that is an unsigned claim which you want the user to attest
- *  @param    {String}      aud               the DID of the identity you want to sign the attestation
- *  @param    {String}      sub               the DID which the unsigned claim is about
- *  @param    {String}      callbackUrl       the url which you want to receive the response of this request
- *  @return   {Promise<Object, Error>}        a promise which resolves with a signed JSON Web Token or rejects with an error
- */
-  createVerificationRequest(unsignedClaim, sub, callbackUrl, aud) {
-    return this.signJWT({unsignedClaim, sub, aud, callback: callbackUrl, type: 'verReq'})
-  }
-
-/**
-  *  Receive signed response token from mobile app. Verifies and parses the given response token.
-  *
-  *  @example
-  *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
-  *  credentials.receive(resToken).then(res => {
-  *      const credentials = res.verified
-         const name =  res.name
-  *      ...
-  *  })
-  *
-  *  @param    {String}                  token                 a response token
-  *  @param    {String}                  [callbackUrl=null]    callbackUrl
-  *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
-  *  @deprecated
-  */
-  receive (token, callbackUrl = null) {
-    return this.authenticate(token, callbackUrl)
-  }
-
-  /**
-  *  Verify and return profile from a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
-  *
-  *  The main difference between this and `authenticate()` is that it does not verify the challenge. This can be used to verify user profiles that have been shared
-  *  through other methods such as QR codes and messages.
-  *
-  *  @example
-  *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
-  *  credentials.verifyProfile(resToken).then(profile => {
-  *      const credentials = profile.verified
-         const name =  profile.name
-  *      ...
-  *  })
-  *
-  *  @param    {String}                  token                 a response token
-  *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
-  */
- async verifyProfile (token) {
-  const { payload, doc } = await verifyJWT(token, {audience: this.did})
-  return this.processDisclosurePayload({ payload, doc })
- }
-
-/**
-  *  Create a credential (a signed JSON Web Token)
-  *
-  *  @example
-  *  credentials.attest({
-  *   sub: '5A8bRWU3F7j3REx3vkJ...', // uPort address of user, likely a MNID
-  *   exp: <future timestamp>,
-  *   claim: { name: 'John Smith' }
-  *  }).then( credential => {
-  *   ...
-  *  })
-  *
-  * @param    {Object}            [credential]           a unsigned credential object
-  * @param    {String}            credential.sub         subject of credential (a uPort address)
-  * @param    {String}            credential.claim       claim about subject single key value or key mapping to object with multiple values (ie { address: {street: ..., zip: ..., country: ...}})
-  * @param    {String}            credential.exp         time at which this claim expires and is no longer valid (seconds since epoch)
-  * @return   {Promise<Object, Error>}                   a promise which resolves with a credential (JWT) or rejects with an error
-  */
-  attest ({sub, claim, exp}) {
+   *  Create a credential (a signed JSON Web Token)
+   *
+   *  @example
+   *  credentials.attest({
+   *   sub: '5A8bRWU3F7j3REx3vkJ...', // uPort address of user, likely a MNID
+   *   exp: <future timestamp>,
+   *   claim: { name: 'John Smith' }
+   *  }).then( credential => {
+   *   ...
+   *  })
+   *
+   * @param    {Object}            [credential]           a unsigned credential object
+   * @param    {String}            credential.sub         subject of credential (a uPort address)
+   * @param    {String}            credential.claim       claim about subject single key value or key mapping to object with multiple values (ie { address: {street: ..., zip: ..., country: ...}})
+   * @param    {String}            credential.exp         time at which this claim expires and is no longer valid (seconds since epoch)
+   * @return   {Promise<Object, Error>}                   a promise which resolves with a credential (JWT) or rejects with an error
+   */
+  createVerification ({sub, claim, exp}) {
     return this.signJWT({sub: sub, claim, exp})
   }
 
   /**
-  *  Builds and returns a contract object which can be used to interact with
-  *  a given contract. Similar to web3.eth.contract but with promises. Once specifying .at(address)
-  *  you can call the contract functions with this object. Each call will create a request.
-  *
-  *  @param    {Object}       abi                                   contract ABI
-  *  @return   {Object}                                             contract object
-  */
-  contract (abi) {
-    const txObjHandler = (txObj, opts) => {
-      txObj.fn = txObj.function
-      delete txObj['function']
-      return this.txRequest(txObj, opts)
-    }
-    return ContractFactory(txObjHandler.bind(this))(abi)
+   *  Creates a signed request for the user to attest a list of claims.
+   *
+   *  @example
+   *  const unsignedClaim = {
+   *    claim: {
+   *      "Citizen of city X": {
+   *        "Allowed to vote": true,
+   *        "Document": "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
+   *      }
+   *    },
+   *    sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
+   *  }
+   *  credentials.createVerificationRequest(unsignedClaim).then(jwt => {
+   *    ...
+   *  })
+   *
+   *  @param    {Object}      unsignedClaim     an object that is an unsigned claim which you want the user to attest
+   *  @param    {String}      aud               the DID of the identity you want to sign the attestation
+   *  @param    {String}      sub               the DID which the unsigned claim is about
+   *  @param    {String}      callbackUrl       the url which you want to receive the response of this request
+   *  @return   {Promise<Object, Error>}        a promise which resolves with a signed JSON Web Token or rejects with an error
+   */
+  createSignVerificationRequest(unsignedClaim, sub, callbackUrl, aud) {
+    return this.signJWT({unsignedClaim, sub, aud, callback: callbackUrl, type: Types.VER_REQ})
   }
 
   /**
@@ -386,7 +243,7 @@ async processDisclosurePayload ({doc, payload}) {
    *    value: '0.1',
    *    fn: "setStatus(string 'hello', bytes32 '0xc3245e75d3ecd1e81a9bfb6558b6dafe71e9f347')",
    *  }
-   *  connect.txRequest(txObject, {callbackUrl: 'http://mycb.domain'}).then(jwt => {
+   *  connect.createTxRequest(txObject, {callbackUrl: 'http://mycb.domain'}).then(jwt => {
    *    ...
    *  })
    *
@@ -394,30 +251,158 @@ async processDisclosurePayload ({doc, payload}) {
    *  @param    {String}    [id='addressReq']    string to identify request, later used to get response
    *  @return   {String}                         a transaction request jwt
    */
-  txRequest(txObj, { callbackUrl, exp = 600, network_id, label } = {}) {
+  createTxRequest(txObj, { callbackUrl, exp = 600, network_id, label } = {}) {
     const payload = {}
     if (callbackUrl) payload.callback = callbackUrl
     if (network_id) payload.net = network_id
     if (label) payload.label = label
-    return this.signJWT({...payload, ...txObj, type: 'ethtx'}, exp )
+    return this.signJWT({...payload, ...txObj, type: Types.ETH_TX}, exp )
   }
 
-// /**
-//   *  Look up a profile in the registry for a given uPort address. Address must be MNID encoded.
-//   *
-//   *  @example
-//   *  credentials.lookup('5A8bRWU3F7j3REx3vkJ...').then(profile => {
-//   *     const name = profile.name
-//   *     const pubkey = profile.pubkey
-//   *     ...
-//   *   })
-//   *
-//   * @param    {String}            address             a MNID encoded address
-//   * @return   {Promise<Object, Error>}                a promise which resolves with parsed profile or rejects with an error
-//   */
-//   lookup (address) {
-//     return this.settings.registry(address)
-//   }
+  /**
+   * Creates a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
+   *
+   * This can either be used to share information about the signing identity or as the response to a
+   * [Selective Disclosure Flow](https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md), where it can be used to verifyAuthentication the identity.
+   *
+   *  @example
+   *  credentials.createDisclosureResponse({own: {name: 'Lourdes Valentina Gomez'}}).then(jwt => {
+   *      ...
+   *  })
+   *
+   *  @param    {Object}             [payload={}]           request params object
+   *  @param    {JWT}                payload.req            A selective disclosure Request JWT if this is returned as part of an authentication flow
+   *  @param    {Object}             payload.own            An object of self attested claims about the signer (eg. name etc)
+   *  @param    {Array}              payload.verified       An array of attestation JWT's to include
+   *  @param    {MNID}               payload.nad            An ethereum address encoded as an [MNID](https://github.com/uport-project/mnid)
+   *  @param    {Array}              payload.capabilities   An array of capability JWT's to include
+   *  @return   {Promise<Object, Error>}                    a promise which resolves with a signed JSON Web Token or rejects with an error
+   */
+  async createDisclosureResponse (payload = {}, expiresIn = 600 ) {
+    if (payload.req) {
+      const verified = await verifyJWT(payload.req)
+      if (verified.issuer) {
+        payload.aud = verified.issuer
+      }
+    }
+    return this.signJWT({...payload, type: Types.SHARE_RESP}, expiresIn)
+  }
+
+  /**
+   * Parse a selective disclosure response, and verify signatures on each included signed claim ("verification")
+   *  
+   * @param     {Object}             response       A selective disclosure response payload, with associated did doc
+   * @param     {Object}             response.doc   
+   */
+  async processDisclosurePayload ({doc, payload}) {
+    const credentials = {...doc.uportProfile || {}, ...(payload.own || {}), ...(payload.capabilities && payload.capabilities.length === 1 ? {pushToken: payload.capabilities[0]} : {}), address: payload.iss}
+    if (payload.nad) {
+      credentials.networkAddress = payload.nad
+    }
+    if (payload.dad) {
+      credentials.deviceKey = payload.dad
+    }
+    if (payload.verified) {
+      const verified = await Promise.all(payload.verified.map(token => verifyJWT(token, {audience: this.did})))
+      return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}
+    } else {
+      return credentials
+    }
+  }
+
+  /**
+   *  Authenticates [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md) from mobile
+   *  app as part of the [Selective Disclosure Flow](https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md).
+   *
+   *  It Verifies and parses the given response token and verifies the challenge response flow.
+   *
+   *  @example
+   *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
+   *  credentials.verifyAuthentication(resToken).then(res => {
+   *      const credentials = res.verified
+   *       const name =  res.name
+   *      ...
+   *  })
+   *
+   *  @param    {String}                  token                 a response token
+   *  @param    {String}                  [callbackUrl=null]    callbackUrl
+   *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
+   */
+  async verifyAuthentication (token, callbackUrl = null) {
+    const { payload, doc } = await verifyJWT(token, {audience: this.did, callbackUrl, auth: true})
+
+    if (payload.req) {
+      const challenge = await verifyJWT(payload.req)
+      if (challenge.payload.iss !== this.did) {
+        throw new Error(`Challenge issuer does not match current identity: ${challenge.payload.iss} !== ${this.did}`)
+      } else if (challenge.payload.type !== Types.SHARE_REQ) {
+        throw new Error(`Challenge payload type invalid: ${challenge.payload.type}`)
+      } else {
+        return this.processDisclosurePayload({payload, doc})
+      }
+    } else {
+      throw new Error('Challenge was not included in response')
+    }
+  }
+
+  /**
+   *  Receive signed response token from mobile app. Verifies and parses the given response token.
+   *
+   *  @example
+   *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
+   *  credentials.receive(resToken).then(res => {
+   *      const credentials = res.verified
+   *      const name =  res.name
+   *      ...
+   *  })
+   *
+   *  @param    {String}                  token                 a response token
+   *  @param    {String}                  [callbackUrl=null]    callbackUrl
+   *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
+   *  @deprecated
+   */
+  receive (token, callbackUrl = null) {
+    return this.verifyAuthentication(token, callbackUrl)
+  }
+
+  /**
+   *  Verify and return profile from a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
+   *
+   *  The main difference between this and `verifyAuthentication()` is that it does not verify the challenge. This can be used to verify user profiles that have been shared
+   *  through other methods such as QR codes and messages.
+   *
+   *  @example
+   *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
+   *  credentials.verifyProfile(resToken).then(profile => {
+   *      const credentials = profile.verified
+   *      const name =  profile.name
+   *      ...
+   *  })
+   *
+   *  @param    {String}                  token                 a response token
+   *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
+   */
+  async verifyProfile (token) {
+    const { payload, doc } = await verifyJWT(token, {audience: this.did})
+    return this.processDisclosurePayload({ payload, doc })
+  }
+
+  /**
+   *  Builds and returns a contract object which can be used to interact with
+   *  a given contract. Similar to web3.eth.contract but with promises. Once specifying .at(address)
+   *  you can call the contract functions with this object. Each call will create a request.
+   *
+   *  @param    {Object}       abi                                   contract ABI
+   *  @return   {Object}                                             contract object
+   */
+  contract (abi) {
+    const txObjHandler = (txObj, opts) => {
+      if (txObj.function) txObj.fn = txObj.function
+      delete txObj['function']
+      return this.txRequest(txObj, opts)
+    }
+    return ContractFactory(txObjHandler.bind(this))(abi)
+  }
 }
 
 const configNetworks = (nets) => {

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -6,7 +6,7 @@ import UportDIDResolver from 'uport-did-resolver'
 import MuportDIDResolver from 'muport-did-resolver'
 import EthrDIDResolver from 'ethr-did-resolver'
 import UportLite from 'uport-lite'
-import MNID from 'mnid'
+import { isMNID } from 'mnid'
 
 import { ContractFactory } from './Contract.js'
 
@@ -90,11 +90,11 @@ class Credentials {
     } else if (privateKey) {
       this.signer = SimpleSigner(privateKey)
     }
-    
+
     if (did) {
       this.did = did
     } else if (address) {
-      if (MNID.isMNID(address)) {
+      if (isMNID(address)) {
         this.did = `did:uport:${address}`
       }
       if (address.match('^0x[0-9a-fA-F]{40}$')) {
@@ -399,7 +399,7 @@ class Credentials {
     const txObjHandler = (txObj, opts) => {
       if (txObj.function) txObj.fn = txObj.function
       delete txObj['function']
-      return this.txRequest(txObj, opts)
+      return this.createTxRequest(txObj, opts)
     }
     return ContractFactory(txObjHandler.bind(this))(abi)
   }

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LEGACY createRequest() creates a valid JWT for a request 1`] = `
+exports[`LEGACY createDisclosureRequest() creates a valid JWT for a request 1`] = `
 Object {
   "doc": Object {
     "@context": "https://w3id.org/did/v1",
@@ -50,82 +50,567 @@ Object {
 }
 `;
 
-exports[`attest() has correct payload in JWT for an attestation 1`] = `Promise {}`;
-
-exports[`authenticate() handles response with missing challenge 1`] = `[Error: Challenge was not included in response]`;
-
-exports[`authenticate() returns profile mixing public and private claims 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "name": "Davie",
-  "phone": "+15555551234",
-}
-`;
-
-exports[`authenticate() returns profile mixing public and private claims and verified credentials 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "name": "Davie",
-  "phone": "+15555551234",
-  "verified": Array [
-    Object {
-      "claim": Object {
-        "email": "bingbangbung@email.com",
-      },
-      "exp": 1485321134,
-      "iat": 1485321133,
-      "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInN1YiI6IjB4MTEyMjMzIiwiY2xhaW0iOnsiZW1haWwiOiJiaW5nYmFuZ2J1bmdAZW1haWwuY29tIn0sImV4cCI6MTQ4NTMyMTEzNCwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y7AK2CZkCfMNM0k2WqAl7X7gg5ieBRVYa3mrI3Wfsq3JkH7mOd4J2XT_7eI5GIL2-tIVpnqMWVzCrvNwRRkzQQE",
-      "sub": "0x112233",
-    },
-  ],
-}
-`;
-
-exports[`authenticate() returns profile with device key claims 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "deviceKey": "0xdeviceKey",
-  "name": "Super Developer",
-}
-`;
-
-exports[`authenticate() returns profile with only public claims 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "name": "Super Developer",
-}
-`;
-
-exports[`authenticate() returns profile with private chain network id claims 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "name": "Super Developer",
-  "networkAddress": "34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m",
-}
-`;
-
-exports[`authenticate() returns pushToken if available 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "name": "Super Developer",
-  "pushToken": "PUSHTOKEN",
-}
-`;
-
 exports[`configuration configNetworks if networks key is passed in it must contain configuration object 1`] = `"Network configuration object required"`;
 
 exports[`configuration configNetworks should require a registry address 1`] = `"Malformed network config object, object must have 'registry' key specified."`;
 
 exports[`configuration configNetworks should require a rpcUrl 1`] = `"Malformed network config object, object must have 'rpcUrl' key specified."`;
 
-exports[`createVerificationRequest creates a valid JWT for a request 1`] = `
+exports[`createDisclosureRequest() creates a valid JWT for a request 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJ0eXBlIjoic2hhcmVSZXEiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.cYVTTaObssUZlT68Viz_Zwo6s6lY1_AghVxCqCx-3zFL7t9m1bzqJJnVOWMgRBIX177attz_ahtAUbB9Fre4pgA",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT for a plain request for public details 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.ptW7jS5lzfcbWCgi3M4MD73dRDTbkfl4v7wM_6Z8pbBAnZQpQYWHUhotfoSsvYdq1aQTKVg-Dlacdpbl--t_RgE",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT for a request 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJ0eXBlIjoic2hhcmVSZXEiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.cYVTTaObssUZlT68Viz_Zwo6s6lY1_AghVxCqCx-3zFL7t9m1bzqJJnVOWMgRBIX177attz_ahtAUbB9Fre4pgA",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT for a request asking for verified credentials 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJ2ZXJpZmllZCI6WyJuYW1lIl0sInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.6-RDnTCbyStFDjRdG8SODqakNWqd-DOwDx-z0sefcwrlg3vDrRV8xSPenifbuhlLIRP3Km4dwCO89dqcMrnUYwA",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+    "type": "shareReq",
+    "verified": Array [
+      "name",
+    ],
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT for a request for push notifications 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJwZXJtaXNzaW9ucyI6WyJub3RpZmljYXRpb25zIl0sInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.90LFA1ITNFW_1We3o1vNoI333GD3mGj7Sa-8bDjk6Psw7oHhvQ5T528VB1aT3-2rlqsXGNA5Re8GXXgMqGNbwQE",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "permissions": Array [
+      "notifications",
+    ],
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT for a request with callbackUrl 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJjYWxsYmFjayI6Imh0dHBzOi8vbXlzZXJ2ZXIuY29tIiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.3v3WjKyeesI0BGP5-p6Pf-jszTBJKHN9fZeTljtXE2cVokiiXxkDeCGPdqMOI372XA1a_i0cV5rGVqe3w05S6gE",
+  "payload": Object {
+    "callback": "https://myserver.com",
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting a specific network_id 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywibmV0IjoiMHg0IiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y6PI2kBsvKG9o2ni_qGHBGVhMypIYsTflvE-oj6I_kha9ughnPDEy_WbDhnNWbgI2tMo6wUh9RF-zW-y6cAeIQE",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "net": "0x4",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting a specific network_id 2`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywibmV0IjoiMHg0IiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y6PI2kBsvKG9o2ni_qGHBGVhMypIYsTflvE-oj6I_kha9ughnPDEy_WbDhnNWbgI2tMo6wUh9RF-zW-y6cAeIQE",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "net": "0x4",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting accountType of devicekey 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0IjoiZGV2aWNla2V5IiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.M7fTKA6RGZong1yAWBjw1YNo9YEn1V5oMXUJafgCIijK5KX1iHUpBwcLgkTi0wQGRSGqtVpD4pl9WP5bu8Ia5wA",
+  "payload": Object {
+    "act": "devicekey",
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting accountType of general 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.CbFYYQCwh4Atv-8rpPNxwv9Sl70PTonaHzrXtsiZpUAio-TjJSyCN_Crc88pwIA6VmK-W8upJWbDLGukFT_JowA",
+  "payload": Object {
+    "act": "general",
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting accountType of keypair 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0Ijoia2V5cGFpciIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.A_jzzsb06OWAX5ajpVjVmzgSvfqGmGqKj2IjW0mAFehOlodlRy8IOm3QPw2BXJlPh4eFpsH0Pd4mTJQBG8VHNQE",
+  "payload": Object {
+    "act": "keypair",
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting accountType of none 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0Ijoibm9uZSIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.U0YCoW3EQZg05ntFAOdZNjgOHr1kShlx8MdaLzuwquSBueOQV1-MnX51x0zGAC4LdbptrBuRxtWsPtqU_VTaCgA",
+  "payload": Object {
+    "act": "none",
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting accountType of segregated 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0Ijoic2VncmVnYXRlZCIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.M4ZwLdD-FlGovbFycTIVTzO9uiypI2tyrDysMy1UcWJRJWyrUz4BApFZ7Xp0wz6-XO7suW7CyvKQD-vAk4kcDAA",
+  "payload": Object {
+    "act": "segregated",
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createDisclosureRequest() has correct payload in JWT requesting unsupported accountType 1`] = `[Error: Unsupported accountType gold]`;
+
+exports[`createDisclosureRequest() ignores unsupported request parameters 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.ptW7jS5lzfcbWCgi3M4MD73dRDTbkfl4v7wM_6Z8pbBAnZQpQYWHUhotfoSsvYdq1aQTKVg-Dlacdpbl--t_RgE",
+  "payload": Object {
+    "exp": 1485321733,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "shareReq",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createSignVerificationRequest() creates a valid JWT for a request 1`] = `
 Object {
   "doc": Object {
     "@context": "https://w3id.org/did/v1",
@@ -169,6 +654,8 @@ Object {
   },
 }
 `;
+
+exports[`createVerification() has correct payload in JWT for an attestation 1`] = `Promise {}`;
 
 exports[`disclose() creates a valid JWT for a disclosure 1`] = `
 Object {
@@ -249,560 +736,6 @@ Object {
 }
 `;
 
-exports[`requestDisclosure() creates a valid JWT for a request 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJ0eXBlIjoic2hhcmVSZXEiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.cYVTTaObssUZlT68Viz_Zwo6s6lY1_AghVxCqCx-3zFL7t9m1bzqJJnVOWMgRBIX177attz_ahtAUbB9Fre4pgA",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "requested": Array [
-      "name",
-      "phone",
-    ],
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT for a plain request for public details 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.ptW7jS5lzfcbWCgi3M4MD73dRDTbkfl4v7wM_6Z8pbBAnZQpQYWHUhotfoSsvYdq1aQTKVg-Dlacdpbl--t_RgE",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT for a request 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJ0eXBlIjoic2hhcmVSZXEiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.cYVTTaObssUZlT68Viz_Zwo6s6lY1_AghVxCqCx-3zFL7t9m1bzqJJnVOWMgRBIX177attz_ahtAUbB9Fre4pgA",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "requested": Array [
-      "name",
-      "phone",
-    ],
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT for a request asking for verified credentials 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJ2ZXJpZmllZCI6WyJuYW1lIl0sInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.6-RDnTCbyStFDjRdG8SODqakNWqd-DOwDx-z0sefcwrlg3vDrRV8xSPenifbuhlLIRP3Km4dwCO89dqcMrnUYwA",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "requested": Array [
-      "name",
-      "phone",
-    ],
-    "type": "shareReq",
-    "verified": Array [
-      "name",
-    ],
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT for a request for push notifications 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJwZXJtaXNzaW9ucyI6WyJub3RpZmljYXRpb25zIl0sInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.90LFA1ITNFW_1We3o1vNoI333GD3mGj7Sa-8bDjk6Psw7oHhvQ5T528VB1aT3-2rlqsXGNA5Re8GXXgMqGNbwQE",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "permissions": Array [
-      "notifications",
-    ],
-    "requested": Array [
-      "name",
-      "phone",
-    ],
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT for a request with callbackUrl 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSJdLCJjYWxsYmFjayI6Imh0dHBzOi8vbXlzZXJ2ZXIuY29tIiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.3v3WjKyeesI0BGP5-p6Pf-jszTBJKHN9fZeTljtXE2cVokiiXxkDeCGPdqMOI372XA1a_i0cV5rGVqe3w05S6gE",
-  "payload": Object {
-    "callback": "https://myserver.com",
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "requested": Array [
-      "name",
-      "phone",
-    ],
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting a specific network_id 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywibmV0IjoiMHg0IiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y6PI2kBsvKG9o2ni_qGHBGVhMypIYsTflvE-oj6I_kha9ughnPDEy_WbDhnNWbgI2tMo6wUh9RF-zW-y6cAeIQE",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "net": "0x4",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting a specific network_id 2`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywibmV0IjoiMHg0IiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y6PI2kBsvKG9o2ni_qGHBGVhMypIYsTflvE-oj6I_kha9ughnPDEy_WbDhnNWbgI2tMo6wUh9RF-zW-y6cAeIQE",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "net": "0x4",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting accountType of devicekey 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0IjoiZGV2aWNla2V5IiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.M7fTKA6RGZong1yAWBjw1YNo9YEn1V5oMXUJafgCIijK5KX1iHUpBwcLgkTi0wQGRSGqtVpD4pl9WP5bu8Ia5wA",
-  "payload": Object {
-    "act": "devicekey",
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting accountType of general 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.CbFYYQCwh4Atv-8rpPNxwv9Sl70PTonaHzrXtsiZpUAio-TjJSyCN_Crc88pwIA6VmK-W8upJWbDLGukFT_JowA",
-  "payload": Object {
-    "act": "general",
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting accountType of keypair 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0Ijoia2V5cGFpciIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.A_jzzsb06OWAX5ajpVjVmzgSvfqGmGqKj2IjW0mAFehOlodlRy8IOm3QPw2BXJlPh4eFpsH0Pd4mTJQBG8VHNQE",
-  "payload": Object {
-    "act": "keypair",
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting accountType of none 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0Ijoibm9uZSIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.U0YCoW3EQZg05ntFAOdZNjgOHr1kShlx8MdaLzuwquSBueOQV1-MnX51x0zGAC4LdbptrBuRxtWsPtqU_VTaCgA",
-  "payload": Object {
-    "act": "none",
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting accountType of segregated 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0Ijoic2VncmVnYXRlZCIsInR5cGUiOiJzaGFyZVJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.M4ZwLdD-FlGovbFycTIVTzO9uiypI2tyrDysMy1UcWJRJWyrUz4BApFZ7Xp0wz6-XO7suW7CyvKQD-vAk4kcDAA",
-  "payload": Object {
-    "act": "segregated",
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`requestDisclosure() has correct payload in JWT requesting unsupported accountType 1`] = `[Error: Unsupported accountType gold]`;
-
-exports[`requestDisclosure() ignores unsupported request parameters 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.ptW7jS5lzfcbWCgi3M4MD73dRDTbkfl4v7wM_6Z8pbBAnZQpQYWHUhotfoSsvYdq1aQTKVg-Dlacdpbl--t_RgE",
-  "payload": Object {
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
 exports[`txRequest() creates a valid JWT for a request 1`] = `
 Object {
   "exp": 1485321733,
@@ -811,6 +744,73 @@ Object {
   "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
   "to": "0x70A804cCE17149deB6030039798701a38667ca3B",
   "type": "ethtx",
+}
+`;
+
+exports[`verifyAuthentication() handles response with missing challenge 1`] = `[Error: Challenge was not included in response]`;
+
+exports[`verifyAuthentication() returns profile mixing public and private claims 1`] = `
+Object {
+  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "country": "NI",
+  "name": "Davie",
+  "phone": "+15555551234",
+}
+`;
+
+exports[`verifyAuthentication() returns profile mixing public and private claims and verified credentials 1`] = `
+Object {
+  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "country": "NI",
+  "name": "Davie",
+  "phone": "+15555551234",
+  "verified": Array [
+    Object {
+      "claim": Object {
+        "email": "bingbangbung@email.com",
+      },
+      "exp": 1485321134,
+      "iat": 1485321133,
+      "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInN1YiI6IjB4MTEyMjMzIiwiY2xhaW0iOnsiZW1haWwiOiJiaW5nYmFuZ2J1bmdAZW1haWwuY29tIn0sImV4cCI6MTQ4NTMyMTEzNCwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y7AK2CZkCfMNM0k2WqAl7X7gg5ieBRVYa3mrI3Wfsq3JkH7mOd4J2XT_7eI5GIL2-tIVpnqMWVzCrvNwRRkzQQE",
+      "sub": "0x112233",
+    },
+  ],
+}
+`;
+
+exports[`verifyAuthentication() returns profile with device key claims 1`] = `
+Object {
+  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "country": "NI",
+  "deviceKey": "0xdeviceKey",
+  "name": "Super Developer",
+}
+`;
+
+exports[`verifyAuthentication() returns profile with only public claims 1`] = `
+Object {
+  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "country": "NI",
+  "name": "Super Developer",
+}
+`;
+
+exports[`verifyAuthentication() returns profile with private chain network id claims 1`] = `
+Object {
+  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "country": "NI",
+  "name": "Super Developer",
+  "networkAddress": "34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m",
+}
+`;
+
+exports[`verifyAuthentication() returns pushToken if available 1`] = `
+Object {
+  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "country": "NI",
+  "name": "Super Developer",
+  "pushToken": "PUSHTOKEN",
 }
 `;
 


### PR DESCRIPTION
Changed readme, tests, and credentials to use new method names suggested in the discussion on #61.  Also updated README to give a more clear description of uport-credentials and its relationship to other uport libraries.

All name changes are currently up to date re the latest suggestions on #61.  I do still have some reservations about the two different verification flows though (`verifyProfile` and `verifyAuthentication`).  Since the real difference between these methods is whether the challenge/response is verified along with the jwt itself, maybe we could update the names to reflect this small difference.  Though we could probably bikeshed this forever, it's fairly significant as we can't change method names again for a while, and this could be a major blocker for developers' understanding of our libraries, so we should make sure we're sure of the names.

---

My last proposal (not implemented yet) after rewriting some of the wording in README.md describe the verification flows:
- `verifyAuthentication` -> `verifyDisclosureResponse`
  - This way we explicitly mention the fact that the JWT being verified is expected to be a _response_ in the Selective Disclosure Flow, and that this is part of the verification.
- `verifyProfile` -> `verifyArbitraryDisclosure`
  - This indicates that it is very similar to the above, but the only difference is that we don't assume it is a _response_ to a particular _request_.  The name `verifyProfile` describes only a profile use case, but I could imagine someone wanting to share a particular set of attributes/verifications in a context that doesn't conform strictly to the idea of a `profile`.

Those changes would remove the confusion around the word authentication, and leave us with an API of:
- `createVerification`
- `createDisclosureRequest`
- `createSignVerificationRequest`
- `createTxRequest`
- `createDisclosureResponse`
- `verifyDisclosureResponse`
- `verifyArbitraryDisclosure`
- `processDisclosurePayload`
- `contract`

I still favor `attestation` over `verification`, as I believe it is slightly more general, but I digress -- either works, it just may be easier to talk about "verifying an attestation" than "verifying a verification" in docs/guides etc.