### PR TITLE
feat: export normalizeDID function from did-jwt

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import Credentials from './Credentials'
 import { createJWT, verifyJWT } from './JWT'
 import { SimpleSigner } from 'did-jwt'
+import { normalizeDID } from 'did-jwt/lib/JWT'
 import { Contract, ContractFactory } from './Contract'
 import UportDIDResolver from 'uport-did-resolver'
 
 const JWT = { createJWT: createJWT , verifyJWT: verifyJWT }
 
-module.exports = { Credentials, SimpleSigner, Contract, ContractFactory, JWT }
+module.exports = { Credentials, SimpleSigner, Contract, ContractFactory, JWT, normalizeDID }


### PR DESCRIPTION
Depends on uport-project/did-jwt#19

Simply pass the `normalizeDID` function through `uport-js` to ease the process of integrating with legacy MNID addresses in older credentials