### PR TITLE
Final method name changes with updates to tutorials/examples

### DIFF
--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -25,7 +25,7 @@ Go ahead and create identities for the Creator and Requestor, or if you wish to 
 
 In the file `createcredential.js` we have a simple node `express` server. In the setup phase we use the private key we got from the App Manager to create a `SimpleSigner` object.
 
-We then create a `Credentials` object using the privatreKey and the uPort identifier of our app that we got from the App Manager (or the default identity):
+We then create a `Credentials` object using the privateKey and the uPort identifier of our app that we got from the App Manager (or the default identity):
 
 ```js
 var credentials = new uport.Credentials({
@@ -34,17 +34,17 @@ var credentials = new uport.Credentials({
 })
 ```
 
-When we hit the default route using `app.get('/')` we will call `credentials.attest()` in order to sign the credential. For the fields of the credential, the `sub` field is the subject. Set this to the uPort Id of the user that is supposed to receive the credential. For testing purposes this would be the uPort identity shown on the mobile app of the reader. The `exp` field is the expiry of the token, in Unix time (seconds precision). As `claim` field, put your own custom object. We show an example below. The format of the claim needs to be `{'Title': {'key':'value', 'another key': 'another value', ...}}` or simply `{'Title' : 'Value'}`. We do not support more nested claims at this time.
+When we hit the default route using `app.get('/')` we will call `credentials.createVerification()` in order to sign the credential. For the fields of the credential, the `sub` field is the subject. Set this to the uPort Id of the user that is supposed to receive the credential. For testing purposes this would be the uPort identity shown on the mobile app of the reader. The `exp` field is the expiry of the token, in Unix time (seconds precision). As `claim` field, put your own custom object. We show an example below. The format of the claim needs to be `{'Title': {'key':'value', 'another key': 'another value', ...}}` or simply `{'Title' : 'Value'}`. We do not support more nested claims at this time.
 
 ```js
-credentials.attest({
+credentials.createVerification({
   sub: '<uport Id of identity in mobile app>',
   exp: 1552046024,
   claim: {'My Title' : {'KeyOne' : 'ValueOne', 'KeyTwo' : 'Value2', 'Last Key' : 'Last Value'}}
 })
 ```
 
-The `attest()` function returns a promise that resolves to a JSON Web Token. We're going to present this token to the user through a URL that looks like this:
+The `createVerification()` function returns a promise that resolves to a JSON Web Token. We're going to present this token to the user through a URL that looks like this:
 
 ```js
 me.uport:add?attestations=<JSON Web Token>&callback_type=post
@@ -69,21 +69,21 @@ The file `requestcredential.js` contains a simple node express server which will
 
 As with the Creator service we start by setting up the Signer using the private key from the App Manager, and the `Credentials` object using the uPort identifier of our Requestor app. We also set up `bodyParser` so that we can parse the JWT that we will get back from the user.
 
-When we load the app using `app.get('/')` we use `createRequest()` in order to request a specific credential from the user. Here we will request the `Custom Attestation` credential. We will use `verified` to denote which credentials we are requesting.
+When we load the app using `app.get('/')` we use `createDisclosureRequest()` in order to request a specific credential from the user. Here we will request the `Custom Attestation` credential. We will use `verified` to denote which credentials we are requesting.
 
 The `callbackUrl` field specifies where the mobile app user should send the credential, should she agree to share it. If you are running the app on a local network you should put your local IP address here, followed by the route `/callback`. Make sure your mobile device is connected to the same network. If you are running the app on a VPS service like Digital Ocean, make sure to put the correct IP address in and that the right ports are open.
 
 We have an expiry field, denoted `exp`, which represents the unix epoch when the request will expire. In our example we use 300 seconds (5 minutes) in the future. This means that if the user waits longer than 300 seconds to provide the response their response will not be accepted as valid.
 
 ```js
-credentials.createRequest({
+credentials.createDisclosureRequest({
   verified: [<Title of the credential>],
   callbackUrl: 'http://192.168.1.34:8081/callback',
   exp: Math.floor(new Date().getTime()/1000) + <expiry time in seconds>
 })
 ```
 
-The `createRequest()` function creates a signed JWT containing the request. The mobile app can then validate that the correct app sent the request.
+The `createDisclosureRequest()` function creates a signed JWT containing the request. The mobile app can then validate that the correct app sent the request.
 
 To interact with the server, run
 
@@ -95,7 +95,7 @@ and go to `http://localhost:8088` in your browser.
 
 When the mobile app user approves the request to share her credential after scanning the code, the `/callback` route is called using `app.post('/callback')`. Here we fetch the response JWT using `req.body.access_token`.
 
-Once we have the JWT we wish to validate it. We use the `receive()` function first. This validates the JWT by checking that the signature matches the public key of the issuer. This validation is done both for the overall JWT and also for the JWTs that are sent in the larger payload.
+Once we have the JWT we wish to validate it. We use the `verifyDisclsoureResponse()` function first. This validates the JWT by checking that the signature matches the public key of the issuer. This validation is done both for the overall JWT and also for the JWTs that are sent in the larger payload.
 
 Next we check that the issuer of the response token (i.e. the user) matches the subject (`sub` field) of the returned credential, that the issuer of the returned credential is the Creator App, and that the credential has title `My Title` with the values defined by the Creator App.
 

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -95,7 +95,7 @@ and go to `http://localhost:8088` in your browser.
 
 When the mobile app user approves the request to share her credential after scanning the code, the `/callback` route is called using `app.post('/callback')`. Here we fetch the response JWT using `req.body.access_token`.
 
-Once we have the JWT we wish to validate it. We use the `verifyDisclsoureResponse()` function first. This validates the JWT by checking that the signature matches the public key of the issuer. This validation is done both for the overall JWT and also for the JWTs that are sent in the larger payload.
+Once we have the JWT we wish to validate it. We use the `authenticateDisclosureResponse()` function first. This validates the JWT by checking that the signature matches the public key of the issuer. This validation is done both for the overall JWT and also for the JWTs that are sent in the larger payload.
 
 Next we check that the issuer of the response token (i.e. the user) matches the subject (`sub` field) of the returned credential, that the issuer of the returned credential is the Creator App, and that the credential has title `My Title` with the values defined by the Creator App.
 

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -15,11 +15,9 @@ The code for this tutorial can be found in the [Uport-Credentials examples.](git
 
 ## Register The App
 
-First we wish to create identities for our apps. You can skip this step if you're ok with using the default identities that are hardcoded in the tutorial files. To create identities, go to the [uPort AppManager](https://appmanager.uport.me), connect with your uPort, and select "New App". This will create a uPort identity for your app, and will display a private key, which you will use on the server to sign credentials. It's important that you save this key!
+This tutorial uses sample application identities (i.e. private keys) to issue and verify credentials on a server.  For your own applications, you should be sure to create an identity using the uPort [app configuration wizard](https://developer.uport.me/myapps) -- click on **Register an App**, and you will be guided through the process of creating and saving an application identity. For this tutorial, feel free to follow along using the provided sample identities.
 
-Go ahead and create identities for the Creator and Requestor, or if you wish to skip this step we have created identities for these services already, with the private keys and addresses hard coded in the apps.
-
-*Please note that in practice the signing key for the identity should be protected information*
+*Please note that in practice the signing key for the identity should be kept secret!*
 
 ## Creator service
 

--- a/examples/createcredential.js
+++ b/examples/createcredential.js
@@ -11,7 +11,7 @@ var credentials = new uport.Credentials({
 })
 
 app.get('/', function (req, res) {
-  credentials.attest({
+  credentials.createVerification({
     sub: 'did:uport:2omWsSGspY7zhxaG6uHyoGtcYxoGeeohQXz',
     exp: 1552046024,
     claim: {'My Title' : {'KeyOne' : 'ValueOne', 'KeyTwo' : 'Value2', 'Last Key' : 'Last Value'} }

--- a/examples/requestcredential.js
+++ b/examples/requestcredential.js
@@ -33,7 +33,7 @@ app.post('/callback', function (req, res) {
   var jwt = req.body.access_token
   console.log(jwt)
 
-  credentials.verifyDisclosureResponse(jwt).then( function(creds) {
+  credentials.authenticateDisclosureResponse(jwt).then( function(creds) {
     console.log(creds)
     if (creds.address == creds.verified[0].sub && 
        creds.verified[0].iss == '2od4Re9CL92phRUoAhv1LFcFkx2B9UAin92' &&

--- a/examples/requestcredential.js
+++ b/examples/requestcredential.js
@@ -14,7 +14,7 @@ app.use(bodyParser.json({ type: '*/*' }))
 
 app.get('/', function (req, res) {
 
-  credentials.requestDisclosure({
+  credentials.createDisclosureRequest({
     verified: ['My Title'],
     callbackUrl: 'http://192.168.44.162:8081/callback',
     exp: Math.floor(new Date().getTime()/1000) + 300
@@ -33,7 +33,7 @@ app.post('/callback', function (req, res) {
   var jwt = req.body.access_token
   console.log(jwt)
 
-  credentials.authenticate(jwt).then( function(creds) {
+  credentials.verifyDisclosureResponse(jwt).then( function(creds) {
     console.log(creds)
     if (creds.address == creds.verified[0].sub && 
        creds.verified[0].iss == '2od4Re9CL92phRUoAhv1LFcFkx2B9UAin92' &&

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -276,7 +276,7 @@ class Credentials {
    *
    * This can either be used to share information about the signing identity or as the response to a
    * [Selective Disclosure Flow](https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md),
-   * where it can be used to verifyDisclosureResponse the identity.
+   * where it can be used to authenticate the identity.
    *
    *  @example
    *  credentials.createDisclosureResponse({own: {name: 'Lourdes Valentina Gomez'}}).then(jwt => {
@@ -333,7 +333,7 @@ class Credentials {
    *
    *  @example
    *  const resToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
-   *  credentials.verifyDisclosureResponse(resToken).then(res => {
+   *  credentials.authenticateDisclosureResponse(resToken).then(res => {
    *      const credentials = res.verified
    *      const name =  res.name
    *      ...
@@ -343,7 +343,7 @@ class Credentials {
    *  @param    {String}                  [callbackUrl=null]    callbackUrl
    *  @return   {Promise<Object, Error>}                        a promise which resolves with a parsed response or rejects with an error.
    */
-  async verifyDisclosureResponse (token, callbackUrl = null) {
+  async authenticateDisclosureResponse (token, callbackUrl = null) {
     const { payload, doc } = await verifyJWT(token, {audience: this.did, callbackUrl, auth: true})
 
     if (payload.req) {
@@ -363,7 +363,7 @@ class Credentials {
   /**
    *  Verify and return profile from a [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
    *
-   * The main difference between this and `verifyDisclosureResponse()` is that it does not verify the challenge.
+   * The main difference between this and `authenticateDisclosureResponse()` is that it does not verify the challenge.
    * This can be used to verify user profiles that have been shared through other methods such as QR codes and messages.
    *
    *  @example

--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -235,7 +235,7 @@ describe('createVerification()', () => {
   })
 })
 
-describe('verifyDisclosureResponse()', () => {
+describe('authenticateDisclosureResponse()', () => {
   beforeAll(() => mockresolver({
     name: 'Super Developer',
     country: 'NI'
@@ -254,37 +254,37 @@ describe('verifyDisclosureResponse()', () => {
 
   it('returns profile mixing public and private claims', async () => {
     const jwt = await createShareResp({own: {name: 'Davie', phone: '+15555551234'}})
-    const profile = await uport.verifyDisclosureResponse(jwt)
+    const profile = await uport.authenticateDisclosureResponse(jwt)
     expect(profile).toMatchSnapshot()
   })
 
   it('returns profile mixing public and private claims and verified credentials', async () => {
     const jwt = await createShareRespWithVerifiedCredential({own: {name: 'Davie', phone: '+15555551234'}})
-    const profile = await uport.verifyDisclosureResponse(jwt)
+    const profile = await uport.authenticateDisclosureResponse(jwt)
     expect(profile).toMatchSnapshot()
   })
 
   it('returns profile with only public claims', async () => {
     const jwt = await createShareResp()
-    const profile = await uport.verifyDisclosureResponse(jwt)
+    const profile = await uport.authenticateDisclosureResponse(jwt)
     expect(profile).toMatchSnapshot()
   })
 
   it('returns profile with private chain network id claims', async () => {
     const jwt = await createShareResp({nad: '34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m'})
-    const profile = await uport.verifyDisclosureResponse(jwt)
+    const profile = await uport.authenticateDisclosureResponse(jwt)
     expect(profile).toMatchSnapshot()
   })
 
   it('returns pushToken if available', async () => {
     const jwt = await createShareResp({capabilities: ['PUSHTOKEN']})
-    const profile = await uport.verifyDisclosureResponse(jwt)
+    const profile = await uport.authenticateDisclosureResponse(jwt)
     expect(profile).toMatchSnapshot()
   })
 
   it('handles response with missing challenge', async () => {
     const jwt = await uport.createDisclosureResponse({own: {name: 'bob'}})
-    expect(uport.verifyDisclosureResponse(jwt)).rejects.toMatchSnapshot()
+    expect(uport.authenticateDisclosureResponse(jwt)).rejects.toMatchSnapshot()
   })
 })
 

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -41,6 +41,70 @@ Object {
 }
 `;
 
+exports[`authenticateDisclosureResponse() handles response with missing challenge 1`] = `[Error: Challenge was not included in response]`;
+
+exports[`authenticateDisclosureResponse() returns profile mixing public and private claims 1`] = `
+Object {
+  "boxPub": undefined,
+  "country": "NI",
+  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "name": "Davie",
+  "phone": "+15555551234",
+}
+`;
+
+exports[`authenticateDisclosureResponse() returns profile mixing public and private claims and verified credentials 1`] = `
+Object {
+  "boxPub": undefined,
+  "country": "NI",
+  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "name": "Davie",
+  "phone": "+15555551234",
+  "verified": Array [
+    Object {
+      "claim": Object {
+        "email": "bingbangbung@email.com",
+      },
+      "exp": 1485321134,
+      "iat": 1485321133,
+      "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInN1YiI6IjB4MTEyMjMzIiwiY2xhaW0iOnsiZW1haWwiOiJiaW5nYmFuZ2J1bmdAZW1haWwuY29tIn0sImV4cCI6MTQ4NTMyMTEzNCwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y7AK2CZkCfMNM0k2WqAl7X7gg5ieBRVYa3mrI3Wfsq3JkH7mOd4J2XT_7eI5GIL2-tIVpnqMWVzCrvNwRRkzQQE",
+      "sub": "0x112233",
+    },
+  ],
+}
+`;
+
+exports[`authenticateDisclosureResponse() returns profile with only public claims 1`] = `
+Object {
+  "boxPub": undefined,
+  "country": "NI",
+  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "name": "Super Developer",
+}
+`;
+
+exports[`authenticateDisclosureResponse() returns profile with private chain network id claims 1`] = `
+Object {
+  "address": "0x1626f7286ab8cc11e6ec91917dc7969621553fc6",
+  "boxPub": undefined,
+  "country": "NI",
+  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "mnid": "34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m",
+  "name": "Super Developer",
+}
+`;
+
+exports[`authenticateDisclosureResponse() returns pushToken if available 1`] = `
+Object {
+  "boxPub": undefined,
+  "country": "NI",
+  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "name": "Super Developer",
+  "pushToken": "PUSHTOKEN",
+}
+`;
+
 exports[`configuration configNetworks if networks key is passed in it must contain configuration object 1`] = `"Network configuration object required"`;
 
 exports[`configuration configNetworks should require a registry address 1`] = `"Malformed network config object, object must have 'registry' key specified."`;
@@ -795,70 +859,6 @@ Object {
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
   "name": "Bob Smith",
-  "pushToken": "PUSHTOKEN",
-}
-`;
-
-exports[`verifyDisclosureResponse() handles response with missing challenge 1`] = `[Error: Challenge was not included in response]`;
-
-exports[`verifyDisclosureResponse() returns profile mixing public and private claims 1`] = `
-Object {
-  "boxPub": undefined,
-  "country": "NI",
-  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Davie",
-  "phone": "+15555551234",
-}
-`;
-
-exports[`verifyDisclosureResponse() returns profile mixing public and private claims and verified credentials 1`] = `
-Object {
-  "boxPub": undefined,
-  "country": "NI",
-  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Davie",
-  "phone": "+15555551234",
-  "verified": Array [
-    Object {
-      "claim": Object {
-        "email": "bingbangbung@email.com",
-      },
-      "exp": 1485321134,
-      "iat": 1485321133,
-      "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInN1YiI6IjB4MTEyMjMzIiwiY2xhaW0iOnsiZW1haWwiOiJiaW5nYmFuZ2J1bmdAZW1haWwuY29tIn0sImV4cCI6MTQ4NTMyMTEzNCwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y7AK2CZkCfMNM0k2WqAl7X7gg5ieBRVYa3mrI3Wfsq3JkH7mOd4J2XT_7eI5GIL2-tIVpnqMWVzCrvNwRRkzQQE",
-      "sub": "0x112233",
-    },
-  ],
-}
-`;
-
-exports[`verifyDisclosureResponse() returns profile with only public claims 1`] = `
-Object {
-  "boxPub": undefined,
-  "country": "NI",
-  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Super Developer",
-}
-`;
-
-exports[`verifyDisclosureResponse() returns profile with private chain network id claims 1`] = `
-Object {
-  "address": "0x1626f7286ab8cc11e6ec91917dc7969621553fc6",
-  "boxPub": undefined,
-  "country": "NI",
-  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "mnid": "34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m",
-  "name": "Super Developer",
-}
-`;
-
-exports[`verifyDisclosureResponse() returns pushToken if available 1`] = `
-Object {
-  "boxPub": undefined,
-  "country": "NI",
-  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Super Developer",
   "pushToken": "PUSHTOKEN",
 }
 `;


### PR DESCRIPTION
- Renamed `verifyDisclosureResponse` -> `authenticateDisclosureResponse`
- Changed names in tutorials and examples for this and preceding updates
- Updated language about creating app identities to refer to new app configuration wizard