### PR TITLE
doc: rename createSignVerificationRequest 

### DIFF
--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -140,7 +140,7 @@ class Credentials {
    *  const req = { requested: ['name', 'country'],
    *                callbackUrl: 'https://myserver.com',
    *                notifications: true }
-   *  credentials.requestDisclosure(req).then(jwt => {
+   *  credentials.createDisclosureRequest(req).then(jwt => {
    *      ...
    *  })
    *
@@ -188,7 +188,7 @@ class Credentials {
    *  Create a credential (a signed JSON Web Token)
    *
    *  @example
-   *  credentials.attest({
+   *  credentials.createVerification({
    *   sub: '5A8bRWU3F7j3REx3vkJ...', // uPort address of user, likely a MNID
    *   exp: <future timestamp>,
    *   claim: { name: 'John Smith' }
@@ -219,7 +219,7 @@ class Credentials {
    *    },
    *    sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
    *  }
-   *  credentials.createVerificationRequest(unsignedClaim).then(jwt => {
+   *  credentials.createVerificationSignatureRequest(unsignedClaim).then(jwt => {
    *    ...
    *  })
    *
@@ -229,7 +229,7 @@ class Credentials {
    *  @param    {String}      callbackUrl       the url which you want to receive the response of this request
    *  @return   {Promise<Object, Error>}        a promise which resolves with a signed JSON Web Token or rejects with an error
    */
-  createSignVerificationRequest(unsignedClaim, sub, callbackUrl, aud) {
+  createVerificationSignatureRequest(unsignedClaim, sub, callbackUrl, aud) {
     return this.signJWT({unsignedClaim, sub, aud, callback: callbackUrl, type: Types.VER_REQ})
   }
 
@@ -238,7 +238,7 @@ class Credentials {
    *  it creates a JWT transaction request and appends addtional request options.
    *
    *  @example
-   *  const txobject = {
+   *  const txObject = {
    *    to: '0xc3245e75d3ecd1e81a9bfb6558b6dafe71e9f347',
    *    value: '0.1',
    *    fn: "setStatus(string 'hello', bytes32 '0xc3245e75d3ecd1e81a9bfb6558b6dafe71e9f347')",

--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -218,9 +218,9 @@ describe('disclose()', () => {
   })
 })
 
-describe('createSignVerificationRequest()', () => {
+describe('createVerificationSignatureRequest()', () => {
   it('creates a valid JWT for a request', async () => {
-    const jwt = await uport.createSignVerificationRequest({claim: { test: {prop1: 1, prop2: 2}}}, 'did:uport:223ab45')
+    const jwt = await uport.createVerificationSignatureRequest({claim: { test: {prop1: 1, prop2: 2}}}, 'did:uport:223ab45')
     return expect(await verifyJWT(jwt, {audience: did})).toMatchSnapshot()
   })
 })

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -610,7 +610,47 @@ Object {
 }
 `;
 
-exports[`createSignVerificationRequest() creates a valid JWT for a request 1`] = `
+exports[`createVerification() has correct payload in JWT for an attestation 1`] = `
+Object {
+  "doc": Object {
+    "@context": "https://w3id.org/did/v1",
+    "authentication": Array [
+      Object {
+        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "type": "Secp256k1SignatureAuthentication2018",
+      },
+    ],
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "publicKey": Array [
+      Object {
+        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+        "type": "Secp256k1VerificationKey2018",
+      },
+    ],
+  },
+  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInN1YiI6ImRpZDp1cG9ydDoyMjNhYjQ1IiwiY2xhaW0iOnsiZW1haWwiOiJiaW5nYmFuZ2J1bmdAZW1haWwuY29tIn0sImV4cCI6MTQ4NTMyMTEzNCwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.BWI3w3f1kk9285cSNvtuL6UsUH0I_uidG4MfTbHM_2YdO9HE6-rQiJ1e-vbM9jmGRQKDzoq_PjVBzLbhp3G4FwE",
+  "payload": Object {
+    "claim": Object {
+      "email": "bingbangbung@email.com",
+    },
+    "exp": 1485321134,
+    "iat": 1485321133,
+    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "sub": "did:uport:223ab45",
+  },
+  "signer": Object {
+    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
+    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+    "type": "Secp256k1VerificationKey2018",
+  },
+}
+`;
+
+exports[`createVerificationSignatureRequest() creates a valid JWT for a request 1`] = `
 Object {
   "doc": Object {
     "@context": "https://w3id.org/did/v1",
@@ -645,46 +685,6 @@ Object {
         },
       },
     },
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`createVerification() has correct payload in JWT for an attestation 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInN1YiI6ImRpZDp1cG9ydDoyMjNhYjQ1IiwiY2xhaW0iOnsiZW1haWwiOiJiaW5nYmFuZ2J1bmdAZW1haWwuY29tIn0sImV4cCI6MTQ4NTMyMTEzNCwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.BWI3w3f1kk9285cSNvtuL6UsUH0I_uidG4MfTbHM_2YdO9HE6-rQiJ1e-vbM9jmGRQKDzoq_PjVBzLbhp3G4FwE",
-  "payload": Object {
-    "claim": Object {
-      "email": "bingbangbung@email.com",
-    },
-    "exp": 1485321134,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "sub": "did:uport:223ab45",
   },
   "signer": Object {
     "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",


### PR DESCRIPTION
Changed last function name in uport-js, to match discussion on uport-project/uport-connect#200

`createSignVerificationRequest` -> `createVerificationSignatureRequest`

@localredhead -- still having issues building the docs, with the following error on the jsdoc-to-markdown command:
```
JSDOC_ERROR: The command-line option "template" requires a value.
```
The `jsdoc` command succeeds but clobbers the existing `docs/` folder again