### PR TITLE
Param/doc fixes

### DIFF
--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -172,7 +172,7 @@ class Credentials {
       payload.net = params.network_id
     }
     if (params.accountType) {
-      if (['general', 'segregated', 'keypair', 'devicekey', 'none'].indexOf(params.accountType) >= 0) {
+      if (['general', 'segregated', 'keypair', 'none'].indexOf(params.accountType) >= 0) {
         payload.act = params.accountType
       } else {
         return Promise.reject(new Error(`Unsupported accountType ${params.accountType}`))
@@ -219,17 +219,21 @@ class Credentials {
    *    },
    *    sub: "2oTvBxSGseWFqhstsEHgmCBi762FbcigK5u"
    *  }
-   *  credentials.createVerificationSignatureRequest(unsignedClaim).then(jwt => {
-   *    ...
+   *  const aud = '0x123...'
+   *  const sub = '0x456...'
+   *  const callbackUrl = 'https://my.cool.site/handleTheResponse'
+   *  credentials.createVerificationSignatureRequest(unsignedClaim, {aud, sub, callbackUrl}).then(jwt => {
+   *    // ...
    *  })
    *
-   *  @param    {Object}      unsignedClaim     an object that is an unsigned claim which you want the user to attest
-   *  @param    {String}      aud               the DID of the identity you want to sign the attestation
-   *  @param    {String}      sub               the DID which the unsigned claim is about
-   *  @param    {String}      callbackUrl       the url which you want to receive the response of this request
-   *  @return   {Promise<Object, Error>}        a promise which resolves with a signed JSON Web Token or rejects with an error
+   * @param    {Object}      unsignedClaim     an object that is an unsigned claim which you want the user to attest
+   * @param    {Object}      opts            
+   *   @param    {String}      opts.aud          the DID of the identity you want to sign the attestation
+   *   @param    {String}      opts.sub          the DID which the unsigned claim is about
+   *   @param    {String}      opts.callbackUrl  the url to receive the response of this request
+   * @returns  {Promise<Object, Error>}        a promise which resolves with a signed JSON Web Token or rejects with an error
    */
-  createVerificationSignatureRequest(unsignedClaim, sub, callbackUrl, aud) {
+  createVerificationSignatureRequest(unsignedClaim, {aud, sub, callbackUrl} = {}) {
     return this.signJWT({unsignedClaim, sub, aud, callback: callbackUrl, type: Types.VER_REQ})
   }
 
@@ -344,26 +348,6 @@ class Credentials {
     } else {
       throw new Error('Challenge was not included in response')
     }
-  }
-
-  /**
-   *  Receive signed response token from mobile app. Verifies and parses the given response token.
-   *
-   *  @example
-   *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
-   *  credentials.receive(resToken).then(res => {
-   *      const credentials = res.verified
-   *      const name =  res.name
-   *      ...
-   *  })
-   *
-   *  @param    {String}                  token                 a response token
-   *  @param    {String}                  [callbackUrl=null]    callbackUrl
-   *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
-   *  @deprecated
-   */
-  receive (token, callbackUrl = null) {
-    return this.verifyDisclosureResponse(token, callbackUrl)
   }
 
   /**

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -149,13 +149,14 @@ class Credentials {
    *  @param    {Array}              params.verified       an array of attributes for which you are requesting verified credentials to be shared for
    *  @param    {Boolean}            params.notifications  boolean if you want to request the ability to send push notifications
    *  @param    {String}             params.callbackUrl    the url which you want to receive the response of this request
-   *  @param    {String}             params.network_id     network id of Ethereum chain of identity eg. 0x4 for rinkeby
+   *  @param    {String}             params.networkId      network id of Ethereum chain of identity eg. 0x4 for rinkeby
    *  @param    {String}             params.accountType    Ethereum account type: "general", "segregated", "keypair", "devicekey" or "none"
    *  @param    {Number}             expiresIn             Seconds until expiry
    *  @return   {Promise<Object, Error>}                   a promise which resolves with a signed JSON Web Token or rejects with an error
    */
   createDisclosureRequest (params = {}, expiresIn = 600) {
     const payload = {}
+
     if (params.requested) {
       payload.requested = params.requested
     }
@@ -168,9 +169,10 @@ class Credentials {
     if (params.callbackUrl) {
       payload.callback = params.callbackUrl
     }
-    if (params.network_id) {
-      payload.net = params.network_id
+    if (params.networkId) {
+      payload.net = params.networkId
     }
+
     if (params.accountType) {
       if (['general', 'segregated', 'keypair', 'none'].indexOf(params.accountType) >= 0) {
         payload.act = params.accountType
@@ -255,10 +257,10 @@ class Credentials {
    *  @param    {String}    [id='addressReq']    string to identify request, later used to get response
    *  @return   {String}                         a transaction request jwt
    */
-  createTxRequest(txObj, { callbackUrl, exp = 600, network_id, label } = {}) {
+  createTxRequest(txObj, { callbackUrl, exp = 600, networkId, label } = {}) {
     const payload = {}
     if (callbackUrl) payload.callback = callbackUrl
-    if (network_id) payload.net = network_id
+    if (networkId) payload.net = networkId
     if (label) payload.label = label
     return this.signJWT({...payload, ...txObj, type: Types.ETH_TX}, exp )
   }
@@ -304,9 +306,7 @@ class Credentials {
     if (payload.nad) {
       credentials.networkAddress = payload.nad
     }
-    if (payload.dad) {
-      credentials.deviceKey = payload.dad
-    }
+
     if (payload.verified) {
       const verified = await Promise.all(payload.verified.map(token => verifyJWT(token, {audience: this.did})))
       return {...credentials, verified: verified.map(v => ({...v.payload, jwt: v.jwt}))}

--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -140,17 +140,17 @@ describe('createDisclosureRequest()', () => {
     return expect(response).toMatchSnapshot()
   })
 
-  it('has correct payload in JWT requesting a specific network_id', async () => {
-    const response = await createAndVerify({network_id: '0x4'})
+  it('has correct payload in JWT requesting a specific networkId', async () => {
+    const response = await createAndVerify({networkId: '0x4'})
     return expect(response).toMatchSnapshot()
   })
 
-  it('has correct payload in JWT requesting a specific network_id', async () => {
-    const response = await createAndVerify({network_id: '0x4'})
+  it('has correct payload in JWT requesting a specific networkId', async () => {
+    const response = await createAndVerify({networkId: '0x4'})
     return expect(response).toMatchSnapshot()
   })
 
-  for (let accountType of ['general', 'segregated', 'keypair', 'devicekey', 'none']) {
+  for (let accountType of ['general', 'segregated', 'keypair', 'none']) {
     it(`has correct payload in JWT requesting accountType of ${accountType}`, async () => {
       const response = await createAndVerify({accountType})
       return expect(response).toMatchSnapshot()
@@ -276,12 +276,6 @@ describe('verifyDisclosureResponse()', () => {
     expect(profile).toMatchSnapshot()
   })
 
-  it('returns profile with device key claims', async () => {
-    const jwt = await createShareResp({dad: '0xdeviceKey'})
-    const profile = await uport.verifyDisclosureResponse(jwt)
-    expect(profile).toMatchSnapshot()
-  })
-
   it('returns pushToken if available', async () => {
     const jwt = await createShareResp({capabilities: ['PUSHTOKEN']})
     const profile = await uport.verifyDisclosureResponse(jwt)
@@ -331,19 +325,6 @@ describe('verifyDisclosure()', () => {
   })
 })
 
-describe('LEGACY receive()', () => {
-  beforeAll(() => mockresolver({
-    name: 'Bob Smith',
-    country: 'NI'
-  }))
-  it('returns profile mixing public and private claims', async () => {
-    const req = await uport.createDisclosureRequest({requested: ['name', 'phone']})
-    const jwt = await uport.createDisclosureResponse({own: {name: 'Davie', phone: '+15555551234'}, req})
-    const profile = await uport.receive(jwt)
-    expect(profile).toMatchSnapshot()
-  })
-})
-
 describe('txRequest()', () => {
   beforeAll(() => mockresolver())
 
@@ -370,11 +351,11 @@ describe('txRequest()', () => {
   })
 
   it('adds additional request options passed to jwt', async () => {
-      const network_id =  '0x4'
+      const networkId =  '0x4'
       const callbackUrl = 'mydomain'
-      const jwt = await statusContract.updateStatus('hello', {network_id, callbackUrl })
+      const jwt = await statusContract.updateStatus('hello', {networkId, callbackUrl })
       const verified = await verifyJWT(jwt)
-      expect(verified.payload.net).toEqual(network_id)
+      expect(verified.payload.net).toEqual(networkId)
       expect(verified.payload.callback).toEqual(callbackUrl)
   })
 })

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -41,15 +41,6 @@ Object {
 }
 `;
 
-exports[`LEGACY receive() returns profile mixing public and private claims 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "name": "Davie",
-  "phone": "+15555551234",
-}
-`;
-
 exports[`configuration configNetworks if networks key is passed in it must contain configuration object 1`] = `"Network configuration object required"`;
 
 exports[`configuration configNetworks should require a registry address 1`] = `"Malformed network config object, object must have 'registry' key specified."`;
@@ -305,7 +296,7 @@ Object {
 }
 `;
 
-exports[`createDisclosureRequest() has correct payload in JWT requesting a specific network_id 1`] = `
+exports[`createDisclosureRequest() has correct payload in JWT requesting a specific networkId 1`] = `
 Object {
   "doc": Object {
     "@context": "https://w3id.org/did/v1",
@@ -343,7 +334,7 @@ Object {
 }
 `;
 
-exports[`createDisclosureRequest() has correct payload in JWT requesting a specific network_id 2`] = `
+exports[`createDisclosureRequest() has correct payload in JWT requesting a specific networkId 2`] = `
 Object {
   "doc": Object {
     "@context": "https://w3id.org/did/v1",
@@ -370,44 +361,6 @@ Object {
     "iat": 1485321133,
     "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
     "net": "0x4",
-    "type": "shareReq",
-  },
-  "signer": Object {
-    "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-    "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "type": "Secp256k1VerificationKey2018",
-  },
-}
-`;
-
-exports[`createDisclosureRequest() has correct payload in JWT requesting accountType of devicekey 1`] = `
-Object {
-  "doc": Object {
-    "@context": "https://w3id.org/did/v1",
-    "authentication": Array [
-      Object {
-        "publicKey": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "type": "Secp256k1SignatureAuthentication2018",
-      },
-    ],
-    "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "publicKey": Array [
-      Object {
-        "ethereumAddress": "0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "id": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840#owner",
-        "owner": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-        "type": "Secp256k1VerificationKey2018",
-      },
-    ],
-  },
-  "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywiYWN0IjoiZGV2aWNla2V5IiwidHlwZSI6InNoYXJlUmVxIiwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.M7fTKA6RGZong1yAWBjw1YNo9YEn1V5oMXUJafgCIijK5KX1iHUpBwcLgkTi0wQGRSGqtVpD4pl9WP5bu8Ia5wA",
-  "payload": Object {
-    "act": "devicekey",
-    "exp": 1485321733,
-    "iat": 1485321133,
-    "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
     "type": "shareReq",
   },
   "signer": Object {
@@ -671,11 +624,10 @@ Object {
     ],
   },
   "issuer": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInVuc2lnbmVkQ2xhaW0iOnsiY2xhaW0iOnsidGVzdCI6eyJwcm9wMSI6MSwicHJvcDIiOjJ9fX0sInN1YiI6ImRpZDp1cG9ydDoyMjNhYjQ1IiwidHlwZSI6InZlclJlcSIsImlzcyI6ImRpZDpldGhyOjB4YmMzYWU1OWJjNzZmODk0ODIyNjIyY2RlZjdhMjAxOGRiZTM1Mzg0MCJ9.jU2vU1PatmKB_M8zPvZNqSblKJqHCaGW1ngkiqnw1Xy83-_q1wtMUU-30gSSPWDQ1Gt6enNNXZFwRqM9lQMqngE",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInVuc2lnbmVkQ2xhaW0iOnsiY2xhaW0iOnsidGVzdCI6eyJwcm9wMSI6MSwicHJvcDIiOjJ9fX0sInR5cGUiOiJ2ZXJSZXEiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.QshcaK4eGrr2HTe77KWXOFF0hQmuLwrNIDulQeM8UWtmtD5VQ0lhUszJYdUzvQpyjB9KGLAG6j4iseQ_Bbo9ywE",
   "payload": Object {
     "iat": 1485321133,
     "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-    "sub": "did:uport:223ab45",
     "type": "verReq",
     "unsignedClaim": Object {
       "claim": Object {
@@ -870,15 +822,6 @@ Object {
       "sub": "0x112233",
     },
   ],
-}
-`;
-
-exports[`verifyDisclosureResponse() returns profile with device key claims 1`] = `
-Object {
-  "address": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "country": "NI",
-  "deviceKey": "0xdeviceKey",
-  "name": "Super Developer",
 }
 `;
 


### PR DESCRIPTION
- remove superfluous method `receive` (now implemented as verifyDisclosureResponse)
- improve examples in inline docs
- remove `'deviceKey'` option for `accountType`
- rename the `network_id` parameter to `networkId` throughout, to match `uport-connect`