### PR TITLE
feat: pass txObj and subsequent arguments through contract method

### DIFF
--- a/src/Contract.js
+++ b/src/Contract.js
@@ -1,15 +1,14 @@
-const arrayContainsArray = require('ethjs-util').arrayContainsArray;
 
 // A derivative work of Nick Dodson's eths-contract https://github.com/ethjs/ethjs-contract/blob/master/src/index.js
 
-const hasTransactionObject = (args) => {
-  const txObjectProperties = ['from', 'to', 'data', 'value', 'gasPrice', 'gas'];
-  if (typeof args === 'object' && Array.isArray(args) === true && args.length > 0) {
-    if (typeof args[args.length - 1] === 'object'
-      && (Object.keys(args[args.length - 1]).length === 0
-      || arrayContainsArray(Object.keys(args[args.length - 1]), txObjectProperties, true))) {
-      return true;
-    }
+const isTransactionObject = (txObj) => {
+  const txObjectProperties = ['from', 'to', 'data', 'value', 'gasPrice', 'gas']
+  if (typeof txObj !== 'object') return false
+  // Return true for empty object
+  if (Object.keys(txObj).length === 0) return true
+  // Also return true if the object contains any of the expected txObject properties
+  for (const prop of txObjectProperties) {
+    if (prop in txObj) return true
   }
 
   return false;
@@ -67,19 +66,23 @@ const ContractFactory = (extend) => (contractABI) => {
 
           let providedTxObject = {};
           const methodArgs = [].slice.call(arguments);
+          const nArgs = methodObject.inputs.length
 
           if (methodObject.type === 'function') {
-            if (hasTransactionObject(methodArgs)) providedTxObject = methodArgs.pop();
-            const methodTxObject = Object.assign({},
-                providedTxObject, {
-                  to: self.address,
-              });
+            // Remove transaction object if provided
+            if (isTransactionObject(methodArgs[nArgs])) {
+              providedTxObject = methodArgs.splice(nArgs, 1)[0]
+            }
 
-            methodTxObject.function = encodeMethodReadable(methodObject, methodArgs)
+            const methodTxObject = {
+              ...providedTxObject, 
+              to: self.address,
+              function: encodeMethodReadable(methodObject, methodArgs)
+            }
 
             if (!extend) return methodTxObject
 
-            const extendArgs = methodArgs.slice(methodObject.inputs.length)
+            const extendArgs = methodArgs.slice(nArgs)
             return extend(methodTxObject, ...extendArgs)
           }
         };

--- a/src/__tests__/Contract-test.js
+++ b/src/__tests__/Contract-test.js
@@ -357,5 +357,21 @@ describe('ContractFactory', () => {
       const tokenContract = Contract(abiToken).at(address)
       expect(tokenContract.transfer('0x41566e3a081f5032bdcad470adb797635ddfe1f0', 10, str)).toEqual(str)
     });
+
+    it('passes additional args beyond a transaction object to the extend function', () => {
+      const extend = (txObj, id, sendOpts) => ({txObj, id, sendOpts})
+      const Contract = ContractFactory(extend)
+      const tokenContract = Contract(abiToken).at(address)
+
+      const txObj = {gas: '10000000'}
+      const id = 'WOOP'
+      const sendOpts = {woop: 'woop'}
+
+      const result = tokenContract.transfer('0xdeadbeef', 10, txObj, id, sendOpts)
+
+      expect(result.txObj).toMatchObject(txObj)
+      expect(result.id).toEqual(id)
+      expect(result.sendOpts).toEqual(sendOpts)
+    })
   });
 });


### PR DESCRIPTION
This fixes a bug where only **full** transaction objects were accepted in a uPort Contract.  Now a supplied transaction object is considered valid as long as it matches at least one of the keys `['gas', 'gasPrice', 'from', 'to', 'value', 'data']`.  Subsequent arguments, e.g. `requestId` or `sendOpts` are simply passed through to the extend function.

This also removes the dependency on `ethj-util`:`arrayContainsArray`

No changes should be necessary in connect.